### PR TITLE
Add support for comments, variables, consts, index access, and assignments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -35,6 +35,7 @@ module.exports = grammar({
       $.string                  ,
       $.array                   ,
       $.hash                    ,
+      $.index_expression   ,
       $.regex                   ,
       $.tuple                   ,
       $.namedTupleLiteral       ,
@@ -160,6 +161,13 @@ module.exports = grammar({
       );
     },
 
+    index_expression: $ => seq(
+      field('target', $._variable),
+      token.immediate('['),
+      field('key', $._expression),
+      token.immediate(']')
+    ),
+
     // TODO: ranges
 
     /**
@@ -241,18 +249,21 @@ module.exports = grammar({
       seq(/[A-Z]/, optional(identifierRegex))
     ),
 
+    _variable: $ => choice(
+      $.local_variable,
+      $.instance_variable,
+      $.class_variable,
+      $.constant
+    ),
+
     /**
      * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/assignment.html}
      */
     assignment: $ => prec.right(2, seq(
       field('lhs', choice(
-        $.local_variable,
-        $.instance_variable,
-        $.class_variable,
-        $.constant,
-        // TODO: support "setters": foo.bar = 42
-        // TODO: support array/hash index assignment: foo[:test] = "test"
-        // TODO: support foo.[]=(2,4) (which would technically be a method call?)
+        $._variable, 
+        $.index_expression
+        // TODO: "setters", like foo.bar = 42
       )),
       '=',
       field('rhs', $._expression)

--- a/grammar.js
+++ b/grammar.js
@@ -231,9 +231,15 @@ module.exports = grammar({
     class_variable: $ => seq('@@', /[a-z_]/, optional(identifierRegex)),
 
     /**
-     * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/class_variables.html}
+     * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/constants.html}
      */
-    constant: $ => seq(/[A-Z]/, optional(identifierRegex)),
+    constant: $ => choice(
+      '__LINE__',
+      '__END_LINE__',
+      '__FILE__',
+      '__DIR__',
+      seq(/[A-Z]/, optional(identifierRegex))
+    ),
 
     /**
      * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/assignment.html}

--- a/grammar.js
+++ b/grammar.js
@@ -35,7 +35,7 @@ module.exports = grammar({
       $.string                  ,
       $.array                   ,
       $.hash                    ,
-      $.index_expression   ,
+      $.index_expression        ,
       $.regex                   ,
       $.tuple                   ,
       $.namedTupleLiteral       ,

--- a/grammar.js
+++ b/grammar.js
@@ -9,6 +9,12 @@ const identifierRegex = /[^\x00-\x40\x5B-\x5E\x60-\x60\x7B-\x9F][^\x00-\x2F\x3A-
 module.exports = grammar({
   name: 'crystal',
 
+  // stuff that can show up anywhere
+  extras: $ => [
+    /\s/, // we have to include this, or else tree-sitter assumes we're handling whitespace all manually
+    $.comment,
+  ],
+
   rules: {
     program: $ => repeat($._statement),
 
@@ -202,6 +208,11 @@ module.exports = grammar({
       seq('`', /[^`]*/, '`'),
       seq('%x(', /[^\)]*/, ')')
     ),
+
+    /**
+	   * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/comments.html}
+	   */
+    comment: $ => /#.*[^\n]/,
 
     _operator: $ => choice( "+", "-", "*", "/", "%", "&", "|", "^", "**", ">>", "<<", "==", "!=", "<", "<=", ">", ">=", "<=>", "===", "[]", "[]?", "[]=", "!", "~", "!~", "=~",),
 

--- a/grammar.js
+++ b/grammar.js
@@ -39,6 +39,7 @@ module.exports = grammar({
       $.tuple                   ,
       $.namedTupleLiteral       ,
       $.commandLiteral          ,
+      $.assignment              ,
     ),
 
     identifier: $ => identifierRegex,
@@ -213,6 +214,43 @@ module.exports = grammar({
 	   * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/comments.html}
 	   */
     comment: $ => /#.*[^\n]/,
+
+    /**
+     * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/local_variables.html}
+     */
+    local_variable: $ => seq(/[a-z_]/, optional(identifierRegex)),
+
+    /**
+     * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/methods_and_instance_variables.html}
+     */
+    instance_variable: $ => seq('@', /[a-z_]/, optional(identifierRegex)),
+
+    /**
+     * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/class_variables.html}
+     */
+    class_variable: $ => seq('@@', /[a-z_]/, optional(identifierRegex)),
+
+    /**
+     * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/class_variables.html}
+     */
+    constant: $ => seq(/[A-Z]/, optional(identifierRegex)),
+
+    /**
+     * @see {@link https://crystal-lang.org/reference/syntax_and_semantics/assignment.html}
+     */
+    assignment: $ => prec.right(2, seq(
+      field('lhs', choice(
+        $.local_variable,
+        $.instance_variable,
+        $.class_variable,
+        $.constant,
+        // TODO: support "setters": foo.bar = 42
+        // TODO: support array/hash index assignment: foo[:test] = "test"
+        // TODO: support foo.[]=(2,4) (which would technically be a method call?)
+      )),
+      '=',
+      field('rhs', $._expression)
+    )),
 
     _operator: $ => choice( "+", "-", "*", "/", "%", "&", "|", "^", "**", ">>", "<<", "==", "!=", "<", "<=", ">", ">=", "<=>", "===", "[]", "[]?", "[]=", "!", "~", "!~", "=~",),
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Crystal grammar for tree-sitter",
   "main": "bindings/node",
   "scripts": {
-	"generate": "$(npm bin)/tree-sitter generate",
-	"pretest": "npm run generate",
+    "generate": "$(npm bin)/tree-sitter generate",
+    "pretest": "npm run generate",
     "test": "$(npm bin)/tree-sitter test",
-	"parse": "npm run generate && $(npm bin)/tree-sitter parse"
+    "parse": "npm run generate && $(npm bin)/tree-sitter parse"
   },
   "author": "Will Leinweber",
   "license": "MIT",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -641,6 +641,10 @@
         }
       ]
     },
+    "comment": {
+      "type": "PATTERN",
+      "value": "#.*[^\\n]"
+    },
     "_operator": {
       "type": "CHOICE",
       "members": [
@@ -755,6 +759,10 @@
     {
       "type": "PATTERN",
       "value": "\\s"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "comment"
     }
   ],
   "conflicts": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -76,6 +76,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "index_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "regex"
         },
         {
@@ -444,6 +448,41 @@
         }
       ]
     },
+    "index_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "target",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_variable"
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "["
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "key",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "]"
+          }
+        }
+      ]
+    },
     "regex": {
       "type": "SEQ",
       "members": [
@@ -762,6 +801,27 @@
         }
       ]
     },
+    "_variable": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "local_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instance_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "class_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant"
+        }
+      ]
+    },
     "assignment": {
       "type": "PREC_RIGHT",
       "value": 2,
@@ -776,19 +836,11 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "local_variable"
+                  "name": "_variable"
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "instance_variable"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "class_variable"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "constant"
+                  "name": "index_expression"
                 }
               ]
             }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -721,21 +721,42 @@
       ]
     },
     "constant": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "PATTERN",
-          "value": "[A-Z]"
+          "type": "STRING",
+          "value": "__LINE__"
         },
         {
-          "type": "CHOICE",
+          "type": "STRING",
+          "value": "__END_LINE__"
+        },
+        {
+          "type": "STRING",
+          "value": "__FILE__"
+        },
+        {
+          "type": "STRING",
+          "value": "__DIR__"
+        },
+        {
+          "type": "SEQ",
           "members": [
             {
               "type": "PATTERN",
-              "value": "[^\\x00-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F][^\\x00-\\x2F\\x3A-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F]*[=!\\?]?"
+              "value": "[A-Z]"
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[^\\x00-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F][^\\x00-\\x2F\\x3A-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F]*[=!\\?]?"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -89,6 +89,10 @@
         {
           "type": "SYMBOL",
           "name": "commandLiteral"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assignment"
         }
       ]
     },
@@ -644,6 +648,144 @@
     "comment": {
       "type": "PATTERN",
       "value": "#.*[^\\n]"
+    },
+    "local_variable": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "PATTERN",
+          "value": "[a-z_]"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "[^\\x00-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F][^\\x00-\\x2F\\x3A-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F]*[=!\\?]?"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "instance_variable": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "@"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[a-z_]"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "[^\\x00-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F][^\\x00-\\x2F\\x3A-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F]*[=!\\?]?"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "class_variable": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "@@"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[a-z_]"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "[^\\x00-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F][^\\x00-\\x2F\\x3A-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F]*[=!\\?]?"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "constant": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "PATTERN",
+          "value": "[A-Z]"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "[^\\x00-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F][^\\x00-\\x2F\\x3A-\\x40\\x5B-\\x5E\\x60-\\x60\\x7B-\\x9F]*[=!\\?]?"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "assignment": {
+      "type": "PREC_RIGHT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "lhs",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "local_variable"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "instance_variable"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "class_variable"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "constant"
+                }
+              ]
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "="
+          },
+          {
+            "type": "FIELD",
+            "name": "rhs",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          }
+        ]
+      }
     },
     "_operator": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -12,6 +12,10 @@
           "named": true
         },
         {
+          "type": "assignment",
+          "named": true
+        },
+        {
           "type": "bool",
           "named": true
         },
@@ -63,6 +67,96 @@
     }
   },
   {
+    "type": "assignment",
+    "named": true,
+    "fields": {
+      "lhs": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "class_variable",
+            "named": true
+          },
+          {
+            "type": "constant",
+            "named": true
+          },
+          {
+            "type": "instance_variable",
+            "named": true
+          },
+          {
+            "type": "local_variable",
+            "named": true
+          }
+        ]
+      },
+      "rhs": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array",
+            "named": true
+          },
+          {
+            "type": "assignment",
+            "named": true
+          },
+          {
+            "type": "bool",
+            "named": true
+          },
+          {
+            "type": "char",
+            "named": true
+          },
+          {
+            "type": "commandLiteral",
+            "named": true
+          },
+          {
+            "type": "float",
+            "named": true
+          },
+          {
+            "type": "hash",
+            "named": true
+          },
+          {
+            "type": "integer",
+            "named": true
+          },
+          {
+            "type": "namedTupleLiteral",
+            "named": true
+          },
+          {
+            "type": "nil",
+            "named": true
+          },
+          {
+            "type": "regex",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "symbol",
+            "named": true
+          },
+          {
+            "type": "tuple",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "bool",
     "named": true,
     "fields": {}
@@ -73,7 +167,17 @@
     "fields": {}
   },
   {
+    "type": "class_variable",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "commandLiteral",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "constant",
     "named": true,
     "fields": {}
   },
@@ -92,6 +196,10 @@
         "types": [
           {
             "type": "array",
+            "named": true
+          },
+          {
+            "type": "assignment",
             "named": true
           },
           {
@@ -150,6 +258,10 @@
         "types": [
           {
             "type": "array",
+            "named": true
+          },
+          {
+            "type": "assignment",
             "named": true
           },
           {
@@ -210,7 +322,17 @@
     "fields": {}
   },
   {
+    "type": "instance_variable",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "integer",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "local_variable",
     "named": true,
     "fields": {}
   },
@@ -238,6 +360,10 @@
         "types": [
           {
             "type": "array",
+            "named": true
+          },
+          {
+            "type": "assignment",
             "named": true
           },
           {
@@ -302,6 +428,10 @@
       "types": [
         {
           "type": "array",
+          "named": true
+        },
+        {
+          "type": "assignment",
           "named": true
         },
         {
@@ -380,6 +510,10 @@
       "types": [
         {
           "type": "array",
+          "named": true
+        },
+        {
+          "type": "assignment",
           "named": true
         },
         {
@@ -558,6 +692,10 @@
     "named": false
   },
   {
+    "type": "=",
+    "named": false
+  },
+  {
     "type": "==",
     "named": false
   },
@@ -583,6 +721,14 @@
   },
   {
     "type": ">>",
+    "named": false
+  },
+  {
+    "type": "@",
+    "named": false
+  },
+  {
+    "type": "@@",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -618,6 +618,10 @@
     "named": false
   },
   {
+    "type": "comment",
+    "named": true
+  },
+  {
     "type": "false",
     "named": false
   },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -760,6 +760,22 @@
     "named": false
   },
   {
+    "type": "__DIR__",
+    "named": false
+  },
+  {
+    "type": "__END_LINE__",
+    "named": false
+  },
+  {
+    "type": "__FILE__",
+    "named": false
+  },
+  {
+    "type": "__LINE__",
+    "named": false
+  },
+  {
     "type": "`",
     "named": false
   },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -36,6 +36,10 @@
           "named": true
         },
         {
+          "type": "index_expression",
+          "named": true
+        },
+        {
           "type": "integer",
           "named": true
         },
@@ -83,6 +87,10 @@
             "named": true
           },
           {
+            "type": "index_expression",
+            "named": true
+          },
+          {
             "type": "instance_variable",
             "named": true
           },
@@ -122,6 +130,10 @@
           },
           {
             "type": "hash",
+            "named": true
+          },
+          {
+            "type": "index_expression",
             "named": true
           },
           {
@@ -223,6 +235,10 @@
             "named": true
           },
           {
+            "type": "index_expression",
+            "named": true
+          },
+          {
             "type": "integer",
             "named": true
           },
@@ -285,6 +301,10 @@
             "named": true
           },
           {
+            "type": "index_expression",
+            "named": true
+          },
+          {
             "type": "integer",
             "named": true
           },
@@ -320,6 +340,100 @@
     "type": "identifier",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "index_expression",
+    "named": true,
+    "fields": {
+      "key": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array",
+            "named": true
+          },
+          {
+            "type": "assignment",
+            "named": true
+          },
+          {
+            "type": "bool",
+            "named": true
+          },
+          {
+            "type": "char",
+            "named": true
+          },
+          {
+            "type": "commandLiteral",
+            "named": true
+          },
+          {
+            "type": "float",
+            "named": true
+          },
+          {
+            "type": "hash",
+            "named": true
+          },
+          {
+            "type": "index_expression",
+            "named": true
+          },
+          {
+            "type": "integer",
+            "named": true
+          },
+          {
+            "type": "namedTupleLiteral",
+            "named": true
+          },
+          {
+            "type": "nil",
+            "named": true
+          },
+          {
+            "type": "regex",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "symbol",
+            "named": true
+          },
+          {
+            "type": "tuple",
+            "named": true
+          }
+        ]
+      },
+      "target": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "class_variable",
+            "named": true
+          },
+          {
+            "type": "constant",
+            "named": true
+          },
+          {
+            "type": "instance_variable",
+            "named": true
+          },
+          {
+            "type": "local_variable",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "instance_variable",
@@ -384,6 +498,10 @@
           },
           {
             "type": "hash",
+            "named": true
+          },
+          {
+            "type": "index_expression",
             "named": true
           },
           {
@@ -452,6 +570,10 @@
         },
         {
           "type": "hash",
+          "named": true
+        },
+        {
+          "type": "index_expression",
           "named": true
         },
         {
@@ -534,6 +656,10 @@
         },
         {
           "type": "hash",
+          "named": true
+        },
+        {
+          "type": "index_expression",
           "named": true
         },
         {

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,15 +6,15 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 155
-#define LARGE_STATE_COUNT 6
-#define SYMBOL_COUNT 94
+#define STATE_COUNT 181
+#define LARGE_STATE_COUNT 22
+#define SYMBOL_COUNT 104
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 72
+#define TOKEN_COUNT 77
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 2
+#define FIELD_COUNT 4
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
-#define PRODUCTION_ID_COUNT 4
+#define PRODUCTION_ID_COUNT 5
 
 enum {
   anon_sym_SEMI = 1,
@@ -63,53 +63,63 @@ enum {
   aux_sym_commandLiteral_token2 = 44,
   anon_sym_RPAREN = 45,
   sym_comment = 46,
-  anon_sym_PLUS = 47,
-  anon_sym_DASH = 48,
-  anon_sym_STAR = 49,
-  anon_sym_PERCENT = 50,
-  anon_sym_AMP = 51,
-  anon_sym_PIPE = 52,
-  anon_sym_CARET = 53,
-  anon_sym_STAR_STAR = 54,
-  anon_sym_GT_GT = 55,
-  anon_sym_LT_LT = 56,
-  anon_sym_EQ_EQ = 57,
-  anon_sym_BANG_EQ = 58,
-  anon_sym_LT = 59,
-  anon_sym_LT_EQ = 60,
-  anon_sym_GT = 61,
-  anon_sym_GT_EQ = 62,
-  anon_sym_LT_EQ_GT = 63,
-  anon_sym_EQ_EQ_EQ = 64,
-  anon_sym_LBRACK_RBRACK = 65,
-  anon_sym_LBRACK_RBRACK_QMARK = 66,
-  anon_sym_LBRACK_RBRACK_EQ = 67,
-  anon_sym_BANG = 68,
-  anon_sym_TILDE = 69,
-  anon_sym_BANG_TILDE = 70,
-  anon_sym_EQ_TILDE = 71,
-  sym_program = 72,
-  sym__statement = 73,
-  sym__expression = 74,
-  sym_identifier = 75,
-  sym_bool = 76,
-  sym_float = 77,
-  sym_integer = 78,
-  sym_symbol = 79,
-  sym_char = 80,
-  sym_string = 81,
-  sym_array = 82,
-  sym_hash = 83,
-  sym_regex = 84,
-  sym_tuple = 85,
-  sym_namedTupleLiteral = 86,
-  sym_commandLiteral = 87,
-  sym__operator = 88,
-  aux_sym_program_repeat1 = 89,
-  aux_sym_symbol_repeat1 = 90,
-  aux_sym_array_repeat1 = 91,
-  aux_sym_hash_repeat1 = 92,
-  aux_sym_namedTupleLiteral_repeat1 = 93,
+  aux_sym_local_variable_token1 = 47,
+  anon_sym_AT = 48,
+  anon_sym_AT_AT = 49,
+  aux_sym_constant_token1 = 50,
+  anon_sym_EQ = 51,
+  anon_sym_PLUS = 52,
+  anon_sym_DASH = 53,
+  anon_sym_STAR = 54,
+  anon_sym_PERCENT = 55,
+  anon_sym_AMP = 56,
+  anon_sym_PIPE = 57,
+  anon_sym_CARET = 58,
+  anon_sym_STAR_STAR = 59,
+  anon_sym_GT_GT = 60,
+  anon_sym_LT_LT = 61,
+  anon_sym_EQ_EQ = 62,
+  anon_sym_BANG_EQ = 63,
+  anon_sym_LT = 64,
+  anon_sym_LT_EQ = 65,
+  anon_sym_GT = 66,
+  anon_sym_GT_EQ = 67,
+  anon_sym_LT_EQ_GT = 68,
+  anon_sym_EQ_EQ_EQ = 69,
+  anon_sym_LBRACK_RBRACK = 70,
+  anon_sym_LBRACK_RBRACK_QMARK = 71,
+  anon_sym_LBRACK_RBRACK_EQ = 72,
+  anon_sym_BANG = 73,
+  anon_sym_TILDE = 74,
+  anon_sym_BANG_TILDE = 75,
+  anon_sym_EQ_TILDE = 76,
+  sym_program = 77,
+  sym__statement = 78,
+  sym__expression = 79,
+  sym_identifier = 80,
+  sym_bool = 81,
+  sym_float = 82,
+  sym_integer = 83,
+  sym_symbol = 84,
+  sym_char = 85,
+  sym_string = 86,
+  sym_array = 87,
+  sym_hash = 88,
+  sym_regex = 89,
+  sym_tuple = 90,
+  sym_namedTupleLiteral = 91,
+  sym_commandLiteral = 92,
+  sym_local_variable = 93,
+  sym_instance_variable = 94,
+  sym_class_variable = 95,
+  sym_constant = 96,
+  sym_assignment = 97,
+  sym__operator = 98,
+  aux_sym_program_repeat1 = 99,
+  aux_sym_symbol_repeat1 = 100,
+  aux_sym_array_repeat1 = 101,
+  aux_sym_hash_repeat1 = 102,
+  aux_sym_namedTupleLiteral_repeat1 = 103,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -160,6 +170,11 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_commandLiteral_token2] = "commandLiteral_token2",
   [anon_sym_RPAREN] = ")",
   [sym_comment] = "comment",
+  [aux_sym_local_variable_token1] = "local_variable_token1",
+  [anon_sym_AT] = "@",
+  [anon_sym_AT_AT] = "@@",
+  [aux_sym_constant_token1] = "constant_token1",
+  [anon_sym_EQ] = "=",
   [anon_sym_PLUS] = "+",
   [anon_sym_DASH] = "-",
   [anon_sym_STAR] = "*",
@@ -201,6 +216,11 @@ static const char * const ts_symbol_names[] = {
   [sym_tuple] = "tuple",
   [sym_namedTupleLiteral] = "namedTupleLiteral",
   [sym_commandLiteral] = "commandLiteral",
+  [sym_local_variable] = "local_variable",
+  [sym_instance_variable] = "instance_variable",
+  [sym_class_variable] = "class_variable",
+  [sym_constant] = "constant",
+  [sym_assignment] = "assignment",
   [sym__operator] = "_operator",
   [aux_sym_program_repeat1] = "program_repeat1",
   [aux_sym_symbol_repeat1] = "symbol_repeat1",
@@ -257,6 +277,11 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_commandLiteral_token2] = aux_sym_commandLiteral_token2,
   [anon_sym_RPAREN] = anon_sym_RPAREN,
   [sym_comment] = sym_comment,
+  [aux_sym_local_variable_token1] = aux_sym_local_variable_token1,
+  [anon_sym_AT] = anon_sym_AT,
+  [anon_sym_AT_AT] = anon_sym_AT_AT,
+  [aux_sym_constant_token1] = aux_sym_constant_token1,
+  [anon_sym_EQ] = anon_sym_EQ,
   [anon_sym_PLUS] = anon_sym_PLUS,
   [anon_sym_DASH] = anon_sym_DASH,
   [anon_sym_STAR] = anon_sym_STAR,
@@ -298,6 +323,11 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_tuple] = sym_tuple,
   [sym_namedTupleLiteral] = sym_namedTupleLiteral,
   [sym_commandLiteral] = sym_commandLiteral,
+  [sym_local_variable] = sym_local_variable,
+  [sym_instance_variable] = sym_instance_variable,
+  [sym_class_variable] = sym_class_variable,
+  [sym_constant] = sym_constant,
+  [sym_assignment] = sym_assignment,
   [sym__operator] = sym__operator,
   [aux_sym_program_repeat1] = aux_sym_program_repeat1,
   [aux_sym_symbol_repeat1] = aux_sym_symbol_repeat1,
@@ -495,6 +525,26 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [aux_sym_local_variable_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_sym_AT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_AT_AT] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_constant_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_sym_EQ] = {
+    .visible = true,
+    .named = false,
+  },
   [anon_sym_PLUS] = {
     .visible = true,
     .named = false,
@@ -659,6 +709,26 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_local_variable] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_instance_variable] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_class_variable] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_constant] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_assignment] = {
+    .visible = true,
+    .named = true,
+  },
   [sym__operator] = {
     .visible = false,
     .named = true,
@@ -687,31 +757,39 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
 
 enum {
   field_key = 1,
-  field_value = 2,
+  field_lhs = 2,
+  field_rhs = 3,
+  field_value = 4,
 };
 
 static const char * const ts_field_names[] = {
   [0] = NULL,
   [field_key] = "key",
+  [field_lhs] = "lhs",
+  [field_rhs] = "rhs",
   [field_value] = "value",
 };
 
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [1] = {.index = 0, .length = 2},
-  [2] = {.index = 2, .length = 4},
-  [3] = {.index = 6, .length = 4},
+  [2] = {.index = 2, .length = 2},
+  [3] = {.index = 4, .length = 4},
+  [4] = {.index = 8, .length = 4},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
   [0] =
+    {field_lhs, 0},
+    {field_rhs, 2},
+  [2] =
     {field_key, 1},
     {field_value, 3},
-  [2] =
+  [4] =
     {field_key, 1},
     {field_key, 4, .inherited = true},
     {field_value, 3},
     {field_value, 4, .inherited = true},
-  [6] =
+  [8] =
     {field_key, 0, .inherited = true},
     {field_key, 1, .inherited = true},
     {field_value, 0, .inherited = true},
@@ -731,79 +809,83 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(90);
-      if (lookahead == '!') ADVANCE(208);
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(88);
-      if (lookahead == '%') ADVANCE(190);
-      if (lookahead == '&') ADVANCE(191);
-      if (lookahead == '\'') ADVANCE(13);
-      if (lookahead == ')') ADVANCE(182);
-      if (lookahead == '*') ADVANCE(188);
-      if (lookahead == '+') ADVANCE(185);
-      if (lookahead == ',') ADVANCE(159);
-      if (lookahead == '-') ADVANCE(187);
-      if (lookahead == '/') ADVANCE(167);
-      if (lookahead == '0') ADVANCE(28);
-      if (lookahead == ':') ADVANCE(130);
-      if (lookahead == ';') ADVANCE(91);
-      if (lookahead == '<') ADVANCE(199);
-      if (lookahead == '=') ADVANCE(57);
-      if (lookahead == '>') ADVANCE(201);
-      if (lookahead == 'T') ADVANCE(74);
-      if (lookahead == '[') ADVANCE(158);
-      if (lookahead == ']') ADVANCE(160);
-      if (lookahead == '^') ADVANCE(193);
-      if (lookahead == '`') ADVANCE(174);
-      if (lookahead == 'f') ADVANCE(60);
-      if (lookahead == 'n') ADVANCE(66);
-      if (lookahead == 'o') ADVANCE(65);
-      if (lookahead == 't') ADVANCE(72);
-      if (lookahead == '{') ADVANCE(161);
-      if (lookahead == '|') ADVANCE(192);
-      if (lookahead == '}') ADVANCE(163);
-      if (lookahead == '~') ADVANCE(209);
+      if (eof) ADVANCE(89);
+      if (lookahead == '!') ADVANCE(217);
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(87);
+      if (lookahead == '%') ADVANCE(199);
+      if (lookahead == '&') ADVANCE(200);
+      if (lookahead == '\'') ADVANCE(16);
+      if (lookahead == ')') ADVANCE(181);
+      if (lookahead == '*') ADVANCE(197);
+      if (lookahead == '+') ADVANCE(194);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == '-') ADVANCE(196);
+      if (lookahead == '/') ADVANCE(166);
+      if (lookahead == '0') ADVANCE(31);
+      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == ';') ADVANCE(90);
+      if (lookahead == '<') ADVANCE(208);
+      if (lookahead == '=') ADVANCE(192);
+      if (lookahead == '>') ADVANCE(210);
+      if (lookahead == '@') ADVANCE(187);
+      if (lookahead == 'T') ADVANCE(106);
+      if (lookahead == '[') ADVANCE(157);
+      if (lookahead == ']') ADVANCE(159);
+      if (lookahead == '^') ADVANCE(202);
+      if (lookahead == '`') ADVANCE(173);
+      if (lookahead == 'f') ADVANCE(95);
+      if (lookahead == 'n') ADVANCE(99);
+      if (lookahead == 't') ADVANCE(104);
+      if (lookahead == '{') ADVANCE(160);
+      if (lookahead == '|') ADVANCE(201);
+      if (lookahead == '}') ADVANCE(162);
+      if (lookahead == '~') ADVANCE(218);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(108);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(108);
+      if (lookahead != 0 &&
+          lookahead > 159) ADVANCE(108);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(92);
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ';') ADVANCE(91);
+      if (lookahead == '\n') ADVANCE(91);
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ';') ADVANCE(90);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(133);
-      if (lookahead != 0) ADVANCE(132);
+          lookahead == ' ') ADVANCE(132);
+      if (lookahead != 0) ADVANCE(131);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(93);
-      if (lookahead == '#') ADVANCE(88);
-      if (lookahead == ';') ADVANCE(91);
+      if (lookahead == '\n') ADVANCE(92);
+      if (lookahead == '#') ADVANCE(87);
+      if (lookahead == ';') ADVANCE(90);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
-      if (lookahead == '!') ADVANCE(208);
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(88);
-      if (lookahead == '%') ADVANCE(189);
-      if (lookahead == '&') ADVANCE(191);
-      if (lookahead == '*') ADVANCE(188);
-      if (lookahead == '+') ADVANCE(184);
-      if (lookahead == '-') ADVANCE(186);
-      if (lookahead == '/') ADVANCE(167);
-      if (lookahead == '<') ADVANCE(199);
-      if (lookahead == '=') ADVANCE(58);
-      if (lookahead == '>') ADVANCE(201);
-      if (lookahead == '[') ADVANCE(59);
-      if (lookahead == '^') ADVANCE(193);
-      if (lookahead == '|') ADVANCE(192);
-      if (lookahead == '~') ADVANCE(209);
+      if (lookahead == '!') ADVANCE(217);
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(87);
+      if (lookahead == '%') ADVANCE(198);
+      if (lookahead == '&') ADVANCE(200);
+      if (lookahead == '*') ADVANCE(197);
+      if (lookahead == '+') ADVANCE(193);
+      if (lookahead == '-') ADVANCE(195);
+      if (lookahead == '/') ADVANCE(166);
+      if (lookahead == '<') ADVANCE(208);
+      if (lookahead == '=') ADVANCE(60);
+      if (lookahead == '>') ADVANCE(210);
+      if (lookahead == '[') ADVANCE(62);
+      if (lookahead == '^') ADVANCE(202);
+      if (lookahead == '|') ADVANCE(201);
+      if (lookahead == '~') ADVANCE(218);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -813,1153 +895,1215 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\\' &&
           lookahead != ']' &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 4:
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(88);
-      if (lookahead == '%') ADVANCE(77);
-      if (lookahead == '\'') ADVANCE(13);
-      if (lookahead == '/') ADVANCE(167);
-      if (lookahead == '0') ADVANCE(28);
-      if (lookahead == ':') ADVANCE(130);
-      if (lookahead == 'T') ADVANCE(107);
-      if (lookahead == '[') ADVANCE(157);
-      if (lookahead == '`') ADVANCE(174);
-      if (lookahead == 'f') ADVANCE(96);
-      if (lookahead == 'n') ADVANCE(100);
-      if (lookahead == 't') ADVANCE(105);
-      if (lookahead == '{') ADVANCE(161);
-      if (lookahead == '}') ADVANCE(163);
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(87);
+      if (lookahead == '%') ADVANCE(76);
+      if (lookahead == '\'') ADVANCE(16);
+      if (lookahead == '/') ADVANCE(166);
+      if (lookahead == '0') ADVANCE(31);
+      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == '=') ADVANCE(191);
+      if (lookahead == '@') ADVANCE(187);
+      if (lookahead == 'T') ADVANCE(106);
+      if (lookahead == '[') ADVANCE(156);
+      if (lookahead == '`') ADVANCE(173);
+      if (lookahead == 'f') ADVANCE(95);
+      if (lookahead == 'n') ADVANCE(99);
+      if (lookahead == 't') ADVANCE(104);
+      if (lookahead == '{') ADVANCE(160);
+      if (lookahead == '}') ADVANCE(162);
       if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(31);
+          lookahead == '-') ADVANCE(34);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(4)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(108);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(108);
       if (lookahead != 0 &&
-          lookahead > '@' &&
-          (lookahead < '\\' || '^' < lookahead) &&
-          (lookahead < '|' || 159 < lookahead)) ADVANCE(109);
+          lookahead > 159) ADVANCE(108);
       END_STATE();
     case 5:
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ',') ADVANCE(159);
-      if (lookahead == ':') ADVANCE(130);
-      if (lookahead == '=') ADVANCE(141);
-      if (lookahead == '}') ADVANCE(163);
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == '=') ADVANCE(140);
+      if (lookahead == '}') ADVANCE(162);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(133);
+      if (lookahead != 0) ADVANCE(131);
+      END_STATE();
+    case 6:
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == '=') ADVANCE(140);
+      if (lookahead == '}') ADVANCE(162);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(134);
-      if (lookahead != 0) ADVANCE(132);
+      if (lookahead != 0) ADVANCE(131);
       END_STATE();
-    case 6:
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ',') ADVANCE(159);
-      if (lookahead == '=') ADVANCE(141);
-      if (lookahead == '}') ADVANCE(163);
+    case 7:
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == ']') ADVANCE(159);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(135);
-      if (lookahead != 0) ADVANCE(132);
+      if (lookahead != 0) ADVANCE(131);
       END_STATE();
-    case 7:
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ',') ADVANCE(159);
-      if (lookahead == ']') ADVANCE(160);
+    case 8:
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == '}') ADVANCE(162);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0) ADVANCE(132);
+      if (lookahead != 0) ADVANCE(131);
       END_STATE();
-    case 8:
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ',') ADVANCE(159);
-      if (lookahead == '}') ADVANCE(163);
+    case 9:
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ':') ADVANCE(129);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(137);
-      if (lookahead != 0) ADVANCE(132);
+      if (lookahead != 0) ADVANCE(131);
       END_STATE();
-    case 9:
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ':') ADVANCE(130);
+    case 10:
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == '=') ADVANCE(140);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(138);
-      if (lookahead != 0) ADVANCE(132);
+      if (lookahead != 0) ADVANCE(131);
       END_STATE();
-    case 10:
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == '=') ADVANCE(141);
+    case 11:
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(141);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(139);
-      if (lookahead != 0) ADVANCE(132);
-      END_STATE();
-    case 11:
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(140);
-      if (lookahead != 0) ADVANCE(132);
+      if (lookahead != 0) ADVANCE(131);
       END_STATE();
     case 12:
-      if (lookahead == '#') ADVANCE(165);
+      if (lookahead == '#') ADVANCE(87);
+      if (lookahead == '=') ADVANCE(191);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(12)
-      if (lookahead != 0) ADVANCE(166);
+      if (lookahead != 0 &&
+          lookahead > '@' &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 13:
-      if (lookahead == '\'') ADVANCE(143);
-      if (lookahead == '\\') ADVANCE(14);
-      if (lookahead != 0) ADVANCE(15);
+      if (lookahead == '#') ADVANCE(87);
+      if (lookahead == 'o') ADVANCE(67);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(13)
       END_STATE();
     case 14:
-      if (lookahead == '\'') ADVANCE(156);
-      if (lookahead == '\\') ADVANCE(16);
-      if (lookahead == 'a') ADVANCE(17);
-      if (lookahead == 'b') ADVANCE(18);
-      if (lookahead == 'e') ADVANCE(19);
-      if (lookahead == 'f') ADVANCE(20);
-      if (lookahead == 'n') ADVANCE(21);
-      if (lookahead == 'r') ADVANCE(22);
-      if (lookahead == 't') ADVANCE(23);
-      if (lookahead == 'u') ADVANCE(78);
-      if (lookahead == 'v') ADVANCE(24);
+      if (lookahead == '#') ADVANCE(87);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(14)
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(183);
       END_STATE();
     case 15:
-      if (lookahead == '\'') ADVANCE(155);
+      if (lookahead == '#') ADVANCE(164);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(15)
+      if (lookahead != 0) ADVANCE(165);
       END_STATE();
     case 16:
-      if (lookahead == '\'') ADVANCE(145);
+      if (lookahead == '\'') ADVANCE(142);
+      if (lookahead == '\\') ADVANCE(17);
+      if (lookahead != 0) ADVANCE(18);
       END_STATE();
     case 17:
-      if (lookahead == '\'') ADVANCE(146);
+      if (lookahead == '\'') ADVANCE(155);
+      if (lookahead == '\\') ADVANCE(19);
+      if (lookahead == 'a') ADVANCE(20);
+      if (lookahead == 'b') ADVANCE(21);
+      if (lookahead == 'e') ADVANCE(22);
+      if (lookahead == 'f') ADVANCE(23);
+      if (lookahead == 'n') ADVANCE(24);
+      if (lookahead == 'r') ADVANCE(25);
+      if (lookahead == 't') ADVANCE(26);
+      if (lookahead == 'u') ADVANCE(77);
+      if (lookahead == 'v') ADVANCE(27);
       END_STATE();
     case 18:
-      if (lookahead == '\'') ADVANCE(147);
+      if (lookahead == '\'') ADVANCE(154);
       END_STATE();
     case 19:
-      if (lookahead == '\'') ADVANCE(148);
+      if (lookahead == '\'') ADVANCE(144);
       END_STATE();
     case 20:
-      if (lookahead == '\'') ADVANCE(149);
+      if (lookahead == '\'') ADVANCE(145);
       END_STATE();
     case 21:
-      if (lookahead == '\'') ADVANCE(150);
+      if (lookahead == '\'') ADVANCE(146);
       END_STATE();
     case 22:
-      if (lookahead == '\'') ADVANCE(151);
+      if (lookahead == '\'') ADVANCE(147);
       END_STATE();
     case 23:
-      if (lookahead == '\'') ADVANCE(152);
+      if (lookahead == '\'') ADVANCE(148);
       END_STATE();
     case 24:
-      if (lookahead == '\'') ADVANCE(153);
+      if (lookahead == '\'') ADVANCE(149);
       END_STATE();
     case 25:
-      if (lookahead == '\'') ADVANCE(154);
+      if (lookahead == '\'') ADVANCE(150);
       END_STATE();
     case 26:
-      if (lookahead == '\'') ADVANCE(154);
-      if (lookahead == '}') ADVANCE(25);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(26);
+      if (lookahead == '\'') ADVANCE(151);
       END_STATE();
     case 27:
-      if (lookahead == '(') ADVANCE(178);
+      if (lookahead == '\'') ADVANCE(152);
       END_STATE();
     case 28:
-      if (lookahead == '.') ADVANCE(85);
-      if (lookahead == 'b') ADVANCE(81);
-      if (lookahead == 'e') ADVANCE(79);
-      if (lookahead == 'f') ADVANCE(43);
-      if (lookahead == 'o') ADVANCE(82);
-      if (lookahead == 'x') ADVANCE(86);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(29);
+      if (lookahead == '\'') ADVANCE(153);
       END_STATE();
     case 29:
-      if (lookahead == '.') ADVANCE(85);
-      if (lookahead == 'e') ADVANCE(79);
-      if (lookahead == 'f') ADVANCE(43);
+      if (lookahead == '\'') ADVANCE(153);
+      if (lookahead == '}') ADVANCE(28);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(29);
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
       END_STATE();
     case 30:
-      if (lookahead == '.') ADVANCE(70);
+      if (lookahead == '(') ADVANCE(177);
       END_STATE();
     case 31:
-      if (lookahead == '0') ADVANCE(28);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
+      if (lookahead == '.') ADVANCE(84);
+      if (lookahead == 'b') ADVANCE(80);
+      if (lookahead == 'e') ADVANCE(78);
+      if (lookahead == 'f') ADVANCE(46);
+      if (lookahead == 'o') ADVANCE(81);
+      if (lookahead == 'x') ADVANCE(85);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(32);
       END_STATE();
     case 32:
-      if (lookahead == '1') ADVANCE(53);
-      if (lookahead == '3') ADVANCE(36);
-      if (lookahead == '6') ADVANCE(46);
-      if (lookahead == '8') ADVANCE(128);
+      if (lookahead == '.') ADVANCE(84);
+      if (lookahead == 'e') ADVANCE(78);
+      if (lookahead == 'f') ADVANCE(46);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(32);
       END_STATE();
     case 33:
-      if (lookahead == '1') ADVANCE(54);
-      if (lookahead == '3') ADVANCE(38);
-      if (lookahead == '6') ADVANCE(48);
-      if (lookahead == '8') ADVANCE(122);
+      if (lookahead == '.') ADVANCE(71);
       END_STATE();
     case 34:
-      if (lookahead == '1') ADVANCE(55);
-      if (lookahead == '3') ADVANCE(39);
-      if (lookahead == '6') ADVANCE(49);
-      if (lookahead == '8') ADVANCE(124);
+      if (lookahead == '0') ADVANCE(31);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
       END_STATE();
     case 35:
       if (lookahead == '1') ADVANCE(56);
-      if (lookahead == '3') ADVANCE(40);
-      if (lookahead == '6') ADVANCE(50);
-      if (lookahead == '8') ADVANCE(126);
+      if (lookahead == '3') ADVANCE(39);
+      if (lookahead == '6') ADVANCE(49);
+      if (lookahead == '8') ADVANCE(127);
       END_STATE();
     case 36:
-      if (lookahead == '2') ADVANCE(128);
-      END_STATE();
-    case 37:
-      if (lookahead == '2') ADVANCE(121);
-      END_STATE();
-    case 38:
-      if (lookahead == '2') ADVANCE(122);
-      END_STATE();
-    case 39:
-      if (lookahead == '2') ADVANCE(124);
-      END_STATE();
-    case 40:
-      if (lookahead == '2') ADVANCE(126);
-      END_STATE();
-    case 41:
-      if (lookahead == '2') ADVANCE(116);
-      END_STATE();
-    case 42:
-      if (lookahead == '2') ADVANCE(119);
-      END_STATE();
-    case 43:
-      if (lookahead == '3') ADVANCE(37);
-      if (lookahead == '6') ADVANCE(47);
-      END_STATE();
-    case 44:
+      if (lookahead == '1') ADVANCE(57);
       if (lookahead == '3') ADVANCE(41);
       if (lookahead == '6') ADVANCE(51);
+      if (lookahead == '8') ADVANCE(121);
       END_STATE();
-    case 45:
+    case 37:
+      if (lookahead == '1') ADVANCE(58);
       if (lookahead == '3') ADVANCE(42);
       if (lookahead == '6') ADVANCE(52);
+      if (lookahead == '8') ADVANCE(123);
+      END_STATE();
+    case 38:
+      if (lookahead == '1') ADVANCE(59);
+      if (lookahead == '3') ADVANCE(43);
+      if (lookahead == '6') ADVANCE(53);
+      if (lookahead == '8') ADVANCE(125);
+      END_STATE();
+    case 39:
+      if (lookahead == '2') ADVANCE(127);
+      END_STATE();
+    case 40:
+      if (lookahead == '2') ADVANCE(120);
+      END_STATE();
+    case 41:
+      if (lookahead == '2') ADVANCE(121);
+      END_STATE();
+    case 42:
+      if (lookahead == '2') ADVANCE(123);
+      END_STATE();
+    case 43:
+      if (lookahead == '2') ADVANCE(125);
+      END_STATE();
+    case 44:
+      if (lookahead == '2') ADVANCE(115);
+      END_STATE();
+    case 45:
+      if (lookahead == '2') ADVANCE(118);
       END_STATE();
     case 46:
-      if (lookahead == '4') ADVANCE(128);
+      if (lookahead == '3') ADVANCE(40);
+      if (lookahead == '6') ADVANCE(50);
       END_STATE();
     case 47:
-      if (lookahead == '4') ADVANCE(121);
+      if (lookahead == '3') ADVANCE(44);
+      if (lookahead == '6') ADVANCE(54);
       END_STATE();
     case 48:
-      if (lookahead == '4') ADVANCE(122);
+      if (lookahead == '3') ADVANCE(45);
+      if (lookahead == '6') ADVANCE(55);
       END_STATE();
     case 49:
-      if (lookahead == '4') ADVANCE(124);
+      if (lookahead == '4') ADVANCE(127);
       END_STATE();
     case 50:
-      if (lookahead == '4') ADVANCE(126);
+      if (lookahead == '4') ADVANCE(120);
       END_STATE();
     case 51:
-      if (lookahead == '4') ADVANCE(116);
+      if (lookahead == '4') ADVANCE(121);
       END_STATE();
     case 52:
-      if (lookahead == '4') ADVANCE(119);
+      if (lookahead == '4') ADVANCE(123);
       END_STATE();
     case 53:
-      if (lookahead == '6') ADVANCE(128);
+      if (lookahead == '4') ADVANCE(125);
       END_STATE();
     case 54:
-      if (lookahead == '6') ADVANCE(122);
+      if (lookahead == '4') ADVANCE(115);
       END_STATE();
     case 55:
-      if (lookahead == '6') ADVANCE(124);
+      if (lookahead == '4') ADVANCE(118);
       END_STATE();
     case 56:
-      if (lookahead == '6') ADVANCE(126);
+      if (lookahead == '6') ADVANCE(127);
       END_STATE();
     case 57:
-      if (lookahead == '=') ADVANCE(197);
-      if (lookahead == '>') ADVANCE(162);
-      if (lookahead == '~') ADVANCE(211);
+      if (lookahead == '6') ADVANCE(121);
       END_STATE();
     case 58:
-      if (lookahead == '=') ADVANCE(197);
-      if (lookahead == '~') ADVANCE(211);
+      if (lookahead == '6') ADVANCE(123);
       END_STATE();
     case 59:
-      if (lookahead == ']') ADVANCE(205);
+      if (lookahead == '6') ADVANCE(125);
       END_STATE();
     case 60:
-      if (lookahead == 'a') ADVANCE(67);
+      if (lookahead == '=') ADVANCE(206);
+      if (lookahead == '~') ADVANCE(220);
       END_STATE();
     case 61:
-      if (lookahead == 'e') ADVANCE(112);
+      if (lookahead == '>') ADVANCE(161);
       END_STATE();
     case 62:
-      if (lookahead == 'e') ADVANCE(30);
+      if (lookahead == ']') ADVANCE(214);
       END_STATE();
     case 63:
-      if (lookahead == 'e') ADVANCE(114);
+      if (lookahead == 'e') ADVANCE(75);
       END_STATE();
     case 64:
-      if (lookahead == 'e') ADVANCE(76);
+      if (lookahead == 'e') ADVANCE(111);
       END_STATE();
     case 65:
-      if (lookahead == 'f') ADVANCE(164);
+      if (lookahead == 'e') ADVANCE(33);
       END_STATE();
     case 66:
-      if (lookahead == 'i') ADVANCE(68);
+      if (lookahead == 'e') ADVANCE(113);
       END_STATE();
     case 67:
-      if (lookahead == 'l') ADVANCE(73);
+      if (lookahead == 'f') ADVANCE(163);
       END_STATE();
     case 68:
-      if (lookahead == 'l') ADVANCE(110);
+      if (lookahead == 'l') ADVANCE(73);
       END_STATE();
     case 69:
-      if (lookahead == 'l') ADVANCE(62);
+      if (lookahead == 'l') ADVANCE(109);
       END_STATE();
     case 70:
-      if (lookahead == 'n') ADVANCE(64);
+      if (lookahead == 'l') ADVANCE(65);
       END_STATE();
     case 71:
-      if (lookahead == 'p') ADVANCE(69);
+      if (lookahead == 'n') ADVANCE(63);
       END_STATE();
     case 72:
-      if (lookahead == 'r') ADVANCE(75);
+      if (lookahead == 'p') ADVANCE(70);
       END_STATE();
     case 73:
-      if (lookahead == 's') ADVANCE(63);
+      if (lookahead == 's') ADVANCE(66);
       END_STATE();
     case 74:
-      if (lookahead == 'u') ADVANCE(71);
+      if (lookahead == 'u') ADVANCE(64);
       END_STATE();
     case 75:
-      if (lookahead == 'u') ADVANCE(61);
+      if (lookahead == 'w') ADVANCE(172);
       END_STATE();
     case 76:
-      if (lookahead == 'w') ADVANCE(173);
+      if (lookahead == 'x') ADVANCE(30);
       END_STATE();
     case 77:
-      if (lookahead == 'x') ADVANCE(27);
-      END_STATE();
-    case 78:
-      if (lookahead == '{') ADVANCE(87);
+      if (lookahead == '{') ADVANCE(86);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(26);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
+      END_STATE();
+    case 78:
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(82);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
       END_STATE();
     case 79:
       if (lookahead == '+' ||
           lookahead == '-') ADVANCE(83);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
       END_STATE();
     case 80:
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(84);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(118);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(122);
       END_STATE();
     case 81:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(123);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(124);
       END_STATE();
     case 82:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(125);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
       END_STATE();
     case 83:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
       END_STATE();
     case 84:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(118);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(116);
       END_STATE();
     case 85:
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(117);
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(126);
       END_STATE();
     case 86:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(127);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
       END_STATE();
     case 87:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(26);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(182);
       END_STATE();
     case 88:
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(183);
-      END_STATE();
-    case 89:
-      if (eof) ADVANCE(90);
-      if (lookahead == '"') ADVANCE(131);
-      if (lookahead == '#') ADVANCE(88);
-      if (lookahead == '%') ADVANCE(77);
-      if (lookahead == '\'') ADVANCE(13);
-      if (lookahead == '/') ADVANCE(167);
-      if (lookahead == '0') ADVANCE(28);
-      if (lookahead == ':') ADVANCE(130);
-      if (lookahead == 'T') ADVANCE(74);
-      if (lookahead == '[') ADVANCE(157);
-      if (lookahead == '`') ADVANCE(174);
-      if (lookahead == 'f') ADVANCE(60);
-      if (lookahead == 'n') ADVANCE(66);
-      if (lookahead == 't') ADVANCE(72);
-      if (lookahead == '{') ADVANCE(161);
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(31);
+      if (eof) ADVANCE(89);
+      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(87);
+      if (lookahead == '%') ADVANCE(76);
+      if (lookahead == '\'') ADVANCE(16);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == '/') ADVANCE(166);
+      if (lookahead == '0') ADVANCE(31);
+      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == '=') ADVANCE(61);
+      if (lookahead == '@') ADVANCE(187);
+      if (lookahead == 'T') ADVANCE(190);
+      if (lookahead == '[') ADVANCE(156);
+      if (lookahead == ']') ADVANCE(159);
+      if (lookahead == '`') ADVANCE(173);
+      if (lookahead == 'f') ADVANCE(184);
+      if (lookahead == 'n') ADVANCE(185);
+      if (lookahead == 't') ADVANCE(186);
+      if (lookahead == '{') ADVANCE(160);
+      if (lookahead == '}') ADVANCE(162);
+      if (('+' <= lookahead && lookahead <= '-')) ADVANCE(34);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(89)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
+          lookahead == ' ') SKIP(88)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(183);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(189);
       END_STATE();
-    case 90:
+    case 89:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 91:
+    case 90:
       ACCEPT_TOKEN(anon_sym_SEMI);
+      END_STATE();
+    case 91:
+      ACCEPT_TOKEN(aux_sym__statement_token1);
+      if (lookahead == '\n') ADVANCE(91);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(132);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(aux_sym__statement_token1);
       if (lookahead == '\n') ADVANCE(92);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(133);
       END_STATE();
     case 93:
-      ACCEPT_TOKEN(aux_sym__statement_token1);
-      if (lookahead == '\n') ADVANCE(93);
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '.') ADVANCE(71);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(93);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '.') ADVANCE(70);
+      if (lookahead == 'a') ADVANCE(100);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'a') ADVANCE(101);
+      if (lookahead == 'e') ADVANCE(112);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(113);
+      if (lookahead == 'e') ADVANCE(94);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(95);
+      if (lookahead == 'e') ADVANCE(114);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(115);
+      if (lookahead == 'i') ADVANCE(101);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'i') ADVANCE(102);
+      if (lookahead == 'l') ADVANCE(105);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(106);
+      if (lookahead == 'l') ADVANCE(110);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(111);
+      if (lookahead == 'l') ADVANCE(97);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(98);
+      if (lookahead == 'p') ADVANCE(102);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'p') ADVANCE(103);
+      if (lookahead == 'r') ADVANCE(107);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'r') ADVANCE(108);
+      if (lookahead == 's') ADVANCE(98);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 's') ADVANCE(99);
+      if (lookahead == 'u') ADVANCE(103);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(104);
+      if (lookahead == 'u') ADVANCE(96);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(97);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 109:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+      ACCEPT_TOKEN(sym_nil);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym_nil);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(sym_nil);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+      END_STATE();
+    case 111:
+      ACCEPT_TOKEN(anon_sym_true);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(anon_sym_true);
-      END_STATE();
-    case 113:
-      ACCEPT_TOKEN(anon_sym_true);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+      END_STATE();
+    case 113:
+      ACCEPT_TOKEN(anon_sym_false);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(anon_sym_false);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(anon_sym_false);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(94);
+          lookahead == '?') ADVANCE(93);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(aux_sym_float_token1);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(aux_sym_float_token1);
+      if (lookahead == 'e') ADVANCE(79);
+      if (lookahead == 'f') ADVANCE(47);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(116);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(aux_sym_float_token1);
-      if (lookahead == 'e') ADVANCE(80);
-      if (lookahead == 'f') ADVANCE(44);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(117);
+      if (lookahead == 'f') ADVANCE(47);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
       END_STATE();
     case 118:
-      ACCEPT_TOKEN(aux_sym_float_token1);
-      if (lookahead == 'f') ADVANCE(44);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(118);
+      ACCEPT_TOKEN(aux_sym_float_token2);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(aux_sym_float_token2);
+      if (lookahead == 'f') ADVANCE(48);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
       END_STATE();
     case 120:
-      ACCEPT_TOKEN(aux_sym_float_token2);
-      if (lookahead == 'f') ADVANCE(45);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(120);
+      ACCEPT_TOKEN(aux_sym_float_token3);
       END_STATE();
     case 121:
-      ACCEPT_TOKEN(aux_sym_float_token3);
+      ACCEPT_TOKEN(aux_sym_integer_token1);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(aux_sym_integer_token1);
+      if (lookahead == 'i') ADVANCE(36);
+      if (lookahead == 'u') ADVANCE(36);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(122);
       END_STATE();
     case 123:
-      ACCEPT_TOKEN(aux_sym_integer_token1);
-      if (lookahead == 'i') ADVANCE(33);
-      if (lookahead == 'u') ADVANCE(33);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(123);
+      ACCEPT_TOKEN(aux_sym_integer_token2);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(aux_sym_integer_token2);
+      if (lookahead == 'i') ADVANCE(37);
+      if (lookahead == 'u') ADVANCE(37);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(124);
       END_STATE();
     case 125:
-      ACCEPT_TOKEN(aux_sym_integer_token2);
-      if (lookahead == 'i') ADVANCE(34);
-      if (lookahead == 'u') ADVANCE(34);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(125);
+      ACCEPT_TOKEN(aux_sym_integer_token3);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(aux_sym_integer_token3);
-      END_STATE();
-    case 127:
-      ACCEPT_TOKEN(aux_sym_integer_token3);
-      if (lookahead == 'i') ADVANCE(35);
-      if (lookahead == 'u') ADVANCE(35);
+      if (lookahead == 'i') ADVANCE(38);
+      if (lookahead == 'u') ADVANCE(38);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(127);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(126);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(aux_sym_integer_token4);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(aux_sym_integer_token4);
+      if (lookahead == '.') ADVANCE(84);
+      if (lookahead == 'e') ADVANCE(78);
+      if (lookahead == 'f') ADVANCE(46);
+      if (lookahead == 'i') ADVANCE(35);
+      if (lookahead == 'u') ADVANCE(35);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(128);
       END_STATE();
     case 129:
-      ACCEPT_TOKEN(aux_sym_integer_token4);
-      if (lookahead == '.') ADVANCE(85);
-      if (lookahead == 'e') ADVANCE(79);
-      if (lookahead == 'f') ADVANCE(43);
-      if (lookahead == 'i') ADVANCE(32);
-      if (lookahead == 'u') ADVANCE(32);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(129);
-      END_STATE();
-    case 130:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 131:
+    case 130:
       ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '\n') ADVANCE(91);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ';') ADVANCE(90);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(132);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(131);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '\n') ADVANCE(92);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ';') ADVANCE(91);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == '=') ADVANCE(140);
+      if (lookahead == '}') ADVANCE(162);
       if (lookahead == '\t' ||
+          lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(133);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(132);
+          lookahead != '"') ADVANCE(131);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ',') ADVANCE(159);
-      if (lookahead == ':') ADVANCE(130);
-      if (lookahead == '=') ADVANCE(141);
-      if (lookahead == '}') ADVANCE(163);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == '=') ADVANCE(140);
+      if (lookahead == '}') ADVANCE(162);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(134);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(132);
+          lookahead != '"') ADVANCE(131);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ',') ADVANCE(159);
-      if (lookahead == '=') ADVANCE(141);
-      if (lookahead == '}') ADVANCE(163);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == ']') ADVANCE(159);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(135);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(132);
+          lookahead != '"') ADVANCE(131);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ',') ADVANCE(159);
-      if (lookahead == ']') ADVANCE(160);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ',') ADVANCE(158);
+      if (lookahead == '}') ADVANCE(162);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(132);
+          lookahead != '"') ADVANCE(131);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ',') ADVANCE(159);
-      if (lookahead == '}') ADVANCE(163);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == ':') ADVANCE(129);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(137);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(132);
+          lookahead != '"') ADVANCE(131);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == ':') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == '=') ADVANCE(140);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(138);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(132);
+          lookahead != '"') ADVANCE(131);
       END_STATE();
     case 139:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == '=') ADVANCE(141);
+      if (lookahead == '#') ADVANCE(141);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(139);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(132);
+          lookahead != '"') ADVANCE(131);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(142);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(140);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(132);
+      if (lookahead == '>') ADVANCE(161);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '>') ADVANCE(162);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(182);
       END_STATE();
     case 142:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(183);
-      END_STATE();
-    case 143:
       ACCEPT_TOKEN(anon_sym_SQUOTE_SQUOTE);
       END_STATE();
-    case 144:
+    case 143:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE);
       END_STATE();
-    case 145:
+    case 144:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE);
       END_STATE();
-    case 146:
+    case 145:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHa_SQUOTE);
       END_STATE();
-    case 147:
+    case 146:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHb_SQUOTE);
       END_STATE();
-    case 148:
+    case 147:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHe_SQUOTE);
       END_STATE();
-    case 149:
+    case 148:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHf_SQUOTE);
       END_STATE();
-    case 150:
+    case 149:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHn_SQUOTE);
       END_STATE();
-    case 151:
+    case 150:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHr_SQUOTE);
       END_STATE();
-    case 152:
+    case 151:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHt_SQUOTE);
       END_STATE();
-    case 153:
+    case 152:
       ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHv_SQUOTE);
       END_STATE();
-    case 154:
+    case 153:
       ACCEPT_TOKEN(aux_sym_char_token1);
+      END_STATE();
+    case 154:
+      ACCEPT_TOKEN(aux_sym_char_token2);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(aux_sym_char_token2);
+      if (lookahead == '\'') ADVANCE(143);
       END_STATE();
     case 156:
-      ACCEPT_TOKEN(aux_sym_char_token2);
-      if (lookahead == '\'') ADVANCE(144);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == ']') ADVANCE(214);
       END_STATE();
     case 158:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      if (lookahead == ']') ADVANCE(205);
-      END_STATE();
-    case 159:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 160:
+    case 159:
       ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
-    case 161:
+    case 160:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 162:
+    case 161:
       ACCEPT_TOKEN(anon_sym_EQ_GT);
       END_STATE();
-    case 163:
+    case 162:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 164:
+    case 163:
       ACCEPT_TOKEN(anon_sym_of);
       END_STATE();
-    case 165:
+    case 164:
       ACCEPT_TOKEN(aux_sym_hash_token1);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(183);
+          lookahead == ' ') ADVANCE(182);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(165);
+          lookahead != '\n') ADVANCE(164);
       END_STATE();
-    case 166:
+    case 165:
       ACCEPT_TOKEN(aux_sym_hash_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(166);
+          lookahead != ' ') ADVANCE(165);
+      END_STATE();
+    case 166:
+      ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
     case 167:
-      ACCEPT_TOKEN(anon_sym_SLASH);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead == '\n') ADVANCE(170);
+      if (lookahead == '/') ADVANCE(182);
+      if (lookahead == '\\') ADVANCE(168);
+      if (lookahead != 0) ADVANCE(167);
       END_STATE();
     case 168:
       ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\n') ADVANCE(171);
-      if (lookahead == '/') ADVANCE(183);
-      if (lookahead == '\\') ADVANCE(169);
-      if (lookahead != 0) ADVANCE(168);
+      if (lookahead == '\n') ADVANCE(170);
+      if (lookahead != 0 &&
+          lookahead != '\\') ADVANCE(167);
+      if (lookahead == '\\') ADVANCE(168);
       END_STATE();
     case 169:
       ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\n') ADVANCE(171);
+      if (lookahead == '#') ADVANCE(167);
+      if (lookahead == '\\') ADVANCE(171);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(169);
       if (lookahead != 0 &&
-          lookahead != '\\') ADVANCE(168);
-      if (lookahead == '\\') ADVANCE(169);
+          lookahead != '/') ADVANCE(170);
       END_STATE();
     case 170:
       ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '#') ADVANCE(168);
-      if (lookahead == '\\') ADVANCE(172);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(170);
+      if (lookahead == '\\') ADVANCE(171);
       if (lookahead != 0 &&
-          lookahead != '/') ADVANCE(171);
+          lookahead != '/') ADVANCE(170);
       END_STATE();
     case 171:
       ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\\') ADVANCE(172);
       if (lookahead != 0 &&
-          lookahead != '/') ADVANCE(171);
+          lookahead != '\\') ADVANCE(170);
+      if (lookahead == '\\') ADVANCE(171);
       END_STATE();
     case 172:
-      ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead != 0 &&
-          lookahead != '\\') ADVANCE(171);
-      if (lookahead == '\\') ADVANCE(172);
-      END_STATE();
-    case 173:
       ACCEPT_TOKEN(anon_sym_Tuple_DOTnew);
       END_STATE();
-    case 174:
+    case 173:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
+      END_STATE();
+    case 174:
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      if (lookahead == '\n') ADVANCE(176);
+      if (lookahead == '`') ADVANCE(182);
+      if (lookahead != 0) ADVANCE(174);
       END_STATE();
     case 175:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
-      if (lookahead == '\n') ADVANCE(177);
-      if (lookahead == '`') ADVANCE(183);
-      if (lookahead != 0) ADVANCE(175);
+      if (lookahead == '#') ADVANCE(174);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(175);
+      if (lookahead != 0 &&
+          lookahead != '`') ADVANCE(176);
       END_STATE();
     case 176:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
-      if (lookahead == '#') ADVANCE(175);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(176);
       if (lookahead != 0 &&
-          lookahead != '`') ADVANCE(177);
+          lookahead != '`') ADVANCE(176);
       END_STATE();
     case 177:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
-      if (lookahead != 0 &&
-          lookahead != '`') ADVANCE(177);
+      ACCEPT_TOKEN(anon_sym_PERCENTx_LPAREN);
       END_STATE();
     case 178:
-      ACCEPT_TOKEN(anon_sym_PERCENTx_LPAREN);
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
+      if (lookahead == '\n') ADVANCE(180);
+      if (lookahead == ')') ADVANCE(182);
+      if (lookahead != 0) ADVANCE(178);
       END_STATE();
     case 179:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
-      if (lookahead == '\n') ADVANCE(181);
-      if (lookahead == ')') ADVANCE(183);
-      if (lookahead != 0) ADVANCE(179);
-      END_STATE();
-    case 180:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
-      if (lookahead == '#') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(178);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(180);
+          lookahead == ' ') ADVANCE(179);
       if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(181);
+          lookahead != ')') ADVANCE(180);
       END_STATE();
-    case 181:
+    case 180:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
       if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(181);
+          lookahead != ')') ADVANCE(180);
       END_STATE();
-    case 182:
+    case 181:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 183:
+    case 182:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(183);
+          lookahead != '\n') ADVANCE(182);
+      END_STATE();
+    case 183:
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
       END_STATE();
     case 184:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
+      if (lookahead == 'a') ADVANCE(68);
       END_STATE();
     case 185:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      if (lookahead == '0') ADVANCE(28);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
+      if (lookahead == 'i') ADVANCE(69);
       END_STATE();
     case 186:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
+      if (lookahead == 'r') ADVANCE(74);
       END_STATE();
     case 187:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '0') ADVANCE(28);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
+      ACCEPT_TOKEN(anon_sym_AT);
+      if (lookahead == '@') ADVANCE(188);
       END_STATE();
     case 188:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '*') ADVANCE(194);
+      ACCEPT_TOKEN(anon_sym_AT_AT);
       END_STATE();
     case 189:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
+      ACCEPT_TOKEN(aux_sym_constant_token1);
       END_STATE();
     case 190:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
-      if (lookahead == 'x') ADVANCE(27);
+      ACCEPT_TOKEN(aux_sym_constant_token1);
+      if (lookahead == 'u') ADVANCE(72);
       END_STATE();
     case 191:
-      ACCEPT_TOKEN(anon_sym_AMP);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 192:
-      ACCEPT_TOKEN(anon_sym_PIPE);
+      ACCEPT_TOKEN(anon_sym_EQ);
+      if (lookahead == '=') ADVANCE(206);
+      if (lookahead == '>') ADVANCE(161);
+      if (lookahead == '~') ADVANCE(220);
       END_STATE();
     case 193:
-      ACCEPT_TOKEN(anon_sym_CARET);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 194:
-      ACCEPT_TOKEN(anon_sym_STAR_STAR);
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      if (lookahead == '0') ADVANCE(31);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
       END_STATE();
     case 195:
-      ACCEPT_TOKEN(anon_sym_GT_GT);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 196:
-      ACCEPT_TOKEN(anon_sym_LT_LT);
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '0') ADVANCE(31);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
       END_STATE();
     case 197:
-      ACCEPT_TOKEN(anon_sym_EQ_EQ);
-      if (lookahead == '=') ADVANCE(204);
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '*') ADVANCE(203);
       END_STATE();
     case 198:
-      ACCEPT_TOKEN(anon_sym_BANG_EQ);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
     case 199:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '<') ADVANCE(196);
-      if (lookahead == '=') ADVANCE(200);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
+      if (lookahead == 'x') ADVANCE(30);
       END_STATE();
     case 200:
-      ACCEPT_TOKEN(anon_sym_LT_EQ);
-      if (lookahead == '>') ADVANCE(203);
+      ACCEPT_TOKEN(anon_sym_AMP);
       END_STATE();
     case 201:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '=') ADVANCE(202);
-      if (lookahead == '>') ADVANCE(195);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 202:
-      ACCEPT_TOKEN(anon_sym_GT_EQ);
+      ACCEPT_TOKEN(anon_sym_CARET);
       END_STATE();
     case 203:
-      ACCEPT_TOKEN(anon_sym_LT_EQ_GT);
+      ACCEPT_TOKEN(anon_sym_STAR_STAR);
       END_STATE();
     case 204:
-      ACCEPT_TOKEN(anon_sym_EQ_EQ_EQ);
+      ACCEPT_TOKEN(anon_sym_GT_GT);
       END_STATE();
     case 205:
-      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK);
-      if (lookahead == '=') ADVANCE(207);
-      if (lookahead == '?') ADVANCE(206);
+      ACCEPT_TOKEN(anon_sym_LT_LT);
       END_STATE();
     case 206:
-      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_QMARK);
+      ACCEPT_TOKEN(anon_sym_EQ_EQ);
+      if (lookahead == '=') ADVANCE(213);
       END_STATE();
     case 207:
-      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_EQ);
+      ACCEPT_TOKEN(anon_sym_BANG_EQ);
       END_STATE();
     case 208:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead == '=') ADVANCE(198);
-      if (lookahead == '~') ADVANCE(210);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '<') ADVANCE(205);
+      if (lookahead == '=') ADVANCE(209);
       END_STATE();
     case 209:
-      ACCEPT_TOKEN(anon_sym_TILDE);
+      ACCEPT_TOKEN(anon_sym_LT_EQ);
+      if (lookahead == '>') ADVANCE(212);
       END_STATE();
     case 210:
-      ACCEPT_TOKEN(anon_sym_BANG_TILDE);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '=') ADVANCE(211);
+      if (lookahead == '>') ADVANCE(204);
       END_STATE();
     case 211:
+      ACCEPT_TOKEN(anon_sym_GT_EQ);
+      END_STATE();
+    case 212:
+      ACCEPT_TOKEN(anon_sym_LT_EQ_GT);
+      END_STATE();
+    case 213:
+      ACCEPT_TOKEN(anon_sym_EQ_EQ_EQ);
+      END_STATE();
+    case 214:
+      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK);
+      if (lookahead == '=') ADVANCE(216);
+      if (lookahead == '?') ADVANCE(215);
+      END_STATE();
+    case 215:
+      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_QMARK);
+      END_STATE();
+    case 216:
+      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_EQ);
+      END_STATE();
+    case 217:
+      ACCEPT_TOKEN(anon_sym_BANG);
+      if (lookahead == '=') ADVANCE(207);
+      if (lookahead == '~') ADVANCE(219);
+      END_STATE();
+    case 218:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      END_STATE();
+    case 219:
+      ACCEPT_TOKEN(anon_sym_BANG_TILDE);
+      END_STATE();
+    case 220:
       ACCEPT_TOKEN(anon_sym_EQ_TILDE);
       END_STATE();
     default:
@@ -1969,166 +2113,193 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 89},
-  [2] = {.lex_state = 89},
-  [3] = {.lex_state = 4},
-  [4] = {.lex_state = 4},
-  [5] = {.lex_state = 89},
-  [6] = {.lex_state = 89},
-  [7] = {.lex_state = 89},
-  [8] = {.lex_state = 89},
-  [9] = {.lex_state = 89},
-  [10] = {.lex_state = 89},
-  [11] = {.lex_state = 89},
-  [12] = {.lex_state = 89},
-  [13] = {.lex_state = 89},
-  [14] = {.lex_state = 89},
-  [15] = {.lex_state = 89},
-  [16] = {.lex_state = 89},
-  [17] = {.lex_state = 89},
-  [18] = {.lex_state = 3},
-  [19] = {.lex_state = 3},
-  [20] = {.lex_state = 3},
-  [21] = {.lex_state = 3},
-  [22] = {.lex_state = 3},
-  [23] = {.lex_state = 5},
-  [24] = {.lex_state = 5},
-  [25] = {.lex_state = 6},
-  [26] = {.lex_state = 6},
-  [27] = {.lex_state = 0},
-  [28] = {.lex_state = 0},
-  [29] = {.lex_state = 0},
-  [30] = {.lex_state = 0},
-  [31] = {.lex_state = 0},
-  [32] = {.lex_state = 1},
-  [33] = {.lex_state = 0},
-  [34] = {.lex_state = 1},
-  [35] = {.lex_state = 0},
-  [36] = {.lex_state = 8},
-  [37] = {.lex_state = 8},
-  [38] = {.lex_state = 8},
-  [39] = {.lex_state = 0},
-  [40] = {.lex_state = 1},
-  [41] = {.lex_state = 7},
-  [42] = {.lex_state = 0},
-  [43] = {.lex_state = 0},
-  [44] = {.lex_state = 0},
-  [45] = {.lex_state = 0},
-  [46] = {.lex_state = 1},
-  [47] = {.lex_state = 0},
-  [48] = {.lex_state = 7},
+  [1] = {.lex_state = 88},
+  [2] = {.lex_state = 4},
+  [3] = {.lex_state = 88},
+  [4] = {.lex_state = 88},
+  [5] = {.lex_state = 4},
+  [6] = {.lex_state = 88},
+  [7] = {.lex_state = 88},
+  [8] = {.lex_state = 88},
+  [9] = {.lex_state = 88},
+  [10] = {.lex_state = 88},
+  [11] = {.lex_state = 88},
+  [12] = {.lex_state = 88},
+  [13] = {.lex_state = 88},
+  [14] = {.lex_state = 88},
+  [15] = {.lex_state = 88},
+  [16] = {.lex_state = 88},
+  [17] = {.lex_state = 88},
+  [18] = {.lex_state = 88},
+  [19] = {.lex_state = 88},
+  [20] = {.lex_state = 88},
+  [21] = {.lex_state = 88},
+  [22] = {.lex_state = 88},
+  [23] = {.lex_state = 3},
+  [24] = {.lex_state = 3},
+  [25] = {.lex_state = 3},
+  [26] = {.lex_state = 3},
+  [27] = {.lex_state = 3},
+  [28] = {.lex_state = 5},
+  [29] = {.lex_state = 5},
+  [30] = {.lex_state = 6},
+  [31] = {.lex_state = 6},
+  [32] = {.lex_state = 6},
+  [33] = {.lex_state = 6},
+  [34] = {.lex_state = 88},
+  [35] = {.lex_state = 88},
+  [36] = {.lex_state = 88},
+  [37] = {.lex_state = 88},
+  [38] = {.lex_state = 88},
+  [39] = {.lex_state = 8},
+  [40] = {.lex_state = 88},
+  [41] = {.lex_state = 8},
+  [42] = {.lex_state = 8},
+  [43] = {.lex_state = 8},
+  [44] = {.lex_state = 1},
+  [45] = {.lex_state = 88},
+  [46] = {.lex_state = 7},
+  [47] = {.lex_state = 88},
+  [48] = {.lex_state = 1},
   [49] = {.lex_state = 7},
-  [50] = {.lex_state = 7},
-  [51] = {.lex_state = 0},
-  [52] = {.lex_state = 0},
-  [53] = {.lex_state = 0},
-  [54] = {.lex_state = 0},
-  [55] = {.lex_state = 0},
-  [56] = {.lex_state = 0},
-  [57] = {.lex_state = 3},
-  [58] = {.lex_state = 0},
-  [59] = {.lex_state = 0},
-  [60] = {.lex_state = 8},
-  [61] = {.lex_state = 11},
-  [62] = {.lex_state = 0},
-  [63] = {.lex_state = 0},
-  [64] = {.lex_state = 0},
-  [65] = {.lex_state = 11},
-  [66] = {.lex_state = 0},
-  [67] = {.lex_state = 0},
-  [68] = {.lex_state = 0},
-  [69] = {.lex_state = 0},
-  [70] = {.lex_state = 0},
+  [50] = {.lex_state = 1},
+  [51] = {.lex_state = 3},
+  [52] = {.lex_state = 7},
+  [53] = {.lex_state = 88},
+  [54] = {.lex_state = 88},
+  [55] = {.lex_state = 88},
+  [56] = {.lex_state = 88},
+  [57] = {.lex_state = 88},
+  [58] = {.lex_state = 7},
+  [59] = {.lex_state = 88},
+  [60] = {.lex_state = 88},
+  [61] = {.lex_state = 88},
+  [62] = {.lex_state = 1},
+  [63] = {.lex_state = 88},
+  [64] = {.lex_state = 88},
+  [65] = {.lex_state = 88},
+  [66] = {.lex_state = 88},
+  [67] = {.lex_state = 88},
+  [68] = {.lex_state = 88},
+  [69] = {.lex_state = 11},
+  [70] = {.lex_state = 11},
   [71] = {.lex_state = 11},
-  [72] = {.lex_state = 0},
+  [72] = {.lex_state = 11},
   [73] = {.lex_state = 11},
   [74] = {.lex_state = 0},
   [75] = {.lex_state = 0},
-  [76] = {.lex_state = 0},
+  [76] = {.lex_state = 11},
   [77] = {.lex_state = 11},
   [78] = {.lex_state = 0},
   [79] = {.lex_state = 11},
-  [80] = {.lex_state = 0},
+  [80] = {.lex_state = 11},
   [81] = {.lex_state = 11},
-  [82] = {.lex_state = 0},
+  [82] = {.lex_state = 11},
   [83] = {.lex_state = 11},
-  [84] = {.lex_state = 11},
-  [85] = {.lex_state = 0},
-  [86] = {.lex_state = 11},
+  [84] = {.lex_state = 0},
+  [85] = {.lex_state = 11},
+  [86] = {.lex_state = 0},
   [87] = {.lex_state = 11},
   [88] = {.lex_state = 0},
   [89] = {.lex_state = 11},
-  [90] = {.lex_state = 11},
+  [90] = {.lex_state = 0},
   [91] = {.lex_state = 11},
   [92] = {.lex_state = 11},
-  [93] = {.lex_state = 11},
+  [93] = {.lex_state = 0},
   [94] = {.lex_state = 11},
-  [95] = {.lex_state = 11},
-  [96] = {.lex_state = 11},
-  [97] = {.lex_state = 0},
-  [98] = {.lex_state = 11},
-  [99] = {.lex_state = 11},
-  [100] = {.lex_state = 11},
-  [101] = {.lex_state = 10},
-  [102] = {.lex_state = 10},
-  [103] = {.lex_state = 10},
-  [104] = {.lex_state = 10},
-  [105] = {.lex_state = 9},
-  [106] = {.lex_state = 9},
-  [107] = {.lex_state = 0},
-  [108] = {.lex_state = 11},
-  [109] = {.lex_state = 2},
-  [110] = {.lex_state = 2},
-  [111] = {.lex_state = 0},
-  [112] = {.lex_state = 0},
-  [113] = {.lex_state = 2},
-  [114] = {.lex_state = 2},
-  [115] = {.lex_state = 2},
-  [116] = {.lex_state = 2},
-  [117] = {.lex_state = 2},
-  [118] = {.lex_state = 2},
+  [95] = {.lex_state = 0},
+  [96] = {.lex_state = 0},
+  [97] = {.lex_state = 11},
+  [98] = {.lex_state = 0},
+  [99] = {.lex_state = 0},
+  [100] = {.lex_state = 0},
+  [101] = {.lex_state = 0},
+  [102] = {.lex_state = 0},
+  [103] = {.lex_state = 0},
+  [104] = {.lex_state = 0},
+  [105] = {.lex_state = 0},
+  [106] = {.lex_state = 11},
+  [107] = {.lex_state = 11},
+  [108] = {.lex_state = 0},
+  [109] = {.lex_state = 11},
+  [110] = {.lex_state = 11},
+  [111] = {.lex_state = 11},
+  [112] = {.lex_state = 11},
+  [113] = {.lex_state = 9},
+  [114] = {.lex_state = 9},
+  [115] = {.lex_state = 10},
+  [116] = {.lex_state = 10},
+  [117] = {.lex_state = 10},
+  [118] = {.lex_state = 10},
   [119] = {.lex_state = 2},
   [120] = {.lex_state = 2},
   [121] = {.lex_state = 2},
   [122] = {.lex_state = 2},
   [123] = {.lex_state = 2},
-  [124] = {.lex_state = 2},
+  [124] = {.lex_state = 12},
   [125] = {.lex_state = 2},
   [126] = {.lex_state = 2},
-  [127] = {.lex_state = 2},
+  [127] = {.lex_state = 12},
   [128] = {.lex_state = 2},
-  [129] = {.lex_state = 0},
-  [130] = {.lex_state = 180},
-  [131] = {.lex_state = 0},
-  [132] = {.lex_state = 12},
-  [133] = {.lex_state = 0},
-  [134] = {.lex_state = 0},
-  [135] = {.lex_state = 0},
+  [129] = {.lex_state = 12},
+  [130] = {.lex_state = 2},
+  [131] = {.lex_state = 2},
+  [132] = {.lex_state = 2},
+  [133] = {.lex_state = 12},
+  [134] = {.lex_state = 2},
+  [135] = {.lex_state = 2},
   [136] = {.lex_state = 0},
   [137] = {.lex_state = 0},
-  [138] = {.lex_state = 0},
-  [139] = {.lex_state = 12},
-  [140] = {.lex_state = 170},
-  [141] = {.lex_state = 176},
-  [142] = {.lex_state = 12},
-  [143] = {.lex_state = 0},
-  [144] = {.lex_state = 180},
-  [145] = {.lex_state = 176},
-  [146] = {.lex_state = 0},
-  [147] = {.lex_state = 0},
-  [148] = {.lex_state = 170},
+  [138] = {.lex_state = 2},
+  [139] = {.lex_state = 2},
+  [140] = {.lex_state = 2},
+  [141] = {.lex_state = 2},
+  [142] = {.lex_state = 2},
+  [143] = {.lex_state = 2},
+  [144] = {.lex_state = 0},
+  [145] = {.lex_state = 0},
+  [146] = {.lex_state = 88},
+  [147] = {.lex_state = 15},
+  [148] = {.lex_state = 88},
   [149] = {.lex_state = 0},
-  [150] = {.lex_state = 0},
+  [150] = {.lex_state = 15},
   [151] = {.lex_state = 0},
-  [152] = {.lex_state = 0},
-  [153] = {.lex_state = 12},
+  [152] = {.lex_state = 4},
+  [153] = {.lex_state = 4},
   [154] = {.lex_state = 0},
+  [155] = {.lex_state = 0},
+  [156] = {.lex_state = 0},
+  [157] = {.lex_state = 15},
+  [158] = {.lex_state = 14},
+  [159] = {.lex_state = 14},
+  [160] = {.lex_state = 169},
+  [161] = {.lex_state = 175},
+  [162] = {.lex_state = 179},
+  [163] = {.lex_state = 0},
+  [164] = {.lex_state = 179},
+  [165] = {.lex_state = 175},
+  [166] = {.lex_state = 4},
+  [167] = {.lex_state = 88},
+  [168] = {.lex_state = 4},
+  [169] = {.lex_state = 169},
+  [170] = {.lex_state = 4},
+  [171] = {.lex_state = 4},
+  [172] = {.lex_state = 4},
+  [173] = {.lex_state = 4},
+  [174] = {.lex_state = 0},
+  [175] = {.lex_state = 0},
+  [176] = {.lex_state = 4},
+  [177] = {.lex_state = 0},
+  [178] = {.lex_state = 13},
+  [179] = {.lex_state = 15},
+  [180] = {.lex_state = 13},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
     [anon_sym_SEMI] = ACTIONS(1),
+    [aux_sym_identifier_token1] = ACTIONS(1),
     [sym_nil] = ACTIONS(1),
     [anon_sym_true] = ACTIONS(1),
     [anon_sym_false] = ACTIONS(1),
@@ -2160,13 +2331,17 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE] = ACTIONS(1),
     [anon_sym_EQ_GT] = ACTIONS(1),
     [anon_sym_RBRACE] = ACTIONS(1),
-    [anon_sym_of] = ACTIONS(1),
     [anon_sym_SLASH] = ACTIONS(1),
     [anon_sym_Tuple_DOTnew] = ACTIONS(1),
     [anon_sym_BQUOTE] = ACTIONS(1),
     [anon_sym_PERCENTx_LPAREN] = ACTIONS(1),
     [anon_sym_RPAREN] = ACTIONS(1),
     [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(1),
+    [anon_sym_AT] = ACTIONS(1),
+    [anon_sym_AT_AT] = ACTIONS(1),
+    [aux_sym_constant_token1] = ACTIONS(1),
+    [anon_sym_EQ] = ACTIONS(1),
     [anon_sym_PLUS] = ACTIONS(1),
     [anon_sym_DASH] = ACTIONS(1),
     [anon_sym_STAR] = ACTIONS(1),
@@ -2194,22 +2369,27 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_EQ_TILDE] = ACTIONS(1),
   },
   [1] = {
-    [sym_program] = STATE(143),
-    [sym__statement] = STATE(5),
-    [sym__expression] = STATE(119),
-    [sym_bool] = STATE(119),
-    [sym_float] = STATE(119),
-    [sym_integer] = STATE(119),
-    [sym_symbol] = STATE(119),
-    [sym_char] = STATE(119),
-    [sym_string] = STATE(119),
-    [sym_array] = STATE(119),
-    [sym_hash] = STATE(119),
-    [sym_regex] = STATE(119),
-    [sym_tuple] = STATE(119),
-    [sym_namedTupleLiteral] = STATE(119),
-    [sym_commandLiteral] = STATE(119),
-    [aux_sym_program_repeat1] = STATE(5),
+    [sym_program] = STATE(154),
+    [sym__statement] = STATE(4),
+    [sym__expression] = STATE(120),
+    [sym_bool] = STATE(120),
+    [sym_float] = STATE(120),
+    [sym_integer] = STATE(120),
+    [sym_symbol] = STATE(120),
+    [sym_char] = STATE(120),
+    [sym_string] = STATE(120),
+    [sym_array] = STATE(120),
+    [sym_hash] = STATE(120),
+    [sym_regex] = STATE(120),
+    [sym_tuple] = STATE(120),
+    [sym_namedTupleLiteral] = STATE(120),
+    [sym_commandLiteral] = STATE(120),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym_assignment] = STATE(120),
+    [aux_sym_program_repeat1] = STATE(4),
     [ts_builtin_sym_end] = ACTIONS(5),
     [sym_nil] = ACTIONS(7),
     [anon_sym_true] = ACTIONS(9),
@@ -2243,36 +2423,44 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_BQUOTE] = ACTIONS(35),
     [anon_sym_PERCENTx_LPAREN] = ACTIONS(37),
     [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
   },
   [2] = {
-    [sym__statement] = STATE(2),
-    [sym__expression] = STATE(119),
-    [sym_bool] = STATE(119),
-    [sym_float] = STATE(119),
-    [sym_integer] = STATE(119),
-    [sym_symbol] = STATE(119),
-    [sym_char] = STATE(119),
-    [sym_string] = STATE(119),
-    [sym_array] = STATE(119),
-    [sym_hash] = STATE(119),
-    [sym_regex] = STATE(119),
-    [sym_tuple] = STATE(119),
-    [sym_namedTupleLiteral] = STATE(119),
-    [sym_commandLiteral] = STATE(119),
-    [aux_sym_program_repeat1] = STATE(2),
-    [ts_builtin_sym_end] = ACTIONS(39),
-    [sym_nil] = ACTIONS(41),
-    [anon_sym_true] = ACTIONS(44),
-    [anon_sym_false] = ACTIONS(44),
-    [aux_sym_float_token1] = ACTIONS(47),
-    [aux_sym_float_token2] = ACTIONS(50),
-    [aux_sym_float_token3] = ACTIONS(50),
-    [aux_sym_integer_token1] = ACTIONS(53),
-    [aux_sym_integer_token2] = ACTIONS(53),
-    [aux_sym_integer_token3] = ACTIONS(53),
-    [aux_sym_integer_token4] = ACTIONS(56),
-    [anon_sym_COLON] = ACTIONS(59),
-    [anon_sym_DQUOTE] = ACTIONS(62),
+    [sym__expression] = STATE(37),
+    [sym_identifier] = STATE(177),
+    [sym_bool] = STATE(37),
+    [sym_float] = STATE(37),
+    [sym_integer] = STATE(37),
+    [sym_symbol] = STATE(37),
+    [sym_char] = STATE(37),
+    [sym_string] = STATE(36),
+    [sym_array] = STATE(37),
+    [sym_hash] = STATE(37),
+    [sym_regex] = STATE(37),
+    [sym_tuple] = STATE(37),
+    [sym_namedTupleLiteral] = STATE(37),
+    [sym_commandLiteral] = STATE(37),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym_assignment] = STATE(37),
+    [aux_sym_identifier_token1] = ACTIONS(47),
+    [sym_nil] = ACTIONS(49),
+    [anon_sym_true] = ACTIONS(51),
+    [anon_sym_false] = ACTIONS(51),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(61),
+    [anon_sym_DQUOTE] = ACTIONS(63),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
@@ -2285,132 +2473,101 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
     [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
     [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(68),
-    [anon_sym_LBRACK] = ACTIONS(71),
-    [anon_sym_LBRACE] = ACTIONS(74),
-    [anon_sym_SLASH] = ACTIONS(77),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(80),
-    [anon_sym_BQUOTE] = ACTIONS(83),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(86),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_RBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
     [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
   },
   [3] = {
-    [sym__expression] = STATE(59),
-    [sym_identifier] = STATE(135),
-    [sym_bool] = STATE(59),
-    [sym_float] = STATE(59),
-    [sym_integer] = STATE(59),
-    [sym_symbol] = STATE(59),
-    [sym_char] = STATE(59),
-    [sym_string] = STATE(55),
-    [sym_array] = STATE(59),
-    [sym_hash] = STATE(59),
-    [sym_regex] = STATE(59),
-    [sym_tuple] = STATE(59),
-    [sym_namedTupleLiteral] = STATE(59),
-    [sym_commandLiteral] = STATE(59),
-    [aux_sym_identifier_token1] = ACTIONS(89),
-    [sym_nil] = ACTIONS(91),
-    [anon_sym_true] = ACTIONS(93),
-    [anon_sym_false] = ACTIONS(93),
-    [aux_sym_float_token1] = ACTIONS(95),
-    [aux_sym_float_token2] = ACTIONS(97),
-    [aux_sym_float_token3] = ACTIONS(97),
-    [aux_sym_integer_token1] = ACTIONS(99),
-    [aux_sym_integer_token2] = ACTIONS(99),
-    [aux_sym_integer_token3] = ACTIONS(99),
-    [aux_sym_integer_token4] = ACTIONS(101),
+    [sym__statement] = STATE(3),
+    [sym__expression] = STATE(120),
+    [sym_bool] = STATE(120),
+    [sym_float] = STATE(120),
+    [sym_integer] = STATE(120),
+    [sym_symbol] = STATE(120),
+    [sym_char] = STATE(120),
+    [sym_string] = STATE(120),
+    [sym_array] = STATE(120),
+    [sym_hash] = STATE(120),
+    [sym_regex] = STATE(120),
+    [sym_tuple] = STATE(120),
+    [sym_namedTupleLiteral] = STATE(120),
+    [sym_commandLiteral] = STATE(120),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym_assignment] = STATE(120),
+    [aux_sym_program_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(83),
+    [sym_nil] = ACTIONS(85),
+    [anon_sym_true] = ACTIONS(88),
+    [anon_sym_false] = ACTIONS(88),
+    [aux_sym_float_token1] = ACTIONS(91),
+    [aux_sym_float_token2] = ACTIONS(94),
+    [aux_sym_float_token3] = ACTIONS(94),
+    [aux_sym_integer_token1] = ACTIONS(97),
+    [aux_sym_integer_token2] = ACTIONS(97),
+    [aux_sym_integer_token3] = ACTIONS(97),
+    [aux_sym_integer_token4] = ACTIONS(100),
     [anon_sym_COLON] = ACTIONS(103),
-    [anon_sym_DQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(107),
-    [aux_sym_char_token1] = ACTIONS(107),
-    [aux_sym_char_token2] = ACTIONS(109),
-    [anon_sym_LBRACK] = ACTIONS(111),
-    [anon_sym_LBRACE] = ACTIONS(113),
-    [anon_sym_RBRACE] = ACTIONS(115),
-    [anon_sym_SLASH] = ACTIONS(117),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(119),
-    [anon_sym_BQUOTE] = ACTIONS(121),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(123),
+    [anon_sym_DQUOTE] = ACTIONS(106),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(109),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(109),
+    [aux_sym_char_token1] = ACTIONS(109),
+    [aux_sym_char_token2] = ACTIONS(112),
+    [anon_sym_LBRACK] = ACTIONS(115),
+    [anon_sym_LBRACE] = ACTIONS(118),
+    [anon_sym_SLASH] = ACTIONS(121),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(124),
+    [anon_sym_BQUOTE] = ACTIONS(127),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(130),
     [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(133),
+    [anon_sym_AT] = ACTIONS(136),
+    [anon_sym_AT_AT] = ACTIONS(139),
+    [aux_sym_constant_token1] = ACTIONS(142),
   },
   [4] = {
-    [sym__expression] = STATE(58),
-    [sym_identifier] = STATE(151),
-    [sym_bool] = STATE(58),
-    [sym_float] = STATE(58),
-    [sym_integer] = STATE(58),
-    [sym_symbol] = STATE(58),
-    [sym_char] = STATE(58),
-    [sym_string] = STATE(31),
-    [sym_array] = STATE(58),
-    [sym_hash] = STATE(58),
-    [sym_regex] = STATE(58),
-    [sym_tuple] = STATE(58),
-    [sym_namedTupleLiteral] = STATE(58),
-    [sym_commandLiteral] = STATE(58),
-    [aux_sym_identifier_token1] = ACTIONS(89),
-    [sym_nil] = ACTIONS(125),
-    [anon_sym_true] = ACTIONS(93),
-    [anon_sym_false] = ACTIONS(93),
-    [aux_sym_float_token1] = ACTIONS(95),
-    [aux_sym_float_token2] = ACTIONS(97),
-    [aux_sym_float_token3] = ACTIONS(97),
-    [aux_sym_integer_token1] = ACTIONS(99),
-    [aux_sym_integer_token2] = ACTIONS(99),
-    [aux_sym_integer_token3] = ACTIONS(99),
-    [aux_sym_integer_token4] = ACTIONS(101),
-    [anon_sym_COLON] = ACTIONS(103),
-    [anon_sym_DQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(107),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(107),
-    [aux_sym_char_token1] = ACTIONS(107),
-    [aux_sym_char_token2] = ACTIONS(109),
-    [anon_sym_LBRACK] = ACTIONS(111),
-    [anon_sym_LBRACE] = ACTIONS(113),
-    [anon_sym_RBRACE] = ACTIONS(127),
-    [anon_sym_SLASH] = ACTIONS(117),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(119),
-    [anon_sym_BQUOTE] = ACTIONS(121),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(123),
-    [sym_comment] = ACTIONS(3),
-  },
-  [5] = {
-    [sym__statement] = STATE(2),
-    [sym__expression] = STATE(119),
-    [sym_bool] = STATE(119),
-    [sym_float] = STATE(119),
-    [sym_integer] = STATE(119),
-    [sym_symbol] = STATE(119),
-    [sym_char] = STATE(119),
-    [sym_string] = STATE(119),
-    [sym_array] = STATE(119),
-    [sym_hash] = STATE(119),
-    [sym_regex] = STATE(119),
-    [sym_tuple] = STATE(119),
-    [sym_namedTupleLiteral] = STATE(119),
-    [sym_commandLiteral] = STATE(119),
-    [aux_sym_program_repeat1] = STATE(2),
-    [ts_builtin_sym_end] = ACTIONS(129),
+    [sym__statement] = STATE(3),
+    [sym__expression] = STATE(120),
+    [sym_bool] = STATE(120),
+    [sym_float] = STATE(120),
+    [sym_integer] = STATE(120),
+    [sym_symbol] = STATE(120),
+    [sym_char] = STATE(120),
+    [sym_string] = STATE(120),
+    [sym_array] = STATE(120),
+    [sym_hash] = STATE(120),
+    [sym_regex] = STATE(120),
+    [sym_tuple] = STATE(120),
+    [sym_namedTupleLiteral] = STATE(120),
+    [sym_commandLiteral] = STATE(120),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym_assignment] = STATE(120),
+    [aux_sym_program_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(145),
     [sym_nil] = ACTIONS(7),
     [anon_sym_true] = ACTIONS(9),
     [anon_sym_false] = ACTIONS(9),
@@ -2443,723 +2600,981 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_BQUOTE] = ACTIONS(35),
     [anon_sym_PERCENTx_LPAREN] = ACTIONS(37),
     [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [5] = {
+    [sym__expression] = STATE(38),
+    [sym_identifier] = STATE(145),
+    [sym_bool] = STATE(38),
+    [sym_float] = STATE(38),
+    [sym_integer] = STATE(38),
+    [sym_symbol] = STATE(38),
+    [sym_char] = STATE(38),
+    [sym_string] = STATE(40),
+    [sym_array] = STATE(38),
+    [sym_hash] = STATE(38),
+    [sym_regex] = STATE(38),
+    [sym_tuple] = STATE(38),
+    [sym_namedTupleLiteral] = STATE(38),
+    [sym_commandLiteral] = STATE(38),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym_assignment] = STATE(38),
+    [aux_sym_identifier_token1] = ACTIONS(47),
+    [sym_nil] = ACTIONS(147),
+    [anon_sym_true] = ACTIONS(51),
+    [anon_sym_false] = ACTIONS(51),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(61),
+    [anon_sym_DQUOTE] = ACTIONS(63),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_RBRACE] = ACTIONS(149),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [6] = {
+    [sym__expression] = STATE(57),
+    [sym_bool] = STATE(57),
+    [sym_float] = STATE(57),
+    [sym_integer] = STATE(57),
+    [sym_symbol] = STATE(57),
+    [sym_char] = STATE(57),
+    [sym_string] = STATE(57),
+    [sym_array] = STATE(57),
+    [sym_hash] = STATE(57),
+    [sym_regex] = STATE(57),
+    [sym_tuple] = STATE(57),
+    [sym_namedTupleLiteral] = STATE(57),
+    [sym_commandLiteral] = STATE(57),
+    [sym_local_variable] = STATE(168),
+    [sym_instance_variable] = STATE(168),
+    [sym_class_variable] = STATE(168),
+    [sym_constant] = STATE(168),
+    [sym_assignment] = STATE(57),
+    [sym_nil] = ACTIONS(151),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(155),
+    [anon_sym_DQUOTE] = ACTIONS(157),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [7] = {
+    [sym__expression] = STATE(136),
+    [sym_bool] = STATE(136),
+    [sym_float] = STATE(136),
+    [sym_integer] = STATE(136),
+    [sym_symbol] = STATE(136),
+    [sym_char] = STATE(136),
+    [sym_string] = STATE(136),
+    [sym_array] = STATE(136),
+    [sym_hash] = STATE(136),
+    [sym_regex] = STATE(136),
+    [sym_tuple] = STATE(136),
+    [sym_namedTupleLiteral] = STATE(136),
+    [sym_commandLiteral] = STATE(136),
+    [sym_local_variable] = STATE(173),
+    [sym_instance_variable] = STATE(173),
+    [sym_class_variable] = STATE(173),
+    [sym_constant] = STATE(173),
+    [sym_assignment] = STATE(136),
+    [sym_nil] = ACTIONS(159),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(161),
+    [anon_sym_DQUOTE] = ACTIONS(163),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [8] = {
+    [sym__expression] = STATE(57),
+    [sym_bool] = STATE(57),
+    [sym_float] = STATE(57),
+    [sym_integer] = STATE(57),
+    [sym_symbol] = STATE(57),
+    [sym_char] = STATE(57),
+    [sym_string] = STATE(57),
+    [sym_array] = STATE(57),
+    [sym_hash] = STATE(57),
+    [sym_regex] = STATE(57),
+    [sym_tuple] = STATE(57),
+    [sym_namedTupleLiteral] = STATE(57),
+    [sym_commandLiteral] = STATE(57),
+    [sym_local_variable] = STATE(173),
+    [sym_instance_variable] = STATE(173),
+    [sym_class_variable] = STATE(173),
+    [sym_constant] = STATE(173),
+    [sym_assignment] = STATE(57),
+    [sym_nil] = ACTIONS(151),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(161),
+    [anon_sym_DQUOTE] = ACTIONS(163),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [9] = {
+    [sym__expression] = STATE(90),
+    [sym_bool] = STATE(90),
+    [sym_float] = STATE(90),
+    [sym_integer] = STATE(90),
+    [sym_symbol] = STATE(90),
+    [sym_char] = STATE(90),
+    [sym_string] = STATE(90),
+    [sym_array] = STATE(90),
+    [sym_hash] = STATE(90),
+    [sym_regex] = STATE(90),
+    [sym_tuple] = STATE(90),
+    [sym_namedTupleLiteral] = STATE(90),
+    [sym_commandLiteral] = STATE(90),
+    [sym_local_variable] = STATE(173),
+    [sym_instance_variable] = STATE(173),
+    [sym_class_variable] = STATE(173),
+    [sym_constant] = STATE(173),
+    [sym_assignment] = STATE(90),
+    [sym_nil] = ACTIONS(165),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(161),
+    [anon_sym_DQUOTE] = ACTIONS(163),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [10] = {
+    [sym__expression] = STATE(96),
+    [sym_bool] = STATE(96),
+    [sym_float] = STATE(96),
+    [sym_integer] = STATE(96),
+    [sym_symbol] = STATE(96),
+    [sym_char] = STATE(96),
+    [sym_string] = STATE(96),
+    [sym_array] = STATE(96),
+    [sym_hash] = STATE(96),
+    [sym_regex] = STATE(96),
+    [sym_tuple] = STATE(96),
+    [sym_namedTupleLiteral] = STATE(96),
+    [sym_commandLiteral] = STATE(96),
+    [sym_local_variable] = STATE(168),
+    [sym_instance_variable] = STATE(168),
+    [sym_class_variable] = STATE(168),
+    [sym_constant] = STATE(168),
+    [sym_assignment] = STATE(96),
+    [sym_nil] = ACTIONS(167),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(155),
+    [anon_sym_DQUOTE] = ACTIONS(157),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [11] = {
+    [sym__expression] = STATE(57),
+    [sym_bool] = STATE(57),
+    [sym_float] = STATE(57),
+    [sym_integer] = STATE(57),
+    [sym_symbol] = STATE(57),
+    [sym_char] = STATE(57),
+    [sym_string] = STATE(57),
+    [sym_array] = STATE(57),
+    [sym_hash] = STATE(57),
+    [sym_regex] = STATE(57),
+    [sym_tuple] = STATE(57),
+    [sym_namedTupleLiteral] = STATE(57),
+    [sym_commandLiteral] = STATE(57),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym_assignment] = STATE(57),
+    [sym_nil] = ACTIONS(151),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(61),
+    [anon_sym_DQUOTE] = ACTIONS(169),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [12] = {
+    [sym__expression] = STATE(101),
+    [sym_bool] = STATE(101),
+    [sym_float] = STATE(101),
+    [sym_integer] = STATE(101),
+    [sym_symbol] = STATE(101),
+    [sym_char] = STATE(101),
+    [sym_string] = STATE(101),
+    [sym_array] = STATE(101),
+    [sym_hash] = STATE(101),
+    [sym_regex] = STATE(101),
+    [sym_tuple] = STATE(101),
+    [sym_namedTupleLiteral] = STATE(101),
+    [sym_commandLiteral] = STATE(101),
+    [sym_local_variable] = STATE(173),
+    [sym_instance_variable] = STATE(173),
+    [sym_class_variable] = STATE(173),
+    [sym_constant] = STATE(173),
+    [sym_assignment] = STATE(101),
+    [sym_nil] = ACTIONS(171),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(161),
+    [anon_sym_DQUOTE] = ACTIONS(163),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [13] = {
+    [sym__expression] = STATE(103),
+    [sym_bool] = STATE(103),
+    [sym_float] = STATE(103),
+    [sym_integer] = STATE(103),
+    [sym_symbol] = STATE(103),
+    [sym_char] = STATE(103),
+    [sym_string] = STATE(103),
+    [sym_array] = STATE(103),
+    [sym_hash] = STATE(103),
+    [sym_regex] = STATE(103),
+    [sym_tuple] = STATE(103),
+    [sym_namedTupleLiteral] = STATE(103),
+    [sym_commandLiteral] = STATE(103),
+    [sym_local_variable] = STATE(173),
+    [sym_instance_variable] = STATE(173),
+    [sym_class_variable] = STATE(173),
+    [sym_constant] = STATE(173),
+    [sym_assignment] = STATE(103),
+    [sym_nil] = ACTIONS(173),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(161),
+    [anon_sym_DQUOTE] = ACTIONS(163),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [14] = {
+    [sym__expression] = STATE(84),
+    [sym_bool] = STATE(84),
+    [sym_float] = STATE(84),
+    [sym_integer] = STATE(84),
+    [sym_symbol] = STATE(84),
+    [sym_char] = STATE(84),
+    [sym_string] = STATE(84),
+    [sym_array] = STATE(84),
+    [sym_hash] = STATE(84),
+    [sym_regex] = STATE(84),
+    [sym_tuple] = STATE(84),
+    [sym_namedTupleLiteral] = STATE(84),
+    [sym_commandLiteral] = STATE(84),
+    [sym_local_variable] = STATE(173),
+    [sym_instance_variable] = STATE(173),
+    [sym_class_variable] = STATE(173),
+    [sym_constant] = STATE(173),
+    [sym_assignment] = STATE(84),
+    [sym_nil] = ACTIONS(175),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(161),
+    [anon_sym_DQUOTE] = ACTIONS(163),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [15] = {
+    [sym__expression] = STATE(108),
+    [sym_bool] = STATE(108),
+    [sym_float] = STATE(108),
+    [sym_integer] = STATE(108),
+    [sym_symbol] = STATE(108),
+    [sym_char] = STATE(108),
+    [sym_string] = STATE(108),
+    [sym_array] = STATE(108),
+    [sym_hash] = STATE(108),
+    [sym_regex] = STATE(108),
+    [sym_tuple] = STATE(108),
+    [sym_namedTupleLiteral] = STATE(108),
+    [sym_commandLiteral] = STATE(108),
+    [sym_local_variable] = STATE(168),
+    [sym_instance_variable] = STATE(168),
+    [sym_class_variable] = STATE(168),
+    [sym_constant] = STATE(168),
+    [sym_assignment] = STATE(108),
+    [sym_nil] = ACTIONS(177),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(155),
+    [anon_sym_DQUOTE] = ACTIONS(157),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [16] = {
+    [sym__expression] = STATE(57),
+    [sym_bool] = STATE(57),
+    [sym_float] = STATE(57),
+    [sym_integer] = STATE(57),
+    [sym_symbol] = STATE(57),
+    [sym_char] = STATE(57),
+    [sym_string] = STATE(57),
+    [sym_array] = STATE(57),
+    [sym_hash] = STATE(57),
+    [sym_regex] = STATE(57),
+    [sym_tuple] = STATE(57),
+    [sym_namedTupleLiteral] = STATE(57),
+    [sym_commandLiteral] = STATE(57),
+    [sym_local_variable] = STATE(176),
+    [sym_instance_variable] = STATE(176),
+    [sym_class_variable] = STATE(176),
+    [sym_constant] = STATE(176),
+    [sym_assignment] = STATE(57),
+    [sym_nil] = ACTIONS(151),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(179),
+    [anon_sym_DQUOTE] = ACTIONS(181),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [17] = {
+    [sym__expression] = STATE(134),
+    [sym_bool] = STATE(134),
+    [sym_float] = STATE(134),
+    [sym_integer] = STATE(134),
+    [sym_symbol] = STATE(134),
+    [sym_char] = STATE(134),
+    [sym_string] = STATE(134),
+    [sym_array] = STATE(134),
+    [sym_hash] = STATE(134),
+    [sym_regex] = STATE(134),
+    [sym_tuple] = STATE(134),
+    [sym_namedTupleLiteral] = STATE(134),
+    [sym_commandLiteral] = STATE(134),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym_assignment] = STATE(134),
+    [sym_nil] = ACTIONS(183),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [aux_sym_float_token1] = ACTIONS(11),
+    [aux_sym_float_token2] = ACTIONS(13),
+    [aux_sym_float_token3] = ACTIONS(13),
+    [aux_sym_integer_token1] = ACTIONS(15),
+    [aux_sym_integer_token2] = ACTIONS(15),
+    [aux_sym_integer_token3] = ACTIONS(15),
+    [aux_sym_integer_token4] = ACTIONS(17),
+    [anon_sym_COLON] = ACTIONS(19),
+    [anon_sym_DQUOTE] = ACTIONS(21),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(23),
+    [aux_sym_char_token1] = ACTIONS(23),
+    [aux_sym_char_token2] = ACTIONS(25),
+    [anon_sym_LBRACK] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SLASH] = ACTIONS(31),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(33),
+    [anon_sym_BQUOTE] = ACTIONS(35),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(37),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [18] = {
+    [sym__expression] = STATE(146),
+    [sym_bool] = STATE(146),
+    [sym_float] = STATE(146),
+    [sym_integer] = STATE(146),
+    [sym_symbol] = STATE(146),
+    [sym_char] = STATE(146),
+    [sym_string] = STATE(146),
+    [sym_array] = STATE(146),
+    [sym_hash] = STATE(146),
+    [sym_regex] = STATE(146),
+    [sym_tuple] = STATE(146),
+    [sym_namedTupleLiteral] = STATE(146),
+    [sym_commandLiteral] = STATE(146),
+    [sym_local_variable] = STATE(176),
+    [sym_instance_variable] = STATE(176),
+    [sym_class_variable] = STATE(176),
+    [sym_constant] = STATE(176),
+    [sym_assignment] = STATE(146),
+    [sym_nil] = ACTIONS(185),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(179),
+    [anon_sym_DQUOTE] = ACTIONS(181),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [19] = {
+    [sym__expression] = STATE(84),
+    [sym_bool] = STATE(84),
+    [sym_float] = STATE(84),
+    [sym_integer] = STATE(84),
+    [sym_symbol] = STATE(84),
+    [sym_char] = STATE(84),
+    [sym_string] = STATE(84),
+    [sym_array] = STATE(84),
+    [sym_hash] = STATE(84),
+    [sym_regex] = STATE(84),
+    [sym_tuple] = STATE(84),
+    [sym_namedTupleLiteral] = STATE(84),
+    [sym_commandLiteral] = STATE(84),
+    [sym_local_variable] = STATE(168),
+    [sym_instance_variable] = STATE(168),
+    [sym_class_variable] = STATE(168),
+    [sym_constant] = STATE(168),
+    [sym_assignment] = STATE(84),
+    [sym_nil] = ACTIONS(175),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(155),
+    [anon_sym_DQUOTE] = ACTIONS(157),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [20] = {
+    [sym__expression] = STATE(137),
+    [sym_bool] = STATE(137),
+    [sym_float] = STATE(137),
+    [sym_integer] = STATE(137),
+    [sym_symbol] = STATE(137),
+    [sym_char] = STATE(137),
+    [sym_string] = STATE(137),
+    [sym_array] = STATE(137),
+    [sym_hash] = STATE(137),
+    [sym_regex] = STATE(137),
+    [sym_tuple] = STATE(137),
+    [sym_namedTupleLiteral] = STATE(137),
+    [sym_commandLiteral] = STATE(137),
+    [sym_local_variable] = STATE(173),
+    [sym_instance_variable] = STATE(173),
+    [sym_class_variable] = STATE(173),
+    [sym_constant] = STATE(173),
+    [sym_assignment] = STATE(137),
+    [sym_nil] = ACTIONS(187),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(161),
+    [anon_sym_DQUOTE] = ACTIONS(163),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
+  },
+  [21] = {
+    [sym__expression] = STATE(88),
+    [sym_bool] = STATE(88),
+    [sym_float] = STATE(88),
+    [sym_integer] = STATE(88),
+    [sym_symbol] = STATE(88),
+    [sym_char] = STATE(88),
+    [sym_string] = STATE(88),
+    [sym_array] = STATE(88),
+    [sym_hash] = STATE(88),
+    [sym_regex] = STATE(88),
+    [sym_tuple] = STATE(88),
+    [sym_namedTupleLiteral] = STATE(88),
+    [sym_commandLiteral] = STATE(88),
+    [sym_local_variable] = STATE(173),
+    [sym_instance_variable] = STATE(173),
+    [sym_class_variable] = STATE(173),
+    [sym_constant] = STATE(173),
+    [sym_assignment] = STATE(88),
+    [sym_nil] = ACTIONS(189),
+    [anon_sym_true] = ACTIONS(153),
+    [anon_sym_false] = ACTIONS(153),
+    [aux_sym_float_token1] = ACTIONS(53),
+    [aux_sym_float_token2] = ACTIONS(55),
+    [aux_sym_float_token3] = ACTIONS(55),
+    [aux_sym_integer_token1] = ACTIONS(57),
+    [aux_sym_integer_token2] = ACTIONS(57),
+    [aux_sym_integer_token3] = ACTIONS(57),
+    [aux_sym_integer_token4] = ACTIONS(59),
+    [anon_sym_COLON] = ACTIONS(161),
+    [anon_sym_DQUOTE] = ACTIONS(163),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(67),
+    [anon_sym_LBRACK] = ACTIONS(69),
+    [anon_sym_LBRACE] = ACTIONS(71),
+    [anon_sym_SLASH] = ACTIONS(75),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
+    [anon_sym_BQUOTE] = ACTIONS(79),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [aux_sym_constant_token1] = ACTIONS(45),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 18,
+  [0] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(131), 1,
-      sym_nil,
-    ACTIONS(135), 1,
-      anon_sym_COLON,
-    ACTIONS(137), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(111), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [82] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(135), 1,
-      anon_sym_COLON,
-    ACTIONS(137), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(139), 1,
-      sym_nil,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(112), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [164] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(141), 1,
-      sym_nil,
-    ACTIONS(143), 1,
-      anon_sym_COLON,
-    ACTIONS(145), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(146), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [246] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(135), 1,
-      anon_sym_COLON,
-    ACTIONS(137), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(147), 1,
-      sym_nil,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(76), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [328] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(135), 1,
-      anon_sym_COLON,
-    ACTIONS(137), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(149), 1,
-      sym_nil,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(78), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [410] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(151), 1,
-      sym_nil,
-    ACTIONS(153), 1,
-      anon_sym_COLON,
-    ACTIONS(155), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(97), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [492] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(153), 1,
-      anon_sym_COLON,
-    ACTIONS(155), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(157), 1,
-      sym_nil,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(82), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [574] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(135), 1,
-      anon_sym_COLON,
-    ACTIONS(137), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(159), 1,
-      sym_nil,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(68), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [656] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(135), 1,
-      anon_sym_COLON,
-    ACTIONS(137), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(161), 1,
-      sym_nil,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(72), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [738] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(135), 1,
-      anon_sym_COLON,
-    ACTIONS(137), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(157), 1,
-      sym_nil,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(82), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [820] = 18,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(95), 1,
-      aux_sym_float_token1,
-    ACTIONS(101), 1,
-      aux_sym_integer_token4,
-    ACTIONS(109), 1,
-      aux_sym_char_token2,
-    ACTIONS(111), 1,
-      anon_sym_LBRACK,
-    ACTIONS(113), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      anon_sym_SLASH,
-    ACTIONS(119), 1,
-      anon_sym_Tuple_DOTnew,
-    ACTIONS(121), 1,
-      anon_sym_BQUOTE,
-    ACTIONS(123), 1,
-      anon_sym_PERCENTx_LPAREN,
-    ACTIONS(153), 1,
-      anon_sym_COLON,
-    ACTIONS(155), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(163), 1,
-      sym_nil,
-    ACTIONS(97), 2,
-      aux_sym_float_token2,
-      aux_sym_float_token3,
-    ACTIONS(133), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(99), 3,
-      aux_sym_integer_token1,
-      aux_sym_integer_token2,
-      aux_sym_integer_token3,
-    ACTIONS(107), 12,
-      anon_sym_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
-      anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
-      anon_sym_SQUOTE_BSLASHa_SQUOTE,
-      anon_sym_SQUOTE_BSLASHb_SQUOTE,
-      anon_sym_SQUOTE_BSLASHe_SQUOTE,
-      anon_sym_SQUOTE_BSLASHf_SQUOTE,
-      anon_sym_SQUOTE_BSLASHn_SQUOTE,
-      anon_sym_SQUOTE_BSLASHr_SQUOTE,
-      anon_sym_SQUOTE_BSLASHt_SQUOTE,
-      anon_sym_SQUOTE_BSLASHv_SQUOTE,
-      aux_sym_char_token1,
-    STATE(70), 13,
-      sym__expression,
-      sym_bool,
-      sym_float,
-      sym_integer,
-      sym_symbol,
-      sym_char,
-      sym_string,
-      sym_array,
-      sym_hash,
-      sym_regex,
-      sym_tuple,
-      sym_namedTupleLiteral,
-      sym_commandLiteral,
-  [902] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(167), 4,
+    ACTIONS(193), 7,
       aux_sym_float_token2,
       aux_sym_float_token3,
       aux_sym_integer_token4,
       aux_sym_char_token2,
-    ACTIONS(165), 28,
+      aux_sym_local_variable_token1,
+      anon_sym_AT,
+      aux_sym_constant_token1,
+    ACTIONS(191), 29,
       ts_builtin_sym_end,
       sym_nil,
       anon_sym_true,
@@ -3188,14 +3603,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Tuple_DOTnew,
       anon_sym_BQUOTE,
       anon_sym_PERCENTx_LPAREN,
-  [942] = 5,
+      anon_sym_AT_AT,
+  [44] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(171), 1,
+    ACTIONS(197), 1,
       anon_sym_DQUOTE,
-    STATE(51), 1,
+    STATE(34), 1,
       sym__operator,
-    ACTIONS(173), 7,
+    ACTIONS(199), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3203,7 +3619,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(169), 20,
+    ACTIONS(195), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3224,14 +3640,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [983] = 5,
+  [85] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(175), 1,
+    ACTIONS(201), 1,
       anon_sym_DQUOTE,
-    STATE(51), 1,
+    STATE(34), 1,
       sym__operator,
-    ACTIONS(173), 7,
+    ACTIONS(199), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3239,7 +3655,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(169), 20,
+    ACTIONS(195), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3260,14 +3676,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [1024] = 5,
+  [126] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(177), 1,
+    ACTIONS(205), 1,
       anon_sym_DQUOTE,
-    STATE(51), 1,
+    STATE(128), 1,
       sym__operator,
-    ACTIONS(173), 7,
+    ACTIONS(207), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3275,7 +3691,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(169), 20,
+    ACTIONS(203), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3296,14 +3712,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [1065] = 5,
+  [167] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(181), 1,
+    ACTIONS(209), 1,
       anon_sym_DQUOTE,
-    STATE(121), 1,
+    STATE(34), 1,
       sym__operator,
-    ACTIONS(183), 7,
+    ACTIONS(199), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3311,7 +3727,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(179), 20,
+    ACTIONS(195), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3332,14 +3748,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [1106] = 5,
+  [208] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(185), 1,
+    ACTIONS(211), 1,
       anon_sym_DQUOTE,
-    STATE(51), 1,
+    STATE(34), 1,
       sym__operator,
-    ACTIONS(173), 7,
+    ACTIONS(199), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3347,7 +3763,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(169), 20,
+    ACTIONS(195), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3368,218 +3784,69 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [1147] = 3,
-    ACTIONS(191), 1,
+  [249] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(189), 2,
+    ACTIONS(215), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(187), 4,
-      anon_sym_COLON,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1161] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(193), 4,
-      anon_sym_COLON,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1175] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(195), 3,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1188] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(197), 3,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1201] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(199), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1211] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(201), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1221] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(203), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1231] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(205), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1241] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(207), 1,
-      anon_sym_COLON,
-    ACTIONS(209), 3,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1253] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(197), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-  [1265] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(211), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1275] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(187), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1287] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
     ACTIONS(213), 4,
+      anon_sym_COLON,
       anon_sym_COMMA,
-      anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1297] = 3,
-    ACTIONS(191), 1,
+  [263] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(187), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-    ACTIONS(189), 2,
+    ACTIONS(215), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1309] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(195), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [1321] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(197), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [1333] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(215), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1343] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(193), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-  [1355] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(195), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [1367] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(217), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1377] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
     ACTIONS(219), 4,
+      anon_sym_COLON,
       anon_sym_COMMA,
-      anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1387] = 2,
-    ACTIONS(3), 1,
+  [277] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(221), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1397] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(223), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1407] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
+    ACTIONS(215), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(195), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-  [1419] = 2,
+    ACTIONS(221), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [290] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(223), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [303] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(213), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [316] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(219), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [329] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(225), 4,
@@ -3587,34 +3854,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1429] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(187), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1441] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(197), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [1453] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(193), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [1465] = 2,
+  [339] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(227), 4,
@@ -3622,931 +3862,1253 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1475] = 2,
+  [349] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(229), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1485] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(231), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1495] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(233), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1505] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(235), 1,
+    ACTIONS(229), 1,
       anon_sym_COLON,
-    ACTIONS(209), 3,
+    ACTIONS(231), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1517] = 2,
+  [361] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(237), 4,
+    ACTIONS(233), 1,
+      anon_sym_COMMA,
+    ACTIONS(235), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(237), 1,
+      anon_sym_RBRACE,
+    STATE(104), 1,
+      aux_sym_array_repeat1,
+  [377] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(233), 1,
+      anon_sym_COMMA,
+    ACTIONS(239), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(241), 1,
+      anon_sym_RBRACE,
+    STATE(78), 1,
+      aux_sym_array_repeat1,
+  [393] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(223), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [405] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(243), 1,
+      anon_sym_COLON,
+    ACTIONS(231), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [417] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(219), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [429] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(221), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [441] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(213), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [453] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(213), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [465] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(245), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1527] = 4,
+  [475] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(213), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [487] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(239), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(241), 1,
+    ACTIONS(247), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [497] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
       anon_sym_DQUOTE,
-    STATE(149), 2,
+      aux_sym_symbol_token1,
+    ACTIONS(221), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+  [509] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(221), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [521] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(219), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+  [533] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(249), 1,
+      aux_sym_identifier_token1,
+    ACTIONS(251), 1,
+      anon_sym_DQUOTE,
+    STATE(163), 2,
       sym_identifier,
       sym_string,
-  [1541] = 5,
-    ACTIONS(3), 1,
+  [547] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(243), 1,
-      anon_sym_COMMA,
-    ACTIONS(245), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(247), 1,
-      anon_sym_RBRACE,
-    STATE(62), 1,
-      aux_sym_array_repeat1,
-  [1557] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(243), 1,
-      anon_sym_COMMA,
-    ACTIONS(249), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(251), 1,
-      anon_sym_RBRACE,
-    STATE(85), 1,
-      aux_sym_array_repeat1,
-  [1573] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
+    ACTIONS(215), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(193), 2,
+    ACTIONS(219), 2,
       anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [1585] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(253), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(255), 1,
-      aux_sym_symbol_token1,
-    STATE(95), 1,
-      aux_sym_symbol_repeat1,
-  [1598] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(243), 1,
-      anon_sym_COMMA,
-    ACTIONS(257), 1,
-      anon_sym_RBRACE,
-    STATE(107), 1,
-      aux_sym_array_repeat1,
-  [1611] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(259), 1,
-      anon_sym_COMMA,
-    ACTIONS(261), 1,
       anon_sym_RBRACK,
-    STATE(80), 1,
-      aux_sym_array_repeat1,
-  [1624] = 4,
+  [559] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(263), 1,
+    ACTIONS(253), 4,
       anon_sym_COMMA,
-    ACTIONS(266), 1,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
       anon_sym_RBRACE,
-    STATE(64), 1,
-      aux_sym_hash_repeat1,
-  [1637] = 4,
-    ACTIONS(191), 1,
+  [569] = 2,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(268), 1,
+    ACTIONS(255), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [579] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(257), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [589] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(259), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [599] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(261), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [609] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
       anon_sym_DQUOTE,
-    ACTIONS(270), 1,
       aux_sym_symbol_token1,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [1650] = 4,
+    ACTIONS(223), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [621] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(272), 1,
+    ACTIONS(263), 4,
       anon_sym_COMMA,
-    ACTIONS(274), 1,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
       anon_sym_RBRACE,
-    STATE(64), 1,
-      aux_sym_hash_repeat1,
-  [1663] = 4,
+  [631] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(276), 1,
+    ACTIONS(265), 4,
       anon_sym_COMMA,
-    ACTIONS(279), 1,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
       anon_sym_RBRACE,
-    STATE(67), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1676] = 4,
+  [641] = 2,
     ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(267), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [651] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(223), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+  [663] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(269), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [673] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(271), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [683] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(273), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [693] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(275), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [703] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(277), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [713] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(279), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [723] = 4,
+    ACTIONS(217), 1,
       sym_comment,
     ACTIONS(281), 1,
-      anon_sym_COMMA,
+      anon_sym_DQUOTE,
     ACTIONS(283), 1,
-      anon_sym_RBRACE,
-    STATE(75), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1689] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(281), 1,
-      anon_sym_COMMA,
-    ACTIONS(285), 1,
-      anon_sym_RBRACE,
-    STATE(67), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1702] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(259), 1,
-      anon_sym_COMMA,
-    ACTIONS(287), 1,
-      anon_sym_RBRACK,
-    STATE(63), 1,
-      aux_sym_array_repeat1,
-  [1715] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(270), 1,
       aux_sym_symbol_token1,
+    STATE(92), 1,
+      aux_sym_symbol_repeat1,
+  [736] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(285), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(287), 1,
+      aux_sym_symbol_token1,
+    STATE(81), 1,
+      aux_sym_symbol_repeat1,
+  [749] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
     ACTIONS(289), 1,
       anon_sym_DQUOTE,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [1728] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(272), 1,
-      anon_sym_COMMA,
     ACTIONS(291), 1,
-      anon_sym_RBRACE,
-    STATE(74), 1,
-      aux_sym_hash_repeat1,
-  [1741] = 4,
-    ACTIONS(191), 1,
+      aux_sym_symbol_token1,
+    STATE(106), 1,
+      aux_sym_symbol_repeat1,
+  [762] = 4,
+    ACTIONS(217), 1,
       sym_comment,
     ACTIONS(293), 1,
       anon_sym_DQUOTE,
     ACTIONS(295), 1,
       aux_sym_symbol_token1,
-    STATE(98), 1,
+    STATE(73), 1,
       aux_sym_symbol_repeat1,
-  [1754] = 4,
-    ACTIONS(3), 1,
+  [775] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(272), 1,
-      anon_sym_COMMA,
-    ACTIONS(297), 1,
-      anon_sym_RBRACE,
-    STATE(64), 1,
-      aux_sym_hash_repeat1,
-  [1767] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(281), 1,
-      anon_sym_COMMA,
-    ACTIONS(299), 1,
-      anon_sym_RBRACE,
-    STATE(67), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1780] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(281), 1,
-      anon_sym_COMMA,
-    ACTIONS(301), 1,
-      anon_sym_RBRACE,
-    STATE(69), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1793] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(303), 1,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+    ACTIONS(297), 2,
       anon_sym_DQUOTE,
-    ACTIONS(305), 1,
       aux_sym_symbol_token1,
-    STATE(81), 1,
-      aux_sym_symbol_repeat1,
-  [1806] = 4,
+  [786] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(272), 1,
+    ACTIONS(300), 1,
+      anon_sym_COMMA,
+    ACTIONS(303), 1,
+      anon_sym_RBRACE,
+    STATE(74), 1,
+      aux_sym_array_repeat1,
+  [799] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(305), 1,
       anon_sym_COMMA,
     ACTIONS(307), 1,
-      anon_sym_RBRACE,
-    STATE(66), 1,
-      aux_sym_hash_repeat1,
-  [1819] = 4,
-    ACTIONS(191), 1,
+      anon_sym_RBRACK,
+    STATE(86), 1,
+      aux_sym_array_repeat1,
+  [812] = 4,
+    ACTIONS(217), 1,
       sym_comment,
+    ACTIONS(295), 1,
+      aux_sym_symbol_token1,
     ACTIONS(309), 1,
       anon_sym_DQUOTE,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+  [825] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
     ACTIONS(311), 1,
-      aux_sym_symbol_token1,
-    STATE(83), 1,
-      aux_sym_symbol_repeat1,
-  [1832] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(313), 1,
-      anon_sym_COMMA,
-    ACTIONS(316), 1,
-      anon_sym_RBRACK,
-    STATE(80), 1,
-      aux_sym_array_repeat1,
-  [1845] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(270), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(318), 1,
       anon_sym_DQUOTE,
-    STATE(89), 1,
+    ACTIONS(313), 1,
+      aux_sym_symbol_token1,
+    STATE(76), 1,
       aux_sym_symbol_repeat1,
-  [1858] = 2,
+  [838] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(316), 3,
+    ACTIONS(233), 1,
+      anon_sym_COMMA,
+    ACTIONS(315), 1,
+      anon_sym_RBRACE,
+    STATE(74), 1,
+      aux_sym_array_repeat1,
+  [851] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(295), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(317), 1,
+      anon_sym_DQUOTE,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+  [864] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(319), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(321), 1,
+      aux_sym_symbol_token1,
+    STATE(79), 1,
+      aux_sym_symbol_repeat1,
+  [877] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(295), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(323), 1,
+      anon_sym_DQUOTE,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+  [890] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(295), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(325), 1,
+      anon_sym_DQUOTE,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+  [903] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(327), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(329), 1,
+      aux_sym_symbol_token1,
+    STATE(82), 1,
+      aux_sym_symbol_repeat1,
+  [916] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(303), 3,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_RBRACE,
-  [1867] = 4,
-    ACTIONS(191), 1,
+  [925] = 4,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(270), 1,
+    ACTIONS(295), 1,
       aux_sym_symbol_token1,
-    ACTIONS(320), 1,
+    ACTIONS(331), 1,
       anon_sym_DQUOTE,
-    STATE(89), 1,
+    STATE(73), 1,
       aux_sym_symbol_repeat1,
-  [1880] = 4,
-    ACTIONS(191), 1,
+  [938] = 4,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(322), 1,
+    ACTIONS(303), 1,
+      anon_sym_RBRACK,
+    ACTIONS(333), 1,
+      anon_sym_COMMA,
+    STATE(86), 1,
+      aux_sym_array_repeat1,
+  [951] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(295), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(336), 1,
       anon_sym_DQUOTE,
-    ACTIONS(324), 1,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+  [964] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(338), 1,
+      anon_sym_COMMA,
+    ACTIONS(340), 1,
+      anon_sym_RBRACE,
+    STATE(93), 1,
+      aux_sym_hash_repeat1,
+  [977] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(342), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(344), 1,
+      aux_sym_symbol_token1,
+    STATE(85), 1,
+      aux_sym_symbol_repeat1,
+  [990] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(346), 1,
+      anon_sym_COMMA,
+    ACTIONS(348), 1,
+      anon_sym_RBRACE,
+    STATE(95), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1003] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(350), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(352), 1,
       aux_sym_symbol_token1,
     STATE(87), 1,
       aux_sym_symbol_repeat1,
-  [1893] = 4,
+  [1016] = 4,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(295), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(354), 1,
+      anon_sym_DQUOTE,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+  [1029] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(243), 1,
+    ACTIONS(338), 1,
       anon_sym_COMMA,
-    ACTIONS(326), 1,
+    ACTIONS(356), 1,
       anon_sym_RBRACE,
-    STATE(107), 1,
-      aux_sym_array_repeat1,
-  [1906] = 4,
-    ACTIONS(191), 1,
+    STATE(99), 1,
+      aux_sym_hash_repeat1,
+  [1042] = 4,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(328), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(330), 1,
+    ACTIONS(295), 1,
       aux_sym_symbol_token1,
-    STATE(91), 1,
-      aux_sym_symbol_repeat1,
-  [1919] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(270), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(332), 1,
+    ACTIONS(358), 1,
       anon_sym_DQUOTE,
-    STATE(89), 1,
+    STATE(73), 1,
       aux_sym_symbol_repeat1,
-  [1932] = 4,
+  [1055] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(259), 1,
+    ACTIONS(346), 1,
       anon_sym_COMMA,
-    ACTIONS(334), 1,
+    ACTIONS(360), 1,
+      anon_sym_RBRACE,
+    STATE(102), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1068] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(305), 1,
+      anon_sym_COMMA,
+    ACTIONS(362), 1,
       anon_sym_RBRACK,
-    STATE(80), 1,
+    STATE(75), 1,
       aux_sym_array_repeat1,
-  [1945] = 3,
-    ACTIONS(191), 1,
+  [1081] = 4,
+    ACTIONS(217), 1,
       sym_comment,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-    ACTIONS(336), 2,
+    ACTIONS(364), 1,
       anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1956] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(270), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(339), 1,
-      anon_sym_DQUOTE,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [1969] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(270), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(341), 1,
-      anon_sym_DQUOTE,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [1982] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(343), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(345), 1,
+    ACTIONS(366), 1,
       aux_sym_symbol_token1,
     STATE(94), 1,
       aux_sym_symbol_repeat1,
-  [1995] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(347), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(349), 1,
-      aux_sym_symbol_token1,
-    STATE(65), 1,
-      aux_sym_symbol_repeat1,
-  [2008] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(270), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(351), 1,
-      anon_sym_DQUOTE,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [2021] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(270), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(353), 1,
-      anon_sym_DQUOTE,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [2034] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(355), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(357), 1,
-      aux_sym_symbol_token1,
-    STATE(100), 1,
-      aux_sym_symbol_repeat1,
-  [2047] = 4,
+  [1094] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(259), 1,
+    ACTIONS(346), 1,
       anon_sym_COMMA,
-    ACTIONS(359), 1,
-      anon_sym_RBRACK,
-    STATE(88), 1,
-      aux_sym_array_repeat1,
-  [2060] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(270), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(361), 1,
-      anon_sym_DQUOTE,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [2073] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(363), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(365), 1,
-      aux_sym_symbol_token1,
-    STATE(90), 1,
-      aux_sym_symbol_repeat1,
-  [2086] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(270), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(367), 1,
-      anon_sym_DQUOTE,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [2099] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(193), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [2110] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(197), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [2121] = 3,
-    ACTIONS(187), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [2132] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(195), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [2143] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(193), 1,
-      anon_sym_COLON,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [2154] = 3,
-    ACTIONS(187), 1,
-      anon_sym_COLON,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(189), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [2165] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(316), 1,
+    ACTIONS(368), 1,
       anon_sym_RBRACE,
-    ACTIONS(369), 1,
-      anon_sym_COMMA,
-    STATE(107), 1,
-      aux_sym_array_repeat1,
-  [2178] = 4,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(372), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(374), 1,
-      aux_sym_symbol_token1,
-    STATE(71), 1,
-      aux_sym_symbol_repeat1,
-  [2191] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(225), 1,
-      aux_sym__statement_token1,
-    ACTIONS(376), 1,
-      anon_sym_SEMI,
-  [2201] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(201), 1,
-      aux_sym__statement_token1,
-    ACTIONS(378), 1,
-      anon_sym_SEMI,
-  [2211] = 2,
+    STATE(102), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1107] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(380), 2,
+    ACTIONS(370), 1,
       anon_sym_COMMA,
+    ACTIONS(373), 1,
       anon_sym_RBRACE,
-  [2219] = 2,
+    STATE(99), 1,
+      aux_sym_hash_repeat1,
+  [1120] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(382), 2,
+    ACTIONS(338), 1,
       anon_sym_COMMA,
+    ACTIONS(375), 1,
       anon_sym_RBRACE,
-  [2227] = 3,
-    ACTIONS(191), 1,
+    STATE(99), 1,
+      aux_sym_hash_repeat1,
+  [1133] = 4,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(237), 1,
-      aux_sym__statement_token1,
+    ACTIONS(346), 1,
+      anon_sym_COMMA,
+    ACTIONS(377), 1,
+      anon_sym_RBRACE,
+    STATE(98), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1146] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(379), 1,
+      anon_sym_COMMA,
+    ACTIONS(382), 1,
+      anon_sym_RBRACE,
+    STATE(102), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1159] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(338), 1,
+      anon_sym_COMMA,
     ACTIONS(384), 1,
-      anon_sym_SEMI,
-  [2237] = 3,
-    ACTIONS(191), 1,
+      anon_sym_RBRACE,
+    STATE(100), 1,
+      aux_sym_hash_repeat1,
+  [1172] = 4,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(233), 1,
-      aux_sym__statement_token1,
+      anon_sym_COMMA,
     ACTIONS(386), 1,
-      anon_sym_SEMI,
-  [2247] = 3,
-    ACTIONS(191), 1,
+      anon_sym_RBRACE,
+    STATE(74), 1,
+      aux_sym_array_repeat1,
+  [1185] = 4,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(231), 1,
-      aux_sym__statement_token1,
+    ACTIONS(305), 1,
+      anon_sym_COMMA,
     ACTIONS(388), 1,
-      anon_sym_SEMI,
-  [2257] = 3,
-    ACTIONS(191), 1,
+      anon_sym_RBRACK,
+    STATE(86), 1,
+      aux_sym_array_repeat1,
+  [1198] = 4,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(219), 1,
-      aux_sym__statement_token1,
+    ACTIONS(295), 1,
+      aux_sym_symbol_token1,
     ACTIONS(390), 1,
-      anon_sym_SEMI,
-  [2267] = 3,
-    ACTIONS(191), 1,
+      anon_sym_DQUOTE,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+  [1211] = 4,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(229), 1,
-      aux_sym__statement_token1,
+    ACTIONS(295), 1,
+      aux_sym_symbol_token1,
     ACTIONS(392), 1,
-      anon_sym_SEMI,
-  [2277] = 3,
-    ACTIONS(191), 1,
+      anon_sym_DQUOTE,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+  [1224] = 4,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(221), 1,
-      aux_sym__statement_token1,
+    ACTIONS(305), 1,
+      anon_sym_COMMA,
     ACTIONS(394), 1,
-      anon_sym_SEMI,
-  [2287] = 3,
-    ACTIONS(191), 1,
+      anon_sym_RBRACK,
+    STATE(105), 1,
+      aux_sym_array_repeat1,
+  [1237] = 4,
+    ACTIONS(217), 1,
       sym_comment,
     ACTIONS(396), 1,
-      anon_sym_SEMI,
+      anon_sym_DQUOTE,
     ACTIONS(398), 1,
-      aux_sym__statement_token1,
-  [2297] = 3,
-    ACTIONS(191), 1,
+      aux_sym_symbol_token1,
+    STATE(72), 1,
+      aux_sym_symbol_repeat1,
+  [1250] = 4,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(203), 1,
-      aux_sym__statement_token1,
+    ACTIONS(295), 1,
+      aux_sym_symbol_token1,
     ACTIONS(400), 1,
-      anon_sym_SEMI,
-  [2307] = 3,
-    ACTIONS(191), 1,
+      anon_sym_DQUOTE,
+    STATE(73), 1,
+      aux_sym_symbol_repeat1,
+  [1263] = 4,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(227), 1,
-      aux_sym__statement_token1,
     ACTIONS(402), 1,
-      anon_sym_SEMI,
-  [2317] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(211), 1,
-      aux_sym__statement_token1,
+      anon_sym_DQUOTE,
     ACTIONS(404), 1,
-      anon_sym_SEMI,
-  [2327] = 3,
-    ACTIONS(191), 1,
+      aux_sym_symbol_token1,
+    STATE(107), 1,
+      aux_sym_symbol_repeat1,
+  [1276] = 4,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(213), 1,
-      aux_sym__statement_token1,
     ACTIONS(406), 1,
-      anon_sym_SEMI,
-  [2337] = 3,
-    ACTIONS(191), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(408), 1,
+      aux_sym_symbol_token1,
+    STATE(110), 1,
+      aux_sym_symbol_repeat1,
+  [1289] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(219), 1,
+      anon_sym_COLON,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1300] = 3,
+    ACTIONS(213), 1,
+      anon_sym_COLON,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1311] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(219), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1322] = 3,
+    ACTIONS(213), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1333] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(221), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1344] = 3,
+    ACTIONS(217), 1,
       sym_comment,
     ACTIONS(223), 1,
-      aux_sym__statement_token1,
-    ACTIONS(408), 1,
-      anon_sym_SEMI,
-  [2347] = 3,
-    ACTIONS(191), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(215), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1355] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(199), 1,
+    ACTIONS(269), 1,
       aux_sym__statement_token1,
     ACTIONS(410), 1,
       anon_sym_SEMI,
-  [2357] = 3,
-    ACTIONS(191), 1,
+  [1365] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(205), 1,
-      aux_sym__statement_token1,
     ACTIONS(412), 1,
       anon_sym_SEMI,
-  [2367] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
-    ACTIONS(215), 1,
-      aux_sym__statement_token1,
     ACTIONS(414), 1,
-      anon_sym_SEMI,
-  [2377] = 3,
-    ACTIONS(191), 1,
-      sym_comment,
+      aux_sym__statement_token1,
+  [1375] = 3,
     ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(273), 1,
       aux_sym__statement_token1,
     ACTIONS(416), 1,
       anon_sym_SEMI,
-  [2387] = 2,
-    ACTIONS(3), 1,
+  [1385] = 3,
+    ACTIONS(217), 1,
       sym_comment,
+    ACTIONS(275), 1,
+      aux_sym__statement_token1,
     ACTIONS(418), 1,
-      anon_sym_RPAREN,
-  [2394] = 2,
-    ACTIONS(191), 1,
+      anon_sym_SEMI,
+  [1395] = 3,
+    ACTIONS(217), 1,
       sym_comment,
+    ACTIONS(277), 1,
+      aux_sym__statement_token1,
     ACTIONS(420), 1,
-      aux_sym_commandLiteral_token2,
-  [2401] = 2,
+      anon_sym_SEMI,
+  [1405] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(422), 1,
-      anon_sym_EQ_GT,
-  [2408] = 2,
-    ACTIONS(191), 1,
-      sym_comment,
+      aux_sym_identifier_token1,
     ACTIONS(424), 1,
-      aux_sym_hash_token1,
-  [2415] = 2,
-    ACTIONS(3), 1,
+      anon_sym_EQ,
+  [1415] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(418), 1,
-      anon_sym_BQUOTE,
-  [2422] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
+    ACTIONS(279), 1,
+      aux_sym__statement_token1,
     ACTIONS(426), 1,
-      anon_sym_SLASH,
-  [2429] = 2,
-    ACTIONS(3), 1,
+      anon_sym_SEMI,
+  [1425] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(235), 1,
-      anon_sym_COLON,
-  [2436] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
+    ACTIONS(253), 1,
+      aux_sym__statement_token1,
     ACTIONS(428), 1,
-      anon_sym_of,
-  [2443] = 2,
+      anon_sym_SEMI,
+  [1435] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(430), 1,
-      anon_sym_COLON,
-  [2450] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
+      aux_sym_identifier_token1,
     ACTIONS(432), 1,
-      anon_sym_SLASH,
-  [2457] = 2,
-    ACTIONS(191), 1,
+      anon_sym_EQ,
+  [1445] = 3,
+    ACTIONS(217), 1,
       sym_comment,
+    ACTIONS(225), 1,
+      aux_sym__statement_token1,
     ACTIONS(434), 1,
-      aux_sym_hash_token1,
-  [2464] = 2,
-    ACTIONS(191), 1,
+      anon_sym_SEMI,
+  [1455] = 3,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(436), 1,
-      aux_sym_regex_token1,
-  [2471] = 2,
-    ACTIONS(191), 1,
-      sym_comment,
+      aux_sym_identifier_token1,
     ACTIONS(438), 1,
-      aux_sym_commandLiteral_token1,
-  [2478] = 2,
-    ACTIONS(191), 1,
+      anon_sym_EQ,
+  [1465] = 3,
+    ACTIONS(217), 1,
       sym_comment,
+    ACTIONS(255), 1,
+      aux_sym__statement_token1,
     ACTIONS(440), 1,
-      aux_sym_hash_token1,
-  [2485] = 2,
-    ACTIONS(3), 1,
+      anon_sym_SEMI,
+  [1475] = 3,
+    ACTIONS(217), 1,
       sym_comment,
+    ACTIONS(257), 1,
+      aux_sym__statement_token1,
     ACTIONS(442), 1,
-      ts_builtin_sym_end,
-  [2492] = 2,
-    ACTIONS(191), 1,
+      anon_sym_SEMI,
+  [1485] = 3,
+    ACTIONS(217), 1,
       sym_comment,
+    ACTIONS(259), 1,
+      aux_sym__statement_token1,
     ACTIONS(444), 1,
-      aux_sym_commandLiteral_token2,
-  [2499] = 2,
-    ACTIONS(191), 1,
+      anon_sym_SEMI,
+  [1495] = 3,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(446), 1,
-      aux_sym_commandLiteral_token1,
-  [2506] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
+      aux_sym_identifier_token1,
     ACTIONS(448), 1,
-      anon_sym_EQ_GT,
-  [2513] = 2,
-    ACTIONS(3), 1,
+      anon_sym_EQ,
+  [1505] = 3,
+    ACTIONS(217), 1,
       sym_comment,
+    ACTIONS(261), 1,
+      aux_sym__statement_token1,
     ACTIONS(450), 1,
-      anon_sym_EQ_GT,
-  [2520] = 2,
-    ACTIONS(191), 1,
+      anon_sym_SEMI,
+  [1515] = 3,
+    ACTIONS(217), 1,
       sym_comment,
+    ACTIONS(271), 1,
+      aux_sym__statement_token1,
     ACTIONS(452), 1,
-      aux_sym_regex_token1,
-  [2527] = 2,
+      anon_sym_SEMI,
+  [1525] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(454), 1,
-      anon_sym_COLON,
-  [2534] = 2,
+    ACTIONS(454), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [1533] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(456), 1,
-      anon_sym_RPAREN,
-  [2541] = 2,
-    ACTIONS(3), 1,
+    ACTIONS(456), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [1541] = 3,
+    ACTIONS(217), 1,
       sym_comment,
-    ACTIONS(207), 1,
-      anon_sym_COLON,
-  [2548] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(456), 1,
-      anon_sym_BQUOTE,
-  [2555] = 2,
-    ACTIONS(191), 1,
-      sym_comment,
+    ACTIONS(245), 1,
+      aux_sym__statement_token1,
     ACTIONS(458), 1,
-      aux_sym_hash_token1,
-  [2562] = 2,
+      anon_sym_SEMI,
+  [1551] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(263), 1,
+      aux_sym__statement_token1,
+    ACTIONS(460), 1,
+      anon_sym_SEMI,
+  [1561] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(267), 1,
+      aux_sym__statement_token1,
+    ACTIONS(462), 1,
+      anon_sym_SEMI,
+  [1571] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(247), 1,
+      aux_sym__statement_token1,
+    ACTIONS(464), 1,
+      anon_sym_SEMI,
+  [1581] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(265), 1,
+      aux_sym__statement_token1,
+    ACTIONS(466), 1,
+      anon_sym_SEMI,
+  [1591] = 3,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(227), 1,
+      aux_sym__statement_token1,
+    ACTIONS(468), 1,
+      anon_sym_SEMI,
+  [1601] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(460), 1,
+    ACTIONS(470), 1,
+      anon_sym_RPAREN,
+  [1608] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(243), 1,
+      anon_sym_COLON,
+  [1615] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(472), 1,
+      anon_sym_EQ_GT,
+  [1622] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(474), 1,
+      aux_sym_hash_token1,
+  [1629] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(476), 1,
+      anon_sym_EQ_GT,
+  [1636] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(478), 1,
+      anon_sym_SLASH,
+  [1643] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(480), 1,
+      aux_sym_hash_token1,
+  [1650] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(482), 1,
+      anon_sym_COLON,
+  [1657] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(484), 1,
+      anon_sym_EQ,
+  [1664] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(486), 1,
+      anon_sym_EQ,
+  [1671] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(488), 1,
+      ts_builtin_sym_end,
+  [1678] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(470), 1,
+      anon_sym_BQUOTE,
+  [1685] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(490), 1,
+      anon_sym_SLASH,
+  [1692] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(492), 1,
+      aux_sym_hash_token1,
+  [1699] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(494), 1,
+      aux_sym_local_variable_token1,
+  [1706] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(496), 1,
+      aux_sym_local_variable_token1,
+  [1713] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(498), 1,
+      aux_sym_regex_token1,
+  [1720] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(500), 1,
+      aux_sym_commandLiteral_token1,
+  [1727] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(502), 1,
+      aux_sym_commandLiteral_token2,
+  [1734] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(504), 1,
+      anon_sym_COLON,
+  [1741] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(506), 1,
+      aux_sym_commandLiteral_token2,
+  [1748] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(508), 1,
+      aux_sym_commandLiteral_token1,
+  [1755] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(510), 1,
+      anon_sym_EQ,
+  [1762] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(512), 1,
+      anon_sym_EQ_GT,
+  [1769] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(514), 1,
+      anon_sym_EQ,
+  [1776] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(516), 1,
+      aux_sym_regex_token1,
+  [1783] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(518), 1,
+      anon_sym_EQ,
+  [1790] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(520), 1,
+      anon_sym_EQ,
+  [1797] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(522), 1,
+      anon_sym_EQ,
+  [1804] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(524), 1,
+      anon_sym_EQ,
+  [1811] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(526), 1,
+      anon_sym_RPAREN,
+  [1818] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(526), 1,
+      anon_sym_BQUOTE,
+  [1825] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(528), 1,
+      anon_sym_EQ,
+  [1832] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(229), 1,
+      anon_sym_COLON,
+  [1839] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(530), 1,
+      anon_sym_of,
+  [1846] = 2,
+    ACTIONS(217), 1,
+      sym_comment,
+    ACTIONS(532), 1,
+      aux_sym_hash_token1,
+  [1853] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(534), 1,
       anon_sym_of,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(6)] = 0,
-  [SMALL_STATE(7)] = 82,
-  [SMALL_STATE(8)] = 164,
-  [SMALL_STATE(9)] = 246,
-  [SMALL_STATE(10)] = 328,
-  [SMALL_STATE(11)] = 410,
-  [SMALL_STATE(12)] = 492,
-  [SMALL_STATE(13)] = 574,
-  [SMALL_STATE(14)] = 656,
-  [SMALL_STATE(15)] = 738,
-  [SMALL_STATE(16)] = 820,
-  [SMALL_STATE(17)] = 902,
-  [SMALL_STATE(18)] = 942,
-  [SMALL_STATE(19)] = 983,
-  [SMALL_STATE(20)] = 1024,
-  [SMALL_STATE(21)] = 1065,
-  [SMALL_STATE(22)] = 1106,
-  [SMALL_STATE(23)] = 1147,
-  [SMALL_STATE(24)] = 1161,
-  [SMALL_STATE(25)] = 1175,
-  [SMALL_STATE(26)] = 1188,
-  [SMALL_STATE(27)] = 1201,
-  [SMALL_STATE(28)] = 1211,
-  [SMALL_STATE(29)] = 1221,
-  [SMALL_STATE(30)] = 1231,
-  [SMALL_STATE(31)] = 1241,
-  [SMALL_STATE(32)] = 1253,
-  [SMALL_STATE(33)] = 1265,
-  [SMALL_STATE(34)] = 1275,
-  [SMALL_STATE(35)] = 1287,
-  [SMALL_STATE(36)] = 1297,
-  [SMALL_STATE(37)] = 1309,
-  [SMALL_STATE(38)] = 1321,
-  [SMALL_STATE(39)] = 1333,
-  [SMALL_STATE(40)] = 1343,
-  [SMALL_STATE(41)] = 1355,
-  [SMALL_STATE(42)] = 1367,
-  [SMALL_STATE(43)] = 1377,
-  [SMALL_STATE(44)] = 1387,
-  [SMALL_STATE(45)] = 1397,
-  [SMALL_STATE(46)] = 1407,
-  [SMALL_STATE(47)] = 1419,
-  [SMALL_STATE(48)] = 1429,
-  [SMALL_STATE(49)] = 1441,
-  [SMALL_STATE(50)] = 1453,
-  [SMALL_STATE(51)] = 1465,
-  [SMALL_STATE(52)] = 1475,
-  [SMALL_STATE(53)] = 1485,
-  [SMALL_STATE(54)] = 1495,
-  [SMALL_STATE(55)] = 1505,
-  [SMALL_STATE(56)] = 1517,
-  [SMALL_STATE(57)] = 1527,
-  [SMALL_STATE(58)] = 1541,
-  [SMALL_STATE(59)] = 1557,
-  [SMALL_STATE(60)] = 1573,
-  [SMALL_STATE(61)] = 1585,
-  [SMALL_STATE(62)] = 1598,
-  [SMALL_STATE(63)] = 1611,
-  [SMALL_STATE(64)] = 1624,
-  [SMALL_STATE(65)] = 1637,
-  [SMALL_STATE(66)] = 1650,
-  [SMALL_STATE(67)] = 1663,
-  [SMALL_STATE(68)] = 1676,
-  [SMALL_STATE(69)] = 1689,
-  [SMALL_STATE(70)] = 1702,
-  [SMALL_STATE(71)] = 1715,
-  [SMALL_STATE(72)] = 1728,
-  [SMALL_STATE(73)] = 1741,
-  [SMALL_STATE(74)] = 1754,
-  [SMALL_STATE(75)] = 1767,
-  [SMALL_STATE(76)] = 1780,
-  [SMALL_STATE(77)] = 1793,
-  [SMALL_STATE(78)] = 1806,
-  [SMALL_STATE(79)] = 1819,
-  [SMALL_STATE(80)] = 1832,
-  [SMALL_STATE(81)] = 1845,
-  [SMALL_STATE(82)] = 1858,
-  [SMALL_STATE(83)] = 1867,
-  [SMALL_STATE(84)] = 1880,
-  [SMALL_STATE(85)] = 1893,
-  [SMALL_STATE(86)] = 1906,
-  [SMALL_STATE(87)] = 1919,
-  [SMALL_STATE(88)] = 1932,
-  [SMALL_STATE(89)] = 1945,
-  [SMALL_STATE(90)] = 1956,
-  [SMALL_STATE(91)] = 1969,
-  [SMALL_STATE(92)] = 1982,
-  [SMALL_STATE(93)] = 1995,
-  [SMALL_STATE(94)] = 2008,
-  [SMALL_STATE(95)] = 2021,
-  [SMALL_STATE(96)] = 2034,
-  [SMALL_STATE(97)] = 2047,
-  [SMALL_STATE(98)] = 2060,
-  [SMALL_STATE(99)] = 2073,
-  [SMALL_STATE(100)] = 2086,
-  [SMALL_STATE(101)] = 2099,
-  [SMALL_STATE(102)] = 2110,
-  [SMALL_STATE(103)] = 2121,
-  [SMALL_STATE(104)] = 2132,
-  [SMALL_STATE(105)] = 2143,
-  [SMALL_STATE(106)] = 2154,
-  [SMALL_STATE(107)] = 2165,
-  [SMALL_STATE(108)] = 2178,
-  [SMALL_STATE(109)] = 2191,
-  [SMALL_STATE(110)] = 2201,
-  [SMALL_STATE(111)] = 2211,
-  [SMALL_STATE(112)] = 2219,
-  [SMALL_STATE(113)] = 2227,
-  [SMALL_STATE(114)] = 2237,
-  [SMALL_STATE(115)] = 2247,
-  [SMALL_STATE(116)] = 2257,
-  [SMALL_STATE(117)] = 2267,
-  [SMALL_STATE(118)] = 2277,
-  [SMALL_STATE(119)] = 2287,
-  [SMALL_STATE(120)] = 2297,
-  [SMALL_STATE(121)] = 2307,
-  [SMALL_STATE(122)] = 2317,
-  [SMALL_STATE(123)] = 2327,
-  [SMALL_STATE(124)] = 2337,
-  [SMALL_STATE(125)] = 2347,
-  [SMALL_STATE(126)] = 2357,
-  [SMALL_STATE(127)] = 2367,
-  [SMALL_STATE(128)] = 2377,
-  [SMALL_STATE(129)] = 2387,
-  [SMALL_STATE(130)] = 2394,
-  [SMALL_STATE(131)] = 2401,
-  [SMALL_STATE(132)] = 2408,
-  [SMALL_STATE(133)] = 2415,
-  [SMALL_STATE(134)] = 2422,
-  [SMALL_STATE(135)] = 2429,
-  [SMALL_STATE(136)] = 2436,
-  [SMALL_STATE(137)] = 2443,
-  [SMALL_STATE(138)] = 2450,
-  [SMALL_STATE(139)] = 2457,
-  [SMALL_STATE(140)] = 2464,
-  [SMALL_STATE(141)] = 2471,
-  [SMALL_STATE(142)] = 2478,
-  [SMALL_STATE(143)] = 2485,
-  [SMALL_STATE(144)] = 2492,
-  [SMALL_STATE(145)] = 2499,
-  [SMALL_STATE(146)] = 2506,
-  [SMALL_STATE(147)] = 2513,
-  [SMALL_STATE(148)] = 2520,
-  [SMALL_STATE(149)] = 2527,
-  [SMALL_STATE(150)] = 2534,
-  [SMALL_STATE(151)] = 2541,
-  [SMALL_STATE(152)] = 2548,
-  [SMALL_STATE(153)] = 2555,
-  [SMALL_STATE(154)] = 2562,
+  [SMALL_STATE(22)] = 0,
+  [SMALL_STATE(23)] = 44,
+  [SMALL_STATE(24)] = 85,
+  [SMALL_STATE(25)] = 126,
+  [SMALL_STATE(26)] = 167,
+  [SMALL_STATE(27)] = 208,
+  [SMALL_STATE(28)] = 249,
+  [SMALL_STATE(29)] = 263,
+  [SMALL_STATE(30)] = 277,
+  [SMALL_STATE(31)] = 290,
+  [SMALL_STATE(32)] = 303,
+  [SMALL_STATE(33)] = 316,
+  [SMALL_STATE(34)] = 329,
+  [SMALL_STATE(35)] = 339,
+  [SMALL_STATE(36)] = 349,
+  [SMALL_STATE(37)] = 361,
+  [SMALL_STATE(38)] = 377,
+  [SMALL_STATE(39)] = 393,
+  [SMALL_STATE(40)] = 405,
+  [SMALL_STATE(41)] = 417,
+  [SMALL_STATE(42)] = 429,
+  [SMALL_STATE(43)] = 441,
+  [SMALL_STATE(44)] = 453,
+  [SMALL_STATE(45)] = 465,
+  [SMALL_STATE(46)] = 475,
+  [SMALL_STATE(47)] = 487,
+  [SMALL_STATE(48)] = 497,
+  [SMALL_STATE(49)] = 509,
+  [SMALL_STATE(50)] = 521,
+  [SMALL_STATE(51)] = 533,
+  [SMALL_STATE(52)] = 547,
+  [SMALL_STATE(53)] = 559,
+  [SMALL_STATE(54)] = 569,
+  [SMALL_STATE(55)] = 579,
+  [SMALL_STATE(56)] = 589,
+  [SMALL_STATE(57)] = 599,
+  [SMALL_STATE(58)] = 609,
+  [SMALL_STATE(59)] = 621,
+  [SMALL_STATE(60)] = 631,
+  [SMALL_STATE(61)] = 641,
+  [SMALL_STATE(62)] = 651,
+  [SMALL_STATE(63)] = 663,
+  [SMALL_STATE(64)] = 673,
+  [SMALL_STATE(65)] = 683,
+  [SMALL_STATE(66)] = 693,
+  [SMALL_STATE(67)] = 703,
+  [SMALL_STATE(68)] = 713,
+  [SMALL_STATE(69)] = 723,
+  [SMALL_STATE(70)] = 736,
+  [SMALL_STATE(71)] = 749,
+  [SMALL_STATE(72)] = 762,
+  [SMALL_STATE(73)] = 775,
+  [SMALL_STATE(74)] = 786,
+  [SMALL_STATE(75)] = 799,
+  [SMALL_STATE(76)] = 812,
+  [SMALL_STATE(77)] = 825,
+  [SMALL_STATE(78)] = 838,
+  [SMALL_STATE(79)] = 851,
+  [SMALL_STATE(80)] = 864,
+  [SMALL_STATE(81)] = 877,
+  [SMALL_STATE(82)] = 890,
+  [SMALL_STATE(83)] = 903,
+  [SMALL_STATE(84)] = 916,
+  [SMALL_STATE(85)] = 925,
+  [SMALL_STATE(86)] = 938,
+  [SMALL_STATE(87)] = 951,
+  [SMALL_STATE(88)] = 964,
+  [SMALL_STATE(89)] = 977,
+  [SMALL_STATE(90)] = 990,
+  [SMALL_STATE(91)] = 1003,
+  [SMALL_STATE(92)] = 1016,
+  [SMALL_STATE(93)] = 1029,
+  [SMALL_STATE(94)] = 1042,
+  [SMALL_STATE(95)] = 1055,
+  [SMALL_STATE(96)] = 1068,
+  [SMALL_STATE(97)] = 1081,
+  [SMALL_STATE(98)] = 1094,
+  [SMALL_STATE(99)] = 1107,
+  [SMALL_STATE(100)] = 1120,
+  [SMALL_STATE(101)] = 1133,
+  [SMALL_STATE(102)] = 1146,
+  [SMALL_STATE(103)] = 1159,
+  [SMALL_STATE(104)] = 1172,
+  [SMALL_STATE(105)] = 1185,
+  [SMALL_STATE(106)] = 1198,
+  [SMALL_STATE(107)] = 1211,
+  [SMALL_STATE(108)] = 1224,
+  [SMALL_STATE(109)] = 1237,
+  [SMALL_STATE(110)] = 1250,
+  [SMALL_STATE(111)] = 1263,
+  [SMALL_STATE(112)] = 1276,
+  [SMALL_STATE(113)] = 1289,
+  [SMALL_STATE(114)] = 1300,
+  [SMALL_STATE(115)] = 1311,
+  [SMALL_STATE(116)] = 1322,
+  [SMALL_STATE(117)] = 1333,
+  [SMALL_STATE(118)] = 1344,
+  [SMALL_STATE(119)] = 1355,
+  [SMALL_STATE(120)] = 1365,
+  [SMALL_STATE(121)] = 1375,
+  [SMALL_STATE(122)] = 1385,
+  [SMALL_STATE(123)] = 1395,
+  [SMALL_STATE(124)] = 1405,
+  [SMALL_STATE(125)] = 1415,
+  [SMALL_STATE(126)] = 1425,
+  [SMALL_STATE(127)] = 1435,
+  [SMALL_STATE(128)] = 1445,
+  [SMALL_STATE(129)] = 1455,
+  [SMALL_STATE(130)] = 1465,
+  [SMALL_STATE(131)] = 1475,
+  [SMALL_STATE(132)] = 1485,
+  [SMALL_STATE(133)] = 1495,
+  [SMALL_STATE(134)] = 1505,
+  [SMALL_STATE(135)] = 1515,
+  [SMALL_STATE(136)] = 1525,
+  [SMALL_STATE(137)] = 1533,
+  [SMALL_STATE(138)] = 1541,
+  [SMALL_STATE(139)] = 1551,
+  [SMALL_STATE(140)] = 1561,
+  [SMALL_STATE(141)] = 1571,
+  [SMALL_STATE(142)] = 1581,
+  [SMALL_STATE(143)] = 1591,
+  [SMALL_STATE(144)] = 1601,
+  [SMALL_STATE(145)] = 1608,
+  [SMALL_STATE(146)] = 1615,
+  [SMALL_STATE(147)] = 1622,
+  [SMALL_STATE(148)] = 1629,
+  [SMALL_STATE(149)] = 1636,
+  [SMALL_STATE(150)] = 1643,
+  [SMALL_STATE(151)] = 1650,
+  [SMALL_STATE(152)] = 1657,
+  [SMALL_STATE(153)] = 1664,
+  [SMALL_STATE(154)] = 1671,
+  [SMALL_STATE(155)] = 1678,
+  [SMALL_STATE(156)] = 1685,
+  [SMALL_STATE(157)] = 1692,
+  [SMALL_STATE(158)] = 1699,
+  [SMALL_STATE(159)] = 1706,
+  [SMALL_STATE(160)] = 1713,
+  [SMALL_STATE(161)] = 1720,
+  [SMALL_STATE(162)] = 1727,
+  [SMALL_STATE(163)] = 1734,
+  [SMALL_STATE(164)] = 1741,
+  [SMALL_STATE(165)] = 1748,
+  [SMALL_STATE(166)] = 1755,
+  [SMALL_STATE(167)] = 1762,
+  [SMALL_STATE(168)] = 1769,
+  [SMALL_STATE(169)] = 1776,
+  [SMALL_STATE(170)] = 1783,
+  [SMALL_STATE(171)] = 1790,
+  [SMALL_STATE(172)] = 1797,
+  [SMALL_STATE(173)] = 1804,
+  [SMALL_STATE(174)] = 1811,
+  [SMALL_STATE(175)] = 1818,
+  [SMALL_STATE(176)] = 1825,
+  [SMALL_STATE(177)] = 1832,
+  [SMALL_STATE(178)] = 1839,
+  [SMALL_STATE(179)] = 1846,
+  [SMALL_STATE(180)] = 1853,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -4554,223 +5116,258 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(115),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
-  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
-  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(119),
-  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(126),
-  [47] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(113),
-  [50] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(113),
-  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(114),
-  [56] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(114),
-  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(21),
-  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(73),
-  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(115),
-  [68] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(115),
-  [71] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(11),
-  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(3),
-  [77] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(148),
-  [80] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(117),
-  [83] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(145),
-  [86] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(144),
-  [89] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
-  [91] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
-  [93] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [95] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [97] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
-  [99] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [101] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
-  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [107] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [109] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
-  [111] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
-  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
-  [125] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
-  [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
-  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
-  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statement, 2),
-  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statement, 2),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [173] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
-  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
-  [183] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
-  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
-  [187] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
-  [189] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 1),
-  [191] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [193] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
-  [195] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 4),
-  [197] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 3),
-  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 4),
-  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_regex, 3),
-  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6),
-  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bool, 1),
-  [207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
-  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 1),
-  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 5, .production_id = 1),
-  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commandLiteral, 3),
-  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 2),
-  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6, .production_id = 2),
-  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 3),
-  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
-  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 2),
-  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
-  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char, 1),
-  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer, 1),
-  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
-  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
-  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
-  [253] = {.entry = {.count = 1, .reusable = false}}, SHIFT(102),
-  [255] = {.entry = {.count = 1, .reusable = false}}, SHIFT(95),
-  [257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [263] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 3), SHIFT_REPEAT(8),
-  [266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 3),
-  [268] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [270] = {.entry = {.count = 1, .reusable = false}}, SHIFT(89),
-  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
-  [276] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 3), SHIFT_REPEAT(57),
-  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 3),
-  [281] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
-  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [289] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [293] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [295] = {.entry = {.count = 1, .reusable = false}}, SHIFT(98),
-  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [301] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [303] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [305] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
-  [307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
-  [309] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [311] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
-  [313] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(12),
-  [316] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
-  [318] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [320] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [322] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
-  [324] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
-  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
-  [328] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
-  [330] = {.entry = {.count = 1, .reusable = false}}, SHIFT(91),
-  [332] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [334] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [336] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 2), SHIFT_REPEAT(89),
-  [339] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [341] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [343] = {.entry = {.count = 1, .reusable = false}}, SHIFT(101),
-  [345] = {.entry = {.count = 1, .reusable = false}}, SHIFT(94),
-  [347] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [349] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
-  [351] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
-  [353] = {.entry = {.count = 1, .reusable = false}}, SHIFT(104),
-  [355] = {.entry = {.count = 1, .reusable = false}}, SHIFT(105),
-  [357] = {.entry = {.count = 1, .reusable = false}}, SHIFT(100),
-  [359] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [361] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [363] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [365] = {.entry = {.count = 1, .reusable = false}}, SHIFT(90),
-  [367] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
-  [369] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(15),
-  [372] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [374] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
-  [376] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
-  [378] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_regex, 3),
-  [380] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 4, .production_id = 1),
-  [382] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 4, .production_id = 1),
-  [384] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
-  [386] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer, 1),
-  [388] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_char, 1),
-  [390] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 2),
-  [392] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 1),
-  [394] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6, .production_id = 2),
-  [396] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [398] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [400] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6),
-  [402] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 2),
-  [404] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 1),
-  [406] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 5, .production_id = 1),
-  [408] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 3),
-  [410] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 4),
-  [412] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bool, 1),
-  [414] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 4),
-  [416] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commandLiteral, 3),
-  [418] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [420] = {.entry = {.count = 1, .reusable = false}}, SHIFT(150),
-  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [424] = {.entry = {.count = 1, .reusable = false}}, SHIFT(131),
-  [426] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
-  [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [430] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
-  [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [434] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [436] = {.entry = {.count = 1, .reusable = false}}, SHIFT(138),
-  [438] = {.entry = {.count = 1, .reusable = false}}, SHIFT(152),
-  [440] = {.entry = {.count = 1, .reusable = false}}, SHIFT(120),
-  [442] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [444] = {.entry = {.count = 1, .reusable = false}}, SHIFT(129),
-  [446] = {.entry = {.count = 1, .reusable = false}}, SHIFT(133),
-  [448] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [450] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
-  [452] = {.entry = {.count = 1, .reusable = false}}, SHIFT(134),
-  [454] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [456] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [458] = {.entry = {.count = 1, .reusable = false}}, SHIFT(147),
-  [460] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(122),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(123),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
+  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(127),
+  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(159),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
+  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(124),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(151),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [59] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [67] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [71] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [79] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
+  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(120),
+  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(135),
+  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(121),
+  [94] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(121),
+  [97] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(122),
+  [100] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(122),
+  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(25),
+  [106] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(71),
+  [109] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(123),
+  [112] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(123),
+  [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(10),
+  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(5),
+  [121] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(169),
+  [124] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(125),
+  [127] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(165),
+  [130] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(164),
+  [133] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(127),
+  [136] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(159),
+  [139] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(158),
+  [142] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(124),
+  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
+  [147] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
+  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
+  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
+  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
+  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statement, 2),
+  [193] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statement, 2),
+  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [203] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [207] = {.entry = {.count = 1, .reusable = false}}, SHIFT(128),
+  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
+  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 1),
+  [217] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
+  [221] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 3),
+  [223] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 4),
+  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 2),
+  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6),
+  [229] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
+  [233] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
+  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 3),
+  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6, .production_id = 3),
+  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
+  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
+  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 3),
+  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_regex, 3),
+  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commandLiteral, 3),
+  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 3, .production_id = 1),
+  [263] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
+  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 4),
+  [267] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 5, .production_id = 2),
+  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 2),
+  [271] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bool, 1),
+  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
+  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer, 1),
+  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char, 1),
+  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
+  [281] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
+  [283] = {.entry = {.count = 1, .reusable = false}}, SHIFT(92),
+  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(117),
+  [287] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
+  [289] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
+  [291] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
+  [293] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
+  [295] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
+  [297] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 2), SHIFT_REPEAT(73),
+  [300] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(14),
+  [303] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
+  [305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
+  [309] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
+  [311] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
+  [313] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [315] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [317] = {.entry = {.count = 1, .reusable = false}}, SHIFT(115),
+  [319] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
+  [321] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [323] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
+  [325] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
+  [327] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
+  [329] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
+  [331] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
+  [333] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(19),
+  [336] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [338] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [340] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
+  [342] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [344] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
+  [346] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [348] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [350] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
+  [352] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
+  [354] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
+  [356] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [358] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [360] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [362] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [364] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
+  [366] = {.entry = {.count = 1, .reusable = false}}, SHIFT(94),
+  [368] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [370] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 4), SHIFT_REPEAT(18),
+  [373] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 4),
+  [375] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [377] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [379] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 4), SHIFT_REPEAT(51),
+  [382] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 4),
+  [384] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [386] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [388] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [390] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
+  [392] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [394] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [396] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [398] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
+  [400] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
+  [402] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [404] = {.entry = {.count = 1, .reusable = false}}, SHIFT(107),
+  [406] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [408] = {.entry = {.count = 1, .reusable = false}}, SHIFT(110),
+  [410] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 2),
+  [412] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [414] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [416] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
+  [418] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer, 1),
+  [420] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_char, 1),
+  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [424] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 1),
+  [426] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 1),
+  [428] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
+  [430] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
+  [432] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 1),
+  [434] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 2),
+  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [438] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 2),
+  [440] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 3),
+  [442] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_regex, 3),
+  [444] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commandLiteral, 3),
+  [446] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
+  [448] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 2),
+  [450] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assignment, 3, .production_id = 1),
+  [452] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bool, 1),
+  [454] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 4, .production_id = 2),
+  [456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 4, .production_id = 2),
+  [458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 3),
+  [460] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 4),
+  [462] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 5, .production_id = 2),
+  [464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6, .production_id = 3),
+  [466] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 4),
+  [468] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6),
+  [470] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [472] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [474] = {.entry = {.count = 1, .reusable = false}}, SHIFT(143),
+  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
+  [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
+  [480] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
+  [482] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
+  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 3),
+  [486] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 3),
+  [488] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [490] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [492] = {.entry = {.count = 1, .reusable = false}}, SHIFT(148),
+  [494] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
+  [496] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [498] = {.entry = {.count = 1, .reusable = false}}, SHIFT(156),
+  [500] = {.entry = {.count = 1, .reusable = false}}, SHIFT(155),
+  [502] = {.entry = {.count = 1, .reusable = false}}, SHIFT(144),
+  [504] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [506] = {.entry = {.count = 1, .reusable = false}}, SHIFT(174),
+  [508] = {.entry = {.count = 1, .reusable = false}}, SHIFT(175),
+  [510] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [512] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
+  [514] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [516] = {.entry = {.count = 1, .reusable = false}}, SHIFT(149),
+  [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [520] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 2),
+  [522] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 2),
+  [524] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
+  [528] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [530] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [532] = {.entry = {.count = 1, .reusable = false}}, SHIFT(167),
+  [534] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -8,9 +8,9 @@
 #define LANGUAGE_VERSION 13
 #define STATE_COUNT 155
 #define LARGE_STATE_COUNT 6
-#define SYMBOL_COUNT 93
+#define SYMBOL_COUNT 94
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 71
+#define TOKEN_COUNT 72
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 2
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
@@ -62,53 +62,54 @@ enum {
   anon_sym_PERCENTx_LPAREN = 43,
   aux_sym_commandLiteral_token2 = 44,
   anon_sym_RPAREN = 45,
-  anon_sym_PLUS = 46,
-  anon_sym_DASH = 47,
-  anon_sym_STAR = 48,
-  anon_sym_PERCENT = 49,
-  anon_sym_AMP = 50,
-  anon_sym_PIPE = 51,
-  anon_sym_CARET = 52,
-  anon_sym_STAR_STAR = 53,
-  anon_sym_GT_GT = 54,
-  anon_sym_LT_LT = 55,
-  anon_sym_EQ_EQ = 56,
-  anon_sym_BANG_EQ = 57,
-  anon_sym_LT = 58,
-  anon_sym_LT_EQ = 59,
-  anon_sym_GT = 60,
-  anon_sym_GT_EQ = 61,
-  anon_sym_LT_EQ_GT = 62,
-  anon_sym_EQ_EQ_EQ = 63,
-  anon_sym_LBRACK_RBRACK = 64,
-  anon_sym_LBRACK_RBRACK_QMARK = 65,
-  anon_sym_LBRACK_RBRACK_EQ = 66,
-  anon_sym_BANG = 67,
-  anon_sym_TILDE = 68,
-  anon_sym_BANG_TILDE = 69,
-  anon_sym_EQ_TILDE = 70,
-  sym_program = 71,
-  sym__statement = 72,
-  sym__expression = 73,
-  sym_identifier = 74,
-  sym_bool = 75,
-  sym_float = 76,
-  sym_integer = 77,
-  sym_symbol = 78,
-  sym_char = 79,
-  sym_string = 80,
-  sym_array = 81,
-  sym_hash = 82,
-  sym_regex = 83,
-  sym_tuple = 84,
-  sym_namedTupleLiteral = 85,
-  sym_commandLiteral = 86,
-  sym__operator = 87,
-  aux_sym_program_repeat1 = 88,
-  aux_sym_symbol_repeat1 = 89,
-  aux_sym_array_repeat1 = 90,
-  aux_sym_hash_repeat1 = 91,
-  aux_sym_namedTupleLiteral_repeat1 = 92,
+  sym_comment = 46,
+  anon_sym_PLUS = 47,
+  anon_sym_DASH = 48,
+  anon_sym_STAR = 49,
+  anon_sym_PERCENT = 50,
+  anon_sym_AMP = 51,
+  anon_sym_PIPE = 52,
+  anon_sym_CARET = 53,
+  anon_sym_STAR_STAR = 54,
+  anon_sym_GT_GT = 55,
+  anon_sym_LT_LT = 56,
+  anon_sym_EQ_EQ = 57,
+  anon_sym_BANG_EQ = 58,
+  anon_sym_LT = 59,
+  anon_sym_LT_EQ = 60,
+  anon_sym_GT = 61,
+  anon_sym_GT_EQ = 62,
+  anon_sym_LT_EQ_GT = 63,
+  anon_sym_EQ_EQ_EQ = 64,
+  anon_sym_LBRACK_RBRACK = 65,
+  anon_sym_LBRACK_RBRACK_QMARK = 66,
+  anon_sym_LBRACK_RBRACK_EQ = 67,
+  anon_sym_BANG = 68,
+  anon_sym_TILDE = 69,
+  anon_sym_BANG_TILDE = 70,
+  anon_sym_EQ_TILDE = 71,
+  sym_program = 72,
+  sym__statement = 73,
+  sym__expression = 74,
+  sym_identifier = 75,
+  sym_bool = 76,
+  sym_float = 77,
+  sym_integer = 78,
+  sym_symbol = 79,
+  sym_char = 80,
+  sym_string = 81,
+  sym_array = 82,
+  sym_hash = 83,
+  sym_regex = 84,
+  sym_tuple = 85,
+  sym_namedTupleLiteral = 86,
+  sym_commandLiteral = 87,
+  sym__operator = 88,
+  aux_sym_program_repeat1 = 89,
+  aux_sym_symbol_repeat1 = 90,
+  aux_sym_array_repeat1 = 91,
+  aux_sym_hash_repeat1 = 92,
+  aux_sym_namedTupleLiteral_repeat1 = 93,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -158,6 +159,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_PERCENTx_LPAREN] = "%x(",
   [aux_sym_commandLiteral_token2] = "commandLiteral_token2",
   [anon_sym_RPAREN] = ")",
+  [sym_comment] = "comment",
   [anon_sym_PLUS] = "+",
   [anon_sym_DASH] = "-",
   [anon_sym_STAR] = "*",
@@ -254,6 +256,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_PERCENTx_LPAREN] = anon_sym_PERCENTx_LPAREN,
   [aux_sym_commandLiteral_token2] = aux_sym_commandLiteral_token2,
   [anon_sym_RPAREN] = anon_sym_RPAREN,
+  [sym_comment] = sym_comment,
   [anon_sym_PLUS] = anon_sym_PLUS,
   [anon_sym_DASH] = anon_sym_DASH,
   [anon_sym_STAR] = anon_sym_STAR,
@@ -487,6 +490,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_RPAREN] = {
     .visible = true,
     .named = false,
+  },
+  [sym_comment] = {
+    .visible = true,
+    .named = true,
   },
   [anon_sym_PLUS] = {
     .visible = true,
@@ -724,75 +731,79 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(89);
-      if (lookahead == '!') ADVANCE(200);
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '%') ADVANCE(182);
-      if (lookahead == '&') ADVANCE(183);
-      if (lookahead == '\'') ADVANCE(12);
-      if (lookahead == ')') ADVANCE(175);
-      if (lookahead == '*') ADVANCE(180);
-      if (lookahead == '+') ADVANCE(177);
-      if (lookahead == ',') ADVANCE(157);
-      if (lookahead == '-') ADVANCE(179);
-      if (lookahead == '/') ADVANCE(164);
-      if (lookahead == '0') ADVANCE(27);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == ';') ADVANCE(90);
-      if (lookahead == '<') ADVANCE(191);
-      if (lookahead == '=') ADVANCE(56);
-      if (lookahead == '>') ADVANCE(193);
-      if (lookahead == 'T') ADVANCE(73);
-      if (lookahead == '[') ADVANCE(156);
-      if (lookahead == ']') ADVANCE(158);
-      if (lookahead == '^') ADVANCE(185);
-      if (lookahead == '`') ADVANCE(169);
-      if (lookahead == 'f') ADVANCE(59);
-      if (lookahead == 'n') ADVANCE(65);
-      if (lookahead == 'o') ADVANCE(64);
-      if (lookahead == 't') ADVANCE(71);
-      if (lookahead == '{') ADVANCE(159);
-      if (lookahead == '|') ADVANCE(184);
-      if (lookahead == '}') ADVANCE(161);
-      if (lookahead == '~') ADVANCE(201);
+      if (eof) ADVANCE(90);
+      if (lookahead == '!') ADVANCE(208);
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(88);
+      if (lookahead == '%') ADVANCE(190);
+      if (lookahead == '&') ADVANCE(191);
+      if (lookahead == '\'') ADVANCE(13);
+      if (lookahead == ')') ADVANCE(182);
+      if (lookahead == '*') ADVANCE(188);
+      if (lookahead == '+') ADVANCE(185);
+      if (lookahead == ',') ADVANCE(159);
+      if (lookahead == '-') ADVANCE(187);
+      if (lookahead == '/') ADVANCE(167);
+      if (lookahead == '0') ADVANCE(28);
+      if (lookahead == ':') ADVANCE(130);
+      if (lookahead == ';') ADVANCE(91);
+      if (lookahead == '<') ADVANCE(199);
+      if (lookahead == '=') ADVANCE(57);
+      if (lookahead == '>') ADVANCE(201);
+      if (lookahead == 'T') ADVANCE(74);
+      if (lookahead == '[') ADVANCE(158);
+      if (lookahead == ']') ADVANCE(160);
+      if (lookahead == '^') ADVANCE(193);
+      if (lookahead == '`') ADVANCE(174);
+      if (lookahead == 'f') ADVANCE(60);
+      if (lookahead == 'n') ADVANCE(66);
+      if (lookahead == 'o') ADVANCE(65);
+      if (lookahead == 't') ADVANCE(72);
+      if (lookahead == '{') ADVANCE(161);
+      if (lookahead == '|') ADVANCE(192);
+      if (lookahead == '}') ADVANCE(163);
+      if (lookahead == '~') ADVANCE(209);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(91);
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == ';') ADVANCE(90);
+      if (lookahead == '\n') ADVANCE(92);
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ';') ADVANCE(91);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(132);
-      if (lookahead != 0) ADVANCE(131);
+          lookahead == ' ') ADVANCE(133);
+      if (lookahead != 0) ADVANCE(132);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(92);
-      if (lookahead == ';') ADVANCE(90);
+      if (lookahead == '\n') ADVANCE(93);
+      if (lookahead == '#') ADVANCE(88);
+      if (lookahead == ';') ADVANCE(91);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
-      if (lookahead == '!') ADVANCE(200);
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '%') ADVANCE(181);
-      if (lookahead == '&') ADVANCE(183);
-      if (lookahead == '*') ADVANCE(180);
-      if (lookahead == '+') ADVANCE(176);
-      if (lookahead == '-') ADVANCE(178);
-      if (lookahead == '/') ADVANCE(164);
-      if (lookahead == '<') ADVANCE(191);
-      if (lookahead == '=') ADVANCE(57);
-      if (lookahead == '>') ADVANCE(193);
-      if (lookahead == '[') ADVANCE(58);
-      if (lookahead == '^') ADVANCE(185);
-      if (lookahead == '|') ADVANCE(184);
-      if (lookahead == '~') ADVANCE(201);
+      if (lookahead == '!') ADVANCE(208);
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(88);
+      if (lookahead == '%') ADVANCE(189);
+      if (lookahead == '&') ADVANCE(191);
+      if (lookahead == '*') ADVANCE(188);
+      if (lookahead == '+') ADVANCE(184);
+      if (lookahead == '-') ADVANCE(186);
+      if (lookahead == '/') ADVANCE(167);
+      if (lookahead == '<') ADVANCE(199);
+      if (lookahead == '=') ADVANCE(58);
+      if (lookahead == '>') ADVANCE(201);
+      if (lookahead == '[') ADVANCE(59);
+      if (lookahead == '^') ADVANCE(193);
+      if (lookahead == '|') ADVANCE(192);
+      if (lookahead == '~') ADVANCE(209);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -802,1084 +813,1153 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\\' &&
           lookahead != ']' &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 4:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '%') ADVANCE(76);
-      if (lookahead == '\'') ADVANCE(12);
-      if (lookahead == '/') ADVANCE(164);
-      if (lookahead == '0') ADVANCE(27);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == 'T') ADVANCE(106);
-      if (lookahead == '[') ADVANCE(155);
-      if (lookahead == '`') ADVANCE(169);
-      if (lookahead == 'f') ADVANCE(95);
-      if (lookahead == 'n') ADVANCE(99);
-      if (lookahead == 't') ADVANCE(104);
-      if (lookahead == '{') ADVANCE(159);
-      if (lookahead == '}') ADVANCE(161);
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(88);
+      if (lookahead == '%') ADVANCE(77);
+      if (lookahead == '\'') ADVANCE(13);
+      if (lookahead == '/') ADVANCE(167);
+      if (lookahead == '0') ADVANCE(28);
+      if (lookahead == ':') ADVANCE(130);
+      if (lookahead == 'T') ADVANCE(107);
+      if (lookahead == '[') ADVANCE(157);
+      if (lookahead == '`') ADVANCE(174);
+      if (lookahead == 'f') ADVANCE(96);
+      if (lookahead == 'n') ADVANCE(100);
+      if (lookahead == 't') ADVANCE(105);
+      if (lookahead == '{') ADVANCE(161);
+      if (lookahead == '}') ADVANCE(163);
       if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(30);
+          lookahead == '-') ADVANCE(31);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(4)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
       if (lookahead != 0 &&
           lookahead > '@' &&
           (lookahead < '\\' || '^' < lookahead) &&
-          (lookahead < '|' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '|' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 5:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == ',') ADVANCE(157);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == '=') ADVANCE(139);
-      if (lookahead == '}') ADVANCE(161);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(133);
-      if (lookahead != 0) ADVANCE(131);
-      END_STATE();
-    case 6:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == ',') ADVANCE(157);
-      if (lookahead == '=') ADVANCE(139);
-      if (lookahead == '}') ADVANCE(161);
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ',') ADVANCE(159);
+      if (lookahead == ':') ADVANCE(130);
+      if (lookahead == '=') ADVANCE(141);
+      if (lookahead == '}') ADVANCE(163);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(134);
-      if (lookahead != 0) ADVANCE(131);
+      if (lookahead != 0) ADVANCE(132);
       END_STATE();
-    case 7:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == ',') ADVANCE(157);
-      if (lookahead == ']') ADVANCE(158);
+    case 6:
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ',') ADVANCE(159);
+      if (lookahead == '=') ADVANCE(141);
+      if (lookahead == '}') ADVANCE(163);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(135);
-      if (lookahead != 0) ADVANCE(131);
+      if (lookahead != 0) ADVANCE(132);
       END_STATE();
-    case 8:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == ',') ADVANCE(157);
-      if (lookahead == '}') ADVANCE(161);
+    case 7:
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ',') ADVANCE(159);
+      if (lookahead == ']') ADVANCE(160);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0) ADVANCE(131);
+      if (lookahead != 0) ADVANCE(132);
       END_STATE();
-    case 9:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == ':') ADVANCE(129);
+    case 8:
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ',') ADVANCE(159);
+      if (lookahead == '}') ADVANCE(163);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(137);
-      if (lookahead != 0) ADVANCE(131);
+      if (lookahead != 0) ADVANCE(132);
       END_STATE();
-    case 10:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '=') ADVANCE(139);
+    case 9:
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ':') ADVANCE(130);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(138);
-      if (lookahead != 0) ADVANCE(131);
+      if (lookahead != 0) ADVANCE(132);
+      END_STATE();
+    case 10:
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == '=') ADVANCE(141);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(139);
+      if (lookahead != 0) ADVANCE(132);
       END_STATE();
     case 11:
-      if (lookahead == '"') ADVANCE(130);
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(142);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(140);
-      if (lookahead != 0) ADVANCE(131);
+      if (lookahead != 0) ADVANCE(132);
       END_STATE();
     case 12:
-      if (lookahead == '\'') ADVANCE(141);
-      if (lookahead == '\\') ADVANCE(13);
-      if (lookahead != 0) ADVANCE(14);
+      if (lookahead == '#') ADVANCE(165);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(12)
+      if (lookahead != 0) ADVANCE(166);
       END_STATE();
     case 13:
-      if (lookahead == '\'') ADVANCE(154);
-      if (lookahead == '\\') ADVANCE(15);
-      if (lookahead == 'a') ADVANCE(16);
-      if (lookahead == 'b') ADVANCE(17);
-      if (lookahead == 'e') ADVANCE(18);
-      if (lookahead == 'f') ADVANCE(19);
-      if (lookahead == 'n') ADVANCE(20);
-      if (lookahead == 'r') ADVANCE(21);
-      if (lookahead == 't') ADVANCE(22);
-      if (lookahead == 'u') ADVANCE(77);
-      if (lookahead == 'v') ADVANCE(23);
+      if (lookahead == '\'') ADVANCE(143);
+      if (lookahead == '\\') ADVANCE(14);
+      if (lookahead != 0) ADVANCE(15);
       END_STATE();
     case 14:
-      if (lookahead == '\'') ADVANCE(153);
+      if (lookahead == '\'') ADVANCE(156);
+      if (lookahead == '\\') ADVANCE(16);
+      if (lookahead == 'a') ADVANCE(17);
+      if (lookahead == 'b') ADVANCE(18);
+      if (lookahead == 'e') ADVANCE(19);
+      if (lookahead == 'f') ADVANCE(20);
+      if (lookahead == 'n') ADVANCE(21);
+      if (lookahead == 'r') ADVANCE(22);
+      if (lookahead == 't') ADVANCE(23);
+      if (lookahead == 'u') ADVANCE(78);
+      if (lookahead == 'v') ADVANCE(24);
       END_STATE();
     case 15:
-      if (lookahead == '\'') ADVANCE(143);
+      if (lookahead == '\'') ADVANCE(155);
       END_STATE();
     case 16:
-      if (lookahead == '\'') ADVANCE(144);
-      END_STATE();
-    case 17:
       if (lookahead == '\'') ADVANCE(145);
       END_STATE();
-    case 18:
+    case 17:
       if (lookahead == '\'') ADVANCE(146);
       END_STATE();
-    case 19:
+    case 18:
       if (lookahead == '\'') ADVANCE(147);
       END_STATE();
-    case 20:
+    case 19:
       if (lookahead == '\'') ADVANCE(148);
       END_STATE();
-    case 21:
+    case 20:
       if (lookahead == '\'') ADVANCE(149);
       END_STATE();
-    case 22:
+    case 21:
       if (lookahead == '\'') ADVANCE(150);
       END_STATE();
-    case 23:
+    case 22:
       if (lookahead == '\'') ADVANCE(151);
       END_STATE();
-    case 24:
+    case 23:
       if (lookahead == '\'') ADVANCE(152);
+      END_STATE();
+    case 24:
+      if (lookahead == '\'') ADVANCE(153);
       END_STATE();
     case 25:
-      if (lookahead == '\'') ADVANCE(152);
-      if (lookahead == '}') ADVANCE(24);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(25);
+      if (lookahead == '\'') ADVANCE(154);
       END_STATE();
     case 26:
-      if (lookahead == '(') ADVANCE(172);
+      if (lookahead == '\'') ADVANCE(154);
+      if (lookahead == '}') ADVANCE(25);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(26);
       END_STATE();
     case 27:
-      if (lookahead == '.') ADVANCE(85);
-      if (lookahead == 'b') ADVANCE(80);
-      if (lookahead == 'e') ADVANCE(78);
-      if (lookahead == 'f') ADVANCE(42);
-      if (lookahead == 'o') ADVANCE(82);
-      if (lookahead == 'x') ADVANCE(86);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(28);
+      if (lookahead == '(') ADVANCE(178);
       END_STATE();
     case 28:
       if (lookahead == '.') ADVANCE(85);
-      if (lookahead == 'e') ADVANCE(78);
-      if (lookahead == 'f') ADVANCE(42);
+      if (lookahead == 'b') ADVANCE(81);
+      if (lookahead == 'e') ADVANCE(79);
+      if (lookahead == 'f') ADVANCE(43);
+      if (lookahead == 'o') ADVANCE(82);
+      if (lookahead == 'x') ADVANCE(86);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(28);
+          lookahead == '_') ADVANCE(29);
       END_STATE();
     case 29:
-      if (lookahead == '.') ADVANCE(69);
+      if (lookahead == '.') ADVANCE(85);
+      if (lookahead == 'e') ADVANCE(79);
+      if (lookahead == 'f') ADVANCE(43);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(29);
       END_STATE();
     case 30:
-      if (lookahead == '0') ADVANCE(27);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      if (lookahead == '.') ADVANCE(70);
       END_STATE();
     case 31:
-      if (lookahead == '1') ADVANCE(52);
-      if (lookahead == '3') ADVANCE(35);
-      if (lookahead == '6') ADVANCE(45);
-      if (lookahead == '8') ADVANCE(127);
+      if (lookahead == '0') ADVANCE(28);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
       END_STATE();
     case 32:
       if (lookahead == '1') ADVANCE(53);
-      if (lookahead == '3') ADVANCE(37);
-      if (lookahead == '6') ADVANCE(47);
-      if (lookahead == '8') ADVANCE(121);
+      if (lookahead == '3') ADVANCE(36);
+      if (lookahead == '6') ADVANCE(46);
+      if (lookahead == '8') ADVANCE(128);
       END_STATE();
     case 33:
       if (lookahead == '1') ADVANCE(54);
       if (lookahead == '3') ADVANCE(38);
       if (lookahead == '6') ADVANCE(48);
-      if (lookahead == '8') ADVANCE(123);
+      if (lookahead == '8') ADVANCE(122);
       END_STATE();
     case 34:
       if (lookahead == '1') ADVANCE(55);
       if (lookahead == '3') ADVANCE(39);
       if (lookahead == '6') ADVANCE(49);
-      if (lookahead == '8') ADVANCE(125);
+      if (lookahead == '8') ADVANCE(124);
       END_STATE();
     case 35:
-      if (lookahead == '2') ADVANCE(127);
+      if (lookahead == '1') ADVANCE(56);
+      if (lookahead == '3') ADVANCE(40);
+      if (lookahead == '6') ADVANCE(50);
+      if (lookahead == '8') ADVANCE(126);
       END_STATE();
     case 36:
-      if (lookahead == '2') ADVANCE(120);
+      if (lookahead == '2') ADVANCE(128);
       END_STATE();
     case 37:
       if (lookahead == '2') ADVANCE(121);
       END_STATE();
     case 38:
-      if (lookahead == '2') ADVANCE(123);
+      if (lookahead == '2') ADVANCE(122);
       END_STATE();
     case 39:
-      if (lookahead == '2') ADVANCE(125);
+      if (lookahead == '2') ADVANCE(124);
       END_STATE();
     case 40:
-      if (lookahead == '2') ADVANCE(115);
+      if (lookahead == '2') ADVANCE(126);
       END_STATE();
     case 41:
-      if (lookahead == '2') ADVANCE(118);
+      if (lookahead == '2') ADVANCE(116);
       END_STATE();
     case 42:
-      if (lookahead == '3') ADVANCE(36);
-      if (lookahead == '6') ADVANCE(46);
+      if (lookahead == '2') ADVANCE(119);
       END_STATE();
     case 43:
-      if (lookahead == '3') ADVANCE(40);
-      if (lookahead == '6') ADVANCE(50);
+      if (lookahead == '3') ADVANCE(37);
+      if (lookahead == '6') ADVANCE(47);
       END_STATE();
     case 44:
       if (lookahead == '3') ADVANCE(41);
       if (lookahead == '6') ADVANCE(51);
       END_STATE();
     case 45:
-      if (lookahead == '4') ADVANCE(127);
+      if (lookahead == '3') ADVANCE(42);
+      if (lookahead == '6') ADVANCE(52);
       END_STATE();
     case 46:
-      if (lookahead == '4') ADVANCE(120);
+      if (lookahead == '4') ADVANCE(128);
       END_STATE();
     case 47:
       if (lookahead == '4') ADVANCE(121);
       END_STATE();
     case 48:
-      if (lookahead == '4') ADVANCE(123);
+      if (lookahead == '4') ADVANCE(122);
       END_STATE();
     case 49:
-      if (lookahead == '4') ADVANCE(125);
+      if (lookahead == '4') ADVANCE(124);
       END_STATE();
     case 50:
-      if (lookahead == '4') ADVANCE(115);
+      if (lookahead == '4') ADVANCE(126);
       END_STATE();
     case 51:
-      if (lookahead == '4') ADVANCE(118);
+      if (lookahead == '4') ADVANCE(116);
       END_STATE();
     case 52:
-      if (lookahead == '6') ADVANCE(127);
+      if (lookahead == '4') ADVANCE(119);
       END_STATE();
     case 53:
-      if (lookahead == '6') ADVANCE(121);
+      if (lookahead == '6') ADVANCE(128);
       END_STATE();
     case 54:
-      if (lookahead == '6') ADVANCE(123);
+      if (lookahead == '6') ADVANCE(122);
       END_STATE();
     case 55:
-      if (lookahead == '6') ADVANCE(125);
+      if (lookahead == '6') ADVANCE(124);
       END_STATE();
     case 56:
-      if (lookahead == '=') ADVANCE(189);
-      if (lookahead == '>') ADVANCE(160);
-      if (lookahead == '~') ADVANCE(203);
+      if (lookahead == '6') ADVANCE(126);
       END_STATE();
     case 57:
-      if (lookahead == '=') ADVANCE(189);
-      if (lookahead == '~') ADVANCE(203);
+      if (lookahead == '=') ADVANCE(197);
+      if (lookahead == '>') ADVANCE(162);
+      if (lookahead == '~') ADVANCE(211);
       END_STATE();
     case 58:
-      if (lookahead == ']') ADVANCE(197);
+      if (lookahead == '=') ADVANCE(197);
+      if (lookahead == '~') ADVANCE(211);
       END_STATE();
     case 59:
-      if (lookahead == 'a') ADVANCE(66);
+      if (lookahead == ']') ADVANCE(205);
       END_STATE();
     case 60:
-      if (lookahead == 'e') ADVANCE(111);
+      if (lookahead == 'a') ADVANCE(67);
       END_STATE();
     case 61:
-      if (lookahead == 'e') ADVANCE(29);
+      if (lookahead == 'e') ADVANCE(112);
       END_STATE();
     case 62:
-      if (lookahead == 'e') ADVANCE(113);
+      if (lookahead == 'e') ADVANCE(30);
       END_STATE();
     case 63:
-      if (lookahead == 'e') ADVANCE(75);
+      if (lookahead == 'e') ADVANCE(114);
       END_STATE();
     case 64:
-      if (lookahead == 'f') ADVANCE(162);
+      if (lookahead == 'e') ADVANCE(76);
       END_STATE();
     case 65:
-      if (lookahead == 'i') ADVANCE(67);
+      if (lookahead == 'f') ADVANCE(164);
       END_STATE();
     case 66:
-      if (lookahead == 'l') ADVANCE(72);
+      if (lookahead == 'i') ADVANCE(68);
       END_STATE();
     case 67:
-      if (lookahead == 'l') ADVANCE(109);
+      if (lookahead == 'l') ADVANCE(73);
       END_STATE();
     case 68:
-      if (lookahead == 'l') ADVANCE(61);
+      if (lookahead == 'l') ADVANCE(110);
       END_STATE();
     case 69:
-      if (lookahead == 'n') ADVANCE(63);
+      if (lookahead == 'l') ADVANCE(62);
       END_STATE();
     case 70:
-      if (lookahead == 'p') ADVANCE(68);
+      if (lookahead == 'n') ADVANCE(64);
       END_STATE();
     case 71:
-      if (lookahead == 'r') ADVANCE(74);
+      if (lookahead == 'p') ADVANCE(69);
       END_STATE();
     case 72:
-      if (lookahead == 's') ADVANCE(62);
+      if (lookahead == 'r') ADVANCE(75);
       END_STATE();
     case 73:
-      if (lookahead == 'u') ADVANCE(70);
+      if (lookahead == 's') ADVANCE(63);
       END_STATE();
     case 74:
-      if (lookahead == 'u') ADVANCE(60);
+      if (lookahead == 'u') ADVANCE(71);
       END_STATE();
     case 75:
-      if (lookahead == 'w') ADVANCE(168);
+      if (lookahead == 'u') ADVANCE(61);
       END_STATE();
     case 76:
-      if (lookahead == 'x') ADVANCE(26);
+      if (lookahead == 'w') ADVANCE(173);
       END_STATE();
     case 77:
+      if (lookahead == 'x') ADVANCE(27);
+      END_STATE();
+    case 78:
       if (lookahead == '{') ADVANCE(87);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(25);
-      END_STATE();
-    case 78:
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(83);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(26);
       END_STATE();
     case 79:
       if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(84);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
+          lookahead == '-') ADVANCE(83);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(120);
       END_STATE();
     case 80:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(122);
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(84);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(118);
       END_STATE();
     case 81:
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(81)
-      if (lookahead != 0) ADVANCE(163);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(123);
       END_STATE();
     case 82:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(124);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(125);
       END_STATE();
     case 83:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(120);
       END_STATE();
     case 84:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(118);
       END_STATE();
     case 85:
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(116);
+          lookahead == '_') ADVANCE(117);
       END_STATE();
     case 86:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(126);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(127);
       END_STATE();
     case 87:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(25);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(26);
       END_STATE();
     case 88:
-      if (eof) ADVANCE(89);
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '%') ADVANCE(76);
-      if (lookahead == '\'') ADVANCE(12);
-      if (lookahead == '/') ADVANCE(164);
-      if (lookahead == '0') ADVANCE(27);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == 'T') ADVANCE(73);
-      if (lookahead == '[') ADVANCE(155);
-      if (lookahead == '`') ADVANCE(169);
-      if (lookahead == 'f') ADVANCE(59);
-      if (lookahead == 'n') ADVANCE(65);
-      if (lookahead == 't') ADVANCE(71);
-      if (lookahead == '{') ADVANCE(159);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(183);
+      END_STATE();
+    case 89:
+      if (eof) ADVANCE(90);
+      if (lookahead == '"') ADVANCE(131);
+      if (lookahead == '#') ADVANCE(88);
+      if (lookahead == '%') ADVANCE(77);
+      if (lookahead == '\'') ADVANCE(13);
+      if (lookahead == '/') ADVANCE(167);
+      if (lookahead == '0') ADVANCE(28);
+      if (lookahead == ':') ADVANCE(130);
+      if (lookahead == 'T') ADVANCE(74);
+      if (lookahead == '[') ADVANCE(157);
+      if (lookahead == '`') ADVANCE(174);
+      if (lookahead == 'f') ADVANCE(60);
+      if (lookahead == 'n') ADVANCE(66);
+      if (lookahead == 't') ADVANCE(72);
+      if (lookahead == '{') ADVANCE(161);
       if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(30);
+          lookahead == '-') ADVANCE(31);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(88)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
-      END_STATE();
-    case 89:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+          lookahead == ' ') SKIP(89)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(anon_sym_SEMI);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 91:
-      ACCEPT_TOKEN(aux_sym__statement_token1);
-      if (lookahead == '\n') ADVANCE(91);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(132);
+      ACCEPT_TOKEN(anon_sym_SEMI);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(aux_sym__statement_token1);
       if (lookahead == '\n') ADVANCE(92);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(133);
       END_STATE();
     case 93:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      ACCEPT_TOKEN(aux_sym__statement_token1);
+      if (lookahead == '\n') ADVANCE(93);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '.') ADVANCE(69);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'a') ADVANCE(100);
+      if (lookahead == '.') ADVANCE(70);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(112);
+      if (lookahead == 'a') ADVANCE(101);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(94);
+      if (lookahead == 'e') ADVANCE(113);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(114);
+      if (lookahead == 'e') ADVANCE(95);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'i') ADVANCE(101);
+      if (lookahead == 'e') ADVANCE(115);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(105);
+      if (lookahead == 'i') ADVANCE(102);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(110);
+      if (lookahead == 'l') ADVANCE(106);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(97);
+      if (lookahead == 'l') ADVANCE(111);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'p') ADVANCE(102);
+      if (lookahead == 'l') ADVANCE(98);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'r') ADVANCE(107);
+      if (lookahead == 'p') ADVANCE(103);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 's') ADVANCE(98);
+      if (lookahead == 'r') ADVANCE(108);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(103);
+      if (lookahead == 's') ADVANCE(99);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(96);
+      if (lookahead == 'u') ADVANCE(104);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'u') ADVANCE(97);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 109:
-      ACCEPT_TOKEN(sym_nil);
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(94);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym_nil);
+      END_STATE();
+    case 111:
+      ACCEPT_TOKEN(sym_nil);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(anon_sym_true);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(anon_sym_true);
+      END_STATE();
+    case 113:
+      ACCEPT_TOKEN(anon_sym_true);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 113:
-      ACCEPT_TOKEN(anon_sym_false);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(anon_sym_false);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(anon_sym_false);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(94);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(aux_sym_float_token1);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(109);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(aux_sym_float_token1);
-      if (lookahead == 'e') ADVANCE(79);
-      if (lookahead == 'f') ADVANCE(43);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(116);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(aux_sym_float_token1);
-      if (lookahead == 'f') ADVANCE(43);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
+      if (lookahead == 'e') ADVANCE(80);
+      if (lookahead == 'f') ADVANCE(44);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(117);
       END_STATE();
     case 118:
-      ACCEPT_TOKEN(aux_sym_float_token2);
+      ACCEPT_TOKEN(aux_sym_float_token1);
+      if (lookahead == 'f') ADVANCE(44);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(118);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(aux_sym_float_token2);
-      if (lookahead == 'f') ADVANCE(44);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
       END_STATE();
     case 120:
-      ACCEPT_TOKEN(aux_sym_float_token3);
+      ACCEPT_TOKEN(aux_sym_float_token2);
+      if (lookahead == 'f') ADVANCE(45);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(120);
       END_STATE();
     case 121:
-      ACCEPT_TOKEN(aux_sym_integer_token1);
+      ACCEPT_TOKEN(aux_sym_float_token3);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(aux_sym_integer_token1);
-      if (lookahead == 'i') ADVANCE(32);
-      if (lookahead == 'u') ADVANCE(32);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(122);
       END_STATE();
     case 123:
-      ACCEPT_TOKEN(aux_sym_integer_token2);
+      ACCEPT_TOKEN(aux_sym_integer_token1);
+      if (lookahead == 'i') ADVANCE(33);
+      if (lookahead == 'u') ADVANCE(33);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(123);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(aux_sym_integer_token2);
-      if (lookahead == 'i') ADVANCE(33);
-      if (lookahead == 'u') ADVANCE(33);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(124);
       END_STATE();
     case 125:
-      ACCEPT_TOKEN(aux_sym_integer_token3);
+      ACCEPT_TOKEN(aux_sym_integer_token2);
+      if (lookahead == 'i') ADVANCE(34);
+      if (lookahead == 'u') ADVANCE(34);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(125);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(aux_sym_integer_token3);
-      if (lookahead == 'i') ADVANCE(34);
-      if (lookahead == 'u') ADVANCE(34);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(126);
       END_STATE();
     case 127:
-      ACCEPT_TOKEN(aux_sym_integer_token4);
+      ACCEPT_TOKEN(aux_sym_integer_token3);
+      if (lookahead == 'i') ADVANCE(35);
+      if (lookahead == 'u') ADVANCE(35);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(127);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(aux_sym_integer_token4);
-      if (lookahead == '.') ADVANCE(85);
-      if (lookahead == 'e') ADVANCE(78);
-      if (lookahead == 'f') ADVANCE(42);
-      if (lookahead == 'i') ADVANCE(31);
-      if (lookahead == 'u') ADVANCE(31);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(128);
       END_STATE();
     case 129:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(aux_sym_integer_token4);
+      if (lookahead == '.') ADVANCE(85);
+      if (lookahead == 'e') ADVANCE(79);
+      if (lookahead == 'f') ADVANCE(43);
+      if (lookahead == 'i') ADVANCE(32);
+      if (lookahead == 'u') ADVANCE(32);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(129);
       END_STATE();
     case 130:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 131:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '\n') ADVANCE(91);
-      if (lookahead == ';') ADVANCE(90);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(132);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == ',') ADVANCE(157);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == '=') ADVANCE(139);
-      if (lookahead == '}') ADVANCE(161);
+      if (lookahead == '\n') ADVANCE(92);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ';') ADVANCE(91);
       if (lookahead == '\t' ||
-          lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(133);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
+          lookahead != '"') ADVANCE(132);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == ',') ADVANCE(157);
-      if (lookahead == '=') ADVANCE(139);
-      if (lookahead == '}') ADVANCE(161);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ',') ADVANCE(159);
+      if (lookahead == ':') ADVANCE(130);
+      if (lookahead == '=') ADVANCE(141);
+      if (lookahead == '}') ADVANCE(163);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(134);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
+          lookahead != '"') ADVANCE(132);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == ',') ADVANCE(157);
-      if (lookahead == ']') ADVANCE(158);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ',') ADVANCE(159);
+      if (lookahead == '=') ADVANCE(141);
+      if (lookahead == '}') ADVANCE(163);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(135);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
+          lookahead != '"') ADVANCE(132);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == ',') ADVANCE(157);
-      if (lookahead == '}') ADVANCE(161);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ',') ADVANCE(159);
+      if (lookahead == ']') ADVANCE(160);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
+          lookahead != '"') ADVANCE(132);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ',') ADVANCE(159);
+      if (lookahead == '}') ADVANCE(163);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(137);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
+          lookahead != '"') ADVANCE(132);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '=') ADVANCE(139);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == ':') ADVANCE(130);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(138);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
+          lookahead != '"') ADVANCE(132);
       END_STATE();
     case 139:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '>') ADVANCE(160);
+      if (lookahead == '#') ADVANCE(142);
+      if (lookahead == '=') ADVANCE(141);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(139);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(132);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '#') ADVANCE(142);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(140);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
+          lookahead != '"') ADVANCE(132);
       END_STATE();
     case 141:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_SQUOTE);
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '>') ADVANCE(162);
       END_STATE();
     case 142:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE);
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(183);
       END_STATE();
     case 143:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_SQUOTE);
       END_STATE();
     case 144:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHa_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE);
       END_STATE();
     case 145:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHb_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE);
       END_STATE();
     case 146:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHe_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHa_SQUOTE);
       END_STATE();
     case 147:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHf_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHb_SQUOTE);
       END_STATE();
     case 148:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHn_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHe_SQUOTE);
       END_STATE();
     case 149:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHr_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHf_SQUOTE);
       END_STATE();
     case 150:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHt_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHn_SQUOTE);
       END_STATE();
     case 151:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHv_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHr_SQUOTE);
       END_STATE();
     case 152:
-      ACCEPT_TOKEN(aux_sym_char_token1);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHt_SQUOTE);
       END_STATE();
     case 153:
-      ACCEPT_TOKEN(aux_sym_char_token2);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHv_SQUOTE);
       END_STATE();
     case 154:
-      ACCEPT_TOKEN(aux_sym_char_token2);
-      if (lookahead == '\'') ADVANCE(142);
+      ACCEPT_TOKEN(aux_sym_char_token1);
       END_STATE();
     case 155:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(aux_sym_char_token2);
       END_STATE();
     case 156:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      if (lookahead == ']') ADVANCE(197);
+      ACCEPT_TOKEN(aux_sym_char_token2);
+      if (lookahead == '\'') ADVANCE(144);
       END_STATE();
     case 157:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 158:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == ']') ADVANCE(205);
       END_STATE();
     case 159:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 160:
-      ACCEPT_TOKEN(anon_sym_EQ_GT);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 161:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 162:
-      ACCEPT_TOKEN(anon_sym_of);
+      ACCEPT_TOKEN(anon_sym_EQ_GT);
       END_STATE();
     case 163:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 164:
+      ACCEPT_TOKEN(anon_sym_of);
+      END_STATE();
+    case 165:
+      ACCEPT_TOKEN(aux_sym_hash_token1);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(183);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(165);
+      END_STATE();
+    case 166:
       ACCEPT_TOKEN(aux_sym_hash_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(163);
-      END_STATE();
-    case 164:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      END_STATE();
-    case 165:
-      ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\\') ADVANCE(167);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(165);
-      if (lookahead != 0 &&
-          lookahead != '/') ADVANCE(166);
-      END_STATE();
-    case 166:
-      ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\\') ADVANCE(167);
-      if (lookahead != 0 &&
-          lookahead != '/') ADVANCE(166);
+          lookahead != ' ') ADVANCE(166);
       END_STATE();
     case 167:
-      ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead != 0 &&
-          lookahead != '\\') ADVANCE(166);
-      if (lookahead == '\\') ADVANCE(167);
+      ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
     case 168:
-      ACCEPT_TOKEN(anon_sym_Tuple_DOTnew);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead == '\n') ADVANCE(171);
+      if (lookahead == '/') ADVANCE(183);
+      if (lookahead == '\\') ADVANCE(169);
+      if (lookahead != 0) ADVANCE(168);
       END_STATE();
     case 169:
-      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead == '\n') ADVANCE(171);
+      if (lookahead != 0 &&
+          lookahead != '\\') ADVANCE(168);
+      if (lookahead == '\\') ADVANCE(169);
       END_STATE();
     case 170:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead == '#') ADVANCE(168);
+      if (lookahead == '\\') ADVANCE(172);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(170);
       if (lookahead != 0 &&
-          lookahead != '`') ADVANCE(171);
+          lookahead != '/') ADVANCE(171);
       END_STATE();
     case 171:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead == '\\') ADVANCE(172);
       if (lookahead != 0 &&
-          lookahead != '`') ADVANCE(171);
+          lookahead != '/') ADVANCE(171);
       END_STATE();
     case 172:
-      ACCEPT_TOKEN(anon_sym_PERCENTx_LPAREN);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead != 0 &&
+          lookahead != '\\') ADVANCE(171);
+      if (lookahead == '\\') ADVANCE(172);
       END_STATE();
     case 173:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
+      ACCEPT_TOKEN(anon_sym_Tuple_DOTnew);
+      END_STATE();
+    case 174:
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      END_STATE();
+    case 175:
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      if (lookahead == '\n') ADVANCE(177);
+      if (lookahead == '`') ADVANCE(183);
+      if (lookahead != 0) ADVANCE(175);
+      END_STATE();
+    case 176:
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      if (lookahead == '#') ADVANCE(175);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(173);
+          lookahead == ' ') ADVANCE(176);
       if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(174);
-      END_STATE();
-    case 174:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
-      if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(174);
-      END_STATE();
-    case 175:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      END_STATE();
-    case 176:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+          lookahead != '`') ADVANCE(177);
       END_STATE();
     case 177:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      if (lookahead == '0') ADVANCE(27);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      if (lookahead != 0 &&
+          lookahead != '`') ADVANCE(177);
       END_STATE();
     case 178:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(anon_sym_PERCENTx_LPAREN);
       END_STATE();
     case 179:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '0') ADVANCE(27);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
+      if (lookahead == '\n') ADVANCE(181);
+      if (lookahead == ')') ADVANCE(183);
+      if (lookahead != 0) ADVANCE(179);
       END_STATE();
     case 180:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '*') ADVANCE(186);
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
+      if (lookahead == '#') ADVANCE(179);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(180);
+      if (lookahead != 0 &&
+          lookahead != ')') ADVANCE(181);
       END_STATE();
     case 181:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
+      if (lookahead != 0 &&
+          lookahead != ')') ADVANCE(181);
       END_STATE();
     case 182:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
-      if (lookahead == 'x') ADVANCE(26);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 183:
-      ACCEPT_TOKEN(anon_sym_AMP);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(183);
       END_STATE();
     case 184:
-      ACCEPT_TOKEN(anon_sym_PIPE);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 185:
-      ACCEPT_TOKEN(anon_sym_CARET);
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      if (lookahead == '0') ADVANCE(28);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
       END_STATE();
     case 186:
-      ACCEPT_TOKEN(anon_sym_STAR_STAR);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 187:
-      ACCEPT_TOKEN(anon_sym_GT_GT);
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '0') ADVANCE(28);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(129);
       END_STATE();
     case 188:
-      ACCEPT_TOKEN(anon_sym_LT_LT);
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '*') ADVANCE(194);
       END_STATE();
     case 189:
-      ACCEPT_TOKEN(anon_sym_EQ_EQ);
-      if (lookahead == '=') ADVANCE(196);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
     case 190:
-      ACCEPT_TOKEN(anon_sym_BANG_EQ);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
+      if (lookahead == 'x') ADVANCE(27);
       END_STATE();
     case 191:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '<') ADVANCE(188);
-      if (lookahead == '=') ADVANCE(192);
+      ACCEPT_TOKEN(anon_sym_AMP);
       END_STATE();
     case 192:
-      ACCEPT_TOKEN(anon_sym_LT_EQ);
-      if (lookahead == '>') ADVANCE(195);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 193:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '=') ADVANCE(194);
-      if (lookahead == '>') ADVANCE(187);
+      ACCEPT_TOKEN(anon_sym_CARET);
       END_STATE();
     case 194:
-      ACCEPT_TOKEN(anon_sym_GT_EQ);
+      ACCEPT_TOKEN(anon_sym_STAR_STAR);
       END_STATE();
     case 195:
-      ACCEPT_TOKEN(anon_sym_LT_EQ_GT);
+      ACCEPT_TOKEN(anon_sym_GT_GT);
       END_STATE();
     case 196:
-      ACCEPT_TOKEN(anon_sym_EQ_EQ_EQ);
+      ACCEPT_TOKEN(anon_sym_LT_LT);
       END_STATE();
     case 197:
-      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK);
-      if (lookahead == '=') ADVANCE(199);
-      if (lookahead == '?') ADVANCE(198);
+      ACCEPT_TOKEN(anon_sym_EQ_EQ);
+      if (lookahead == '=') ADVANCE(204);
       END_STATE();
     case 198:
-      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_QMARK);
+      ACCEPT_TOKEN(anon_sym_BANG_EQ);
       END_STATE();
     case 199:
-      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_EQ);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '<') ADVANCE(196);
+      if (lookahead == '=') ADVANCE(200);
       END_STATE();
     case 200:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead == '=') ADVANCE(190);
-      if (lookahead == '~') ADVANCE(202);
+      ACCEPT_TOKEN(anon_sym_LT_EQ);
+      if (lookahead == '>') ADVANCE(203);
       END_STATE();
     case 201:
-      ACCEPT_TOKEN(anon_sym_TILDE);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '=') ADVANCE(202);
+      if (lookahead == '>') ADVANCE(195);
       END_STATE();
     case 202:
-      ACCEPT_TOKEN(anon_sym_BANG_TILDE);
+      ACCEPT_TOKEN(anon_sym_GT_EQ);
       END_STATE();
     case 203:
+      ACCEPT_TOKEN(anon_sym_LT_EQ_GT);
+      END_STATE();
+    case 204:
+      ACCEPT_TOKEN(anon_sym_EQ_EQ_EQ);
+      END_STATE();
+    case 205:
+      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK);
+      if (lookahead == '=') ADVANCE(207);
+      if (lookahead == '?') ADVANCE(206);
+      END_STATE();
+    case 206:
+      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_QMARK);
+      END_STATE();
+    case 207:
+      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_EQ);
+      END_STATE();
+    case 208:
+      ACCEPT_TOKEN(anon_sym_BANG);
+      if (lookahead == '=') ADVANCE(198);
+      if (lookahead == '~') ADVANCE(210);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      END_STATE();
+    case 210:
+      ACCEPT_TOKEN(anon_sym_BANG_TILDE);
+      END_STATE();
+    case 211:
       ACCEPT_TOKEN(anon_sym_EQ_TILDE);
       END_STATE();
     default:
@@ -1889,23 +1969,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 88},
-  [2] = {.lex_state = 88},
+  [1] = {.lex_state = 89},
+  [2] = {.lex_state = 89},
   [3] = {.lex_state = 4},
   [4] = {.lex_state = 4},
-  [5] = {.lex_state = 88},
-  [6] = {.lex_state = 88},
-  [7] = {.lex_state = 88},
-  [8] = {.lex_state = 88},
-  [9] = {.lex_state = 88},
-  [10] = {.lex_state = 88},
-  [11] = {.lex_state = 88},
-  [12] = {.lex_state = 88},
-  [13] = {.lex_state = 88},
-  [14] = {.lex_state = 88},
-  [15] = {.lex_state = 88},
-  [16] = {.lex_state = 88},
-  [17] = {.lex_state = 88},
+  [5] = {.lex_state = 89},
+  [6] = {.lex_state = 89},
+  [7] = {.lex_state = 89},
+  [8] = {.lex_state = 89},
+  [9] = {.lex_state = 89},
+  [10] = {.lex_state = 89},
+  [11] = {.lex_state = 89},
+  [12] = {.lex_state = 89},
+  [13] = {.lex_state = 89},
+  [14] = {.lex_state = 89},
+  [15] = {.lex_state = 89},
+  [16] = {.lex_state = 89},
+  [17] = {.lex_state = 89},
   [18] = {.lex_state = 3},
   [19] = {.lex_state = 3},
   [20] = {.lex_state = 3},
@@ -2018,30 +2098,30 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [127] = {.lex_state = 2},
   [128] = {.lex_state = 2},
   [129] = {.lex_state = 0},
-  [130] = {.lex_state = 173},
+  [130] = {.lex_state = 180},
   [131] = {.lex_state = 0},
-  [132] = {.lex_state = 81},
+  [132] = {.lex_state = 12},
   [133] = {.lex_state = 0},
   [134] = {.lex_state = 0},
   [135] = {.lex_state = 0},
   [136] = {.lex_state = 0},
   [137] = {.lex_state = 0},
   [138] = {.lex_state = 0},
-  [139] = {.lex_state = 81},
-  [140] = {.lex_state = 165},
-  [141] = {.lex_state = 170},
-  [142] = {.lex_state = 81},
+  [139] = {.lex_state = 12},
+  [140] = {.lex_state = 170},
+  [141] = {.lex_state = 176},
+  [142] = {.lex_state = 12},
   [143] = {.lex_state = 0},
-  [144] = {.lex_state = 173},
-  [145] = {.lex_state = 170},
+  [144] = {.lex_state = 180},
+  [145] = {.lex_state = 176},
   [146] = {.lex_state = 0},
   [147] = {.lex_state = 0},
-  [148] = {.lex_state = 165},
+  [148] = {.lex_state = 170},
   [149] = {.lex_state = 0},
   [150] = {.lex_state = 0},
   [151] = {.lex_state = 0},
   [152] = {.lex_state = 0},
-  [153] = {.lex_state = 81},
+  [153] = {.lex_state = 12},
   [154] = {.lex_state = 0},
 };
 
@@ -2086,6 +2166,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_BQUOTE] = ACTIONS(1),
     [anon_sym_PERCENTx_LPAREN] = ACTIONS(1),
     [anon_sym_RPAREN] = ACTIONS(1),
+    [sym_comment] = ACTIONS(3),
     [anon_sym_PLUS] = ACTIONS(1),
     [anon_sym_DASH] = ACTIONS(1),
     [anon_sym_STAR] = ACTIONS(1),
@@ -2129,38 +2210,39 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_namedTupleLiteral] = STATE(119),
     [sym_commandLiteral] = STATE(119),
     [aux_sym_program_repeat1] = STATE(5),
-    [ts_builtin_sym_end] = ACTIONS(3),
-    [sym_nil] = ACTIONS(5),
-    [anon_sym_true] = ACTIONS(7),
-    [anon_sym_false] = ACTIONS(7),
-    [aux_sym_float_token1] = ACTIONS(9),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [aux_sym_float_token3] = ACTIONS(11),
-    [aux_sym_integer_token1] = ACTIONS(13),
-    [aux_sym_integer_token2] = ACTIONS(13),
-    [aux_sym_integer_token3] = ACTIONS(13),
-    [aux_sym_integer_token4] = ACTIONS(15),
-    [anon_sym_COLON] = ACTIONS(17),
-    [anon_sym_DQUOTE] = ACTIONS(19),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(21),
-    [aux_sym_char_token1] = ACTIONS(21),
-    [aux_sym_char_token2] = ACTIONS(23),
-    [anon_sym_LBRACK] = ACTIONS(25),
-    [anon_sym_LBRACE] = ACTIONS(27),
-    [anon_sym_SLASH] = ACTIONS(29),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(31),
-    [anon_sym_BQUOTE] = ACTIONS(33),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(35),
+    [ts_builtin_sym_end] = ACTIONS(5),
+    [sym_nil] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [aux_sym_float_token1] = ACTIONS(11),
+    [aux_sym_float_token2] = ACTIONS(13),
+    [aux_sym_float_token3] = ACTIONS(13),
+    [aux_sym_integer_token1] = ACTIONS(15),
+    [aux_sym_integer_token2] = ACTIONS(15),
+    [aux_sym_integer_token3] = ACTIONS(15),
+    [aux_sym_integer_token4] = ACTIONS(17),
+    [anon_sym_COLON] = ACTIONS(19),
+    [anon_sym_DQUOTE] = ACTIONS(21),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(23),
+    [aux_sym_char_token1] = ACTIONS(23),
+    [aux_sym_char_token2] = ACTIONS(25),
+    [anon_sym_LBRACK] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SLASH] = ACTIONS(31),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(33),
+    [anon_sym_BQUOTE] = ACTIONS(35),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(37),
+    [sym_comment] = ACTIONS(3),
   },
   [2] = {
     [sym__statement] = STATE(2),
@@ -2178,38 +2260,39 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_namedTupleLiteral] = STATE(119),
     [sym_commandLiteral] = STATE(119),
     [aux_sym_program_repeat1] = STATE(2),
-    [ts_builtin_sym_end] = ACTIONS(37),
-    [sym_nil] = ACTIONS(39),
-    [anon_sym_true] = ACTIONS(42),
-    [anon_sym_false] = ACTIONS(42),
-    [aux_sym_float_token1] = ACTIONS(45),
-    [aux_sym_float_token2] = ACTIONS(48),
-    [aux_sym_float_token3] = ACTIONS(48),
-    [aux_sym_integer_token1] = ACTIONS(51),
-    [aux_sym_integer_token2] = ACTIONS(51),
-    [aux_sym_integer_token3] = ACTIONS(51),
-    [aux_sym_integer_token4] = ACTIONS(54),
-    [anon_sym_COLON] = ACTIONS(57),
-    [anon_sym_DQUOTE] = ACTIONS(60),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(63),
-    [aux_sym_char_token1] = ACTIONS(63),
-    [aux_sym_char_token2] = ACTIONS(66),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(72),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(78),
-    [anon_sym_BQUOTE] = ACTIONS(81),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(84),
+    [ts_builtin_sym_end] = ACTIONS(39),
+    [sym_nil] = ACTIONS(41),
+    [anon_sym_true] = ACTIONS(44),
+    [anon_sym_false] = ACTIONS(44),
+    [aux_sym_float_token1] = ACTIONS(47),
+    [aux_sym_float_token2] = ACTIONS(50),
+    [aux_sym_float_token3] = ACTIONS(50),
+    [aux_sym_integer_token1] = ACTIONS(53),
+    [aux_sym_integer_token2] = ACTIONS(53),
+    [aux_sym_integer_token3] = ACTIONS(53),
+    [aux_sym_integer_token4] = ACTIONS(56),
+    [anon_sym_COLON] = ACTIONS(59),
+    [anon_sym_DQUOTE] = ACTIONS(62),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
+    [aux_sym_char_token1] = ACTIONS(65),
+    [aux_sym_char_token2] = ACTIONS(68),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(74),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(80),
+    [anon_sym_BQUOTE] = ACTIONS(83),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(86),
+    [sym_comment] = ACTIONS(3),
   },
   [3] = {
     [sym__expression] = STATE(59),
@@ -2226,39 +2309,40 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_tuple] = STATE(59),
     [sym_namedTupleLiteral] = STATE(59),
     [sym_commandLiteral] = STATE(59),
-    [aux_sym_identifier_token1] = ACTIONS(87),
-    [sym_nil] = ACTIONS(89),
-    [anon_sym_true] = ACTIONS(91),
-    [anon_sym_false] = ACTIONS(91),
-    [aux_sym_float_token1] = ACTIONS(93),
-    [aux_sym_float_token2] = ACTIONS(95),
-    [aux_sym_float_token3] = ACTIONS(95),
-    [aux_sym_integer_token1] = ACTIONS(97),
-    [aux_sym_integer_token2] = ACTIONS(97),
-    [aux_sym_integer_token3] = ACTIONS(97),
-    [aux_sym_integer_token4] = ACTIONS(99),
-    [anon_sym_COLON] = ACTIONS(101),
-    [anon_sym_DQUOTE] = ACTIONS(103),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(105),
-    [aux_sym_char_token1] = ACTIONS(105),
-    [aux_sym_char_token2] = ACTIONS(107),
-    [anon_sym_LBRACK] = ACTIONS(109),
-    [anon_sym_LBRACE] = ACTIONS(111),
-    [anon_sym_RBRACE] = ACTIONS(113),
-    [anon_sym_SLASH] = ACTIONS(115),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(117),
-    [anon_sym_BQUOTE] = ACTIONS(119),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(121),
+    [aux_sym_identifier_token1] = ACTIONS(89),
+    [sym_nil] = ACTIONS(91),
+    [anon_sym_true] = ACTIONS(93),
+    [anon_sym_false] = ACTIONS(93),
+    [aux_sym_float_token1] = ACTIONS(95),
+    [aux_sym_float_token2] = ACTIONS(97),
+    [aux_sym_float_token3] = ACTIONS(97),
+    [aux_sym_integer_token1] = ACTIONS(99),
+    [aux_sym_integer_token2] = ACTIONS(99),
+    [aux_sym_integer_token3] = ACTIONS(99),
+    [aux_sym_integer_token4] = ACTIONS(101),
+    [anon_sym_COLON] = ACTIONS(103),
+    [anon_sym_DQUOTE] = ACTIONS(105),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(107),
+    [aux_sym_char_token1] = ACTIONS(107),
+    [aux_sym_char_token2] = ACTIONS(109),
+    [anon_sym_LBRACK] = ACTIONS(111),
+    [anon_sym_LBRACE] = ACTIONS(113),
+    [anon_sym_RBRACE] = ACTIONS(115),
+    [anon_sym_SLASH] = ACTIONS(117),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(119),
+    [anon_sym_BQUOTE] = ACTIONS(121),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(123),
+    [sym_comment] = ACTIONS(3),
   },
   [4] = {
     [sym__expression] = STATE(58),
@@ -2275,39 +2359,40 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_tuple] = STATE(58),
     [sym_namedTupleLiteral] = STATE(58),
     [sym_commandLiteral] = STATE(58),
-    [aux_sym_identifier_token1] = ACTIONS(87),
-    [sym_nil] = ACTIONS(123),
-    [anon_sym_true] = ACTIONS(91),
-    [anon_sym_false] = ACTIONS(91),
-    [aux_sym_float_token1] = ACTIONS(93),
-    [aux_sym_float_token2] = ACTIONS(95),
-    [aux_sym_float_token3] = ACTIONS(95),
-    [aux_sym_integer_token1] = ACTIONS(97),
-    [aux_sym_integer_token2] = ACTIONS(97),
-    [aux_sym_integer_token3] = ACTIONS(97),
-    [aux_sym_integer_token4] = ACTIONS(99),
-    [anon_sym_COLON] = ACTIONS(101),
-    [anon_sym_DQUOTE] = ACTIONS(103),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(105),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(105),
-    [aux_sym_char_token1] = ACTIONS(105),
-    [aux_sym_char_token2] = ACTIONS(107),
-    [anon_sym_LBRACK] = ACTIONS(109),
-    [anon_sym_LBRACE] = ACTIONS(111),
-    [anon_sym_RBRACE] = ACTIONS(125),
-    [anon_sym_SLASH] = ACTIONS(115),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(117),
-    [anon_sym_BQUOTE] = ACTIONS(119),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(121),
+    [aux_sym_identifier_token1] = ACTIONS(89),
+    [sym_nil] = ACTIONS(125),
+    [anon_sym_true] = ACTIONS(93),
+    [anon_sym_false] = ACTIONS(93),
+    [aux_sym_float_token1] = ACTIONS(95),
+    [aux_sym_float_token2] = ACTIONS(97),
+    [aux_sym_float_token3] = ACTIONS(97),
+    [aux_sym_integer_token1] = ACTIONS(99),
+    [aux_sym_integer_token2] = ACTIONS(99),
+    [aux_sym_integer_token3] = ACTIONS(99),
+    [aux_sym_integer_token4] = ACTIONS(101),
+    [anon_sym_COLON] = ACTIONS(103),
+    [anon_sym_DQUOTE] = ACTIONS(105),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(107),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(107),
+    [aux_sym_char_token1] = ACTIONS(107),
+    [aux_sym_char_token2] = ACTIONS(109),
+    [anon_sym_LBRACK] = ACTIONS(111),
+    [anon_sym_LBRACE] = ACTIONS(113),
+    [anon_sym_RBRACE] = ACTIONS(127),
+    [anon_sym_SLASH] = ACTIONS(117),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(119),
+    [anon_sym_BQUOTE] = ACTIONS(121),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(123),
+    [sym_comment] = ACTIONS(3),
   },
   [5] = {
     [sym__statement] = STATE(2),
@@ -2325,78 +2410,81 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_namedTupleLiteral] = STATE(119),
     [sym_commandLiteral] = STATE(119),
     [aux_sym_program_repeat1] = STATE(2),
-    [ts_builtin_sym_end] = ACTIONS(127),
-    [sym_nil] = ACTIONS(5),
-    [anon_sym_true] = ACTIONS(7),
-    [anon_sym_false] = ACTIONS(7),
-    [aux_sym_float_token1] = ACTIONS(9),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [aux_sym_float_token3] = ACTIONS(11),
-    [aux_sym_integer_token1] = ACTIONS(13),
-    [aux_sym_integer_token2] = ACTIONS(13),
-    [aux_sym_integer_token3] = ACTIONS(13),
-    [aux_sym_integer_token4] = ACTIONS(15),
-    [anon_sym_COLON] = ACTIONS(17),
-    [anon_sym_DQUOTE] = ACTIONS(19),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(21),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(21),
-    [aux_sym_char_token1] = ACTIONS(21),
-    [aux_sym_char_token2] = ACTIONS(23),
-    [anon_sym_LBRACK] = ACTIONS(25),
-    [anon_sym_LBRACE] = ACTIONS(27),
-    [anon_sym_SLASH] = ACTIONS(29),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(31),
-    [anon_sym_BQUOTE] = ACTIONS(33),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(35),
+    [ts_builtin_sym_end] = ACTIONS(129),
+    [sym_nil] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [aux_sym_float_token1] = ACTIONS(11),
+    [aux_sym_float_token2] = ACTIONS(13),
+    [aux_sym_float_token3] = ACTIONS(13),
+    [aux_sym_integer_token1] = ACTIONS(15),
+    [aux_sym_integer_token2] = ACTIONS(15),
+    [aux_sym_integer_token3] = ACTIONS(15),
+    [aux_sym_integer_token4] = ACTIONS(17),
+    [anon_sym_COLON] = ACTIONS(19),
+    [anon_sym_DQUOTE] = ACTIONS(21),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(23),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(23),
+    [aux_sym_char_token1] = ACTIONS(23),
+    [aux_sym_char_token2] = ACTIONS(25),
+    [anon_sym_LBRACK] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SLASH] = ACTIONS(31),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(33),
+    [anon_sym_BQUOTE] = ACTIONS(35),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(37),
+    [sym_comment] = ACTIONS(3),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 17,
-    ACTIONS(93), 1,
+  [0] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(129), 1,
+    ACTIONS(131), 1,
       sym_nil,
-    ACTIONS(133), 1,
-      anon_sym_COLON,
     ACTIONS(135), 1,
+      anon_sym_COLON,
+    ACTIONS(137), 1,
       anon_sym_DQUOTE,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2423,42 +2511,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [79] = 17,
-    ACTIONS(93), 1,
+  [82] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(133), 1,
-      anon_sym_COLON,
     ACTIONS(135), 1,
-      anon_sym_DQUOTE,
+      anon_sym_COLON,
     ACTIONS(137), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(139), 1,
       sym_nil,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2485,42 +2575,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [158] = 17,
-    ACTIONS(93), 1,
+  [164] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(139), 1,
-      sym_nil,
     ACTIONS(141), 1,
-      anon_sym_COLON,
+      sym_nil,
     ACTIONS(143), 1,
+      anon_sym_COLON,
+    ACTIONS(145), 1,
       anon_sym_DQUOTE,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2547,42 +2639,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [237] = 17,
-    ACTIONS(93), 1,
+  [246] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(133), 1,
-      anon_sym_COLON,
     ACTIONS(135), 1,
+      anon_sym_COLON,
+    ACTIONS(137), 1,
       anon_sym_DQUOTE,
-    ACTIONS(145), 1,
+    ACTIONS(147), 1,
       sym_nil,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2609,42 +2703,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [316] = 17,
-    ACTIONS(93), 1,
+  [328] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(133), 1,
-      anon_sym_COLON,
     ACTIONS(135), 1,
+      anon_sym_COLON,
+    ACTIONS(137), 1,
       anon_sym_DQUOTE,
-    ACTIONS(147), 1,
+    ACTIONS(149), 1,
       sym_nil,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2671,42 +2767,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [395] = 17,
-    ACTIONS(93), 1,
+  [410] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(149), 1,
-      sym_nil,
     ACTIONS(151), 1,
-      anon_sym_COLON,
+      sym_nil,
     ACTIONS(153), 1,
+      anon_sym_COLON,
+    ACTIONS(155), 1,
       anon_sym_DQUOTE,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2733,42 +2831,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [474] = 17,
-    ACTIONS(93), 1,
+  [492] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(151), 1,
-      anon_sym_COLON,
     ACTIONS(153), 1,
-      anon_sym_DQUOTE,
+      anon_sym_COLON,
     ACTIONS(155), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(157), 1,
       sym_nil,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2795,42 +2895,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [553] = 17,
-    ACTIONS(93), 1,
+  [574] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(133), 1,
-      anon_sym_COLON,
     ACTIONS(135), 1,
+      anon_sym_COLON,
+    ACTIONS(137), 1,
       anon_sym_DQUOTE,
-    ACTIONS(157), 1,
+    ACTIONS(159), 1,
       sym_nil,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2857,42 +2959,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [632] = 17,
-    ACTIONS(93), 1,
+  [656] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(133), 1,
-      anon_sym_COLON,
     ACTIONS(135), 1,
+      anon_sym_COLON,
+    ACTIONS(137), 1,
       anon_sym_DQUOTE,
-    ACTIONS(159), 1,
+    ACTIONS(161), 1,
       sym_nil,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2919,42 +3023,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [711] = 17,
-    ACTIONS(93), 1,
+  [738] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(133), 1,
-      anon_sym_COLON,
     ACTIONS(135), 1,
+      anon_sym_COLON,
+    ACTIONS(137), 1,
       anon_sym_DQUOTE,
-    ACTIONS(155), 1,
+    ACTIONS(157), 1,
       sym_nil,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -2981,42 +3087,44 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [790] = 17,
-    ACTIONS(93), 1,
+  [820] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(95), 1,
       aux_sym_float_token1,
-    ACTIONS(99), 1,
+    ACTIONS(101), 1,
       aux_sym_integer_token4,
-    ACTIONS(107), 1,
-      aux_sym_char_token2,
     ACTIONS(109), 1,
-      anon_sym_LBRACK,
+      aux_sym_char_token2,
     ACTIONS(111), 1,
+      anon_sym_LBRACK,
+    ACTIONS(113), 1,
       anon_sym_LBRACE,
-    ACTIONS(115), 1,
-      anon_sym_SLASH,
     ACTIONS(117), 1,
-      anon_sym_Tuple_DOTnew,
+      anon_sym_SLASH,
     ACTIONS(119), 1,
-      anon_sym_BQUOTE,
+      anon_sym_Tuple_DOTnew,
     ACTIONS(121), 1,
+      anon_sym_BQUOTE,
+    ACTIONS(123), 1,
       anon_sym_PERCENTx_LPAREN,
-    ACTIONS(151), 1,
-      anon_sym_COLON,
     ACTIONS(153), 1,
+      anon_sym_COLON,
+    ACTIONS(155), 1,
       anon_sym_DQUOTE,
-    ACTIONS(161), 1,
+    ACTIONS(163), 1,
       sym_nil,
-    ACTIONS(95), 2,
+    ACTIONS(97), 2,
       aux_sym_float_token2,
       aux_sym_float_token3,
-    ACTIONS(131), 2,
+    ACTIONS(133), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(97), 3,
+    ACTIONS(99), 3,
       aux_sym_integer_token1,
       aux_sym_integer_token2,
       aux_sym_integer_token3,
-    ACTIONS(105), 12,
+    ACTIONS(107), 12,
       anon_sym_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE,
       anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE,
@@ -3043,13 +3151,15 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tuple,
       sym_namedTupleLiteral,
       sym_commandLiteral,
-  [869] = 2,
-    ACTIONS(165), 4,
+  [902] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(167), 4,
       aux_sym_float_token2,
       aux_sym_float_token3,
       aux_sym_integer_token4,
       aux_sym_char_token2,
-    ACTIONS(163), 28,
+    ACTIONS(165), 28,
       ts_builtin_sym_end,
       sym_nil,
       anon_sym_true,
@@ -3078,12 +3188,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Tuple_DOTnew,
       anon_sym_BQUOTE,
       anon_sym_PERCENTx_LPAREN,
-  [906] = 4,
-    ACTIONS(169), 1,
+  [942] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(171), 1,
       anon_sym_DQUOTE,
     STATE(51), 1,
       sym__operator,
-    ACTIONS(171), 7,
+    ACTIONS(173), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3091,7 +3203,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(167), 20,
+    ACTIONS(169), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3112,46 +3224,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [944] = 4,
-    ACTIONS(173), 1,
-      anon_sym_DQUOTE,
-    STATE(51), 1,
-      sym__operator,
-    ACTIONS(171), 7,
-      anon_sym_STAR,
-      anon_sym_EQ_EQ,
-      anon_sym_LT,
-      anon_sym_LT_EQ,
-      anon_sym_GT,
-      anon_sym_LBRACK_RBRACK,
-      anon_sym_BANG,
-    ACTIONS(167), 20,
-      aux_sym_identifier_token1,
-      anon_sym_SLASH,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_PERCENT,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_STAR_STAR,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-      anon_sym_BANG_EQ,
-      anon_sym_GT_EQ,
-      anon_sym_LT_EQ_GT,
-      anon_sym_EQ_EQ_EQ,
-      anon_sym_LBRACK_RBRACK_QMARK,
-      anon_sym_LBRACK_RBRACK_EQ,
-      anon_sym_TILDE,
-      anon_sym_BANG_TILDE,
-      anon_sym_EQ_TILDE,
-  [982] = 4,
+  [983] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(175), 1,
       anon_sym_DQUOTE,
     STATE(51), 1,
       sym__operator,
-    ACTIONS(171), 7,
+    ACTIONS(173), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3159,7 +3239,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(167), 20,
+    ACTIONS(169), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3180,46 +3260,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [1020] = 4,
-    ACTIONS(179), 1,
-      anon_sym_DQUOTE,
-    STATE(121), 1,
-      sym__operator,
-    ACTIONS(181), 7,
-      anon_sym_STAR,
-      anon_sym_EQ_EQ,
-      anon_sym_LT,
-      anon_sym_LT_EQ,
-      anon_sym_GT,
-      anon_sym_LBRACK_RBRACK,
-      anon_sym_BANG,
-    ACTIONS(177), 20,
-      aux_sym_identifier_token1,
-      anon_sym_SLASH,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_PERCENT,
-      anon_sym_AMP,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_STAR_STAR,
-      anon_sym_GT_GT,
-      anon_sym_LT_LT,
-      anon_sym_BANG_EQ,
-      anon_sym_GT_EQ,
-      anon_sym_LT_EQ_GT,
-      anon_sym_EQ_EQ_EQ,
-      anon_sym_LBRACK_RBRACK_QMARK,
-      anon_sym_LBRACK_RBRACK_EQ,
-      anon_sym_TILDE,
-      anon_sym_BANG_TILDE,
-      anon_sym_EQ_TILDE,
-  [1058] = 4,
-    ACTIONS(183), 1,
+  [1024] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(177), 1,
       anon_sym_DQUOTE,
     STATE(51), 1,
       sym__operator,
-    ACTIONS(171), 7,
+    ACTIONS(173), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3227,7 +3275,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(167), 20,
+    ACTIONS(169), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3248,1145 +3296,1481 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [1096] = 2,
-    ACTIONS(187), 2,
+  [1065] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(181), 1,
+      anon_sym_DQUOTE,
+    STATE(121), 1,
+      sym__operator,
+    ACTIONS(183), 7,
+      anon_sym_STAR,
+      anon_sym_EQ_EQ,
+      anon_sym_LT,
+      anon_sym_LT_EQ,
+      anon_sym_GT,
+      anon_sym_LBRACK_RBRACK,
+      anon_sym_BANG,
+    ACTIONS(179), 20,
+      aux_sym_identifier_token1,
+      anon_sym_SLASH,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_STAR_STAR,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+      anon_sym_LT_EQ_GT,
+      anon_sym_EQ_EQ_EQ,
+      anon_sym_LBRACK_RBRACK_QMARK,
+      anon_sym_LBRACK_RBRACK_EQ,
+      anon_sym_TILDE,
+      anon_sym_BANG_TILDE,
+      anon_sym_EQ_TILDE,
+  [1106] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(185), 1,
+      anon_sym_DQUOTE,
+    STATE(51), 1,
+      sym__operator,
+    ACTIONS(173), 7,
+      anon_sym_STAR,
+      anon_sym_EQ_EQ,
+      anon_sym_LT,
+      anon_sym_LT_EQ,
+      anon_sym_GT,
+      anon_sym_LBRACK_RBRACK,
+      anon_sym_BANG,
+    ACTIONS(169), 20,
+      aux_sym_identifier_token1,
+      anon_sym_SLASH,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_STAR_STAR,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+      anon_sym_LT_EQ_GT,
+      anon_sym_EQ_EQ_EQ,
+      anon_sym_LBRACK_RBRACK_QMARK,
+      anon_sym_LBRACK_RBRACK_EQ,
+      anon_sym_TILDE,
+      anon_sym_BANG_TILDE,
+      anon_sym_EQ_TILDE,
+  [1147] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(185), 4,
+    ACTIONS(187), 4,
       anon_sym_COLON,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1107] = 2,
-    ACTIONS(187), 2,
+  [1161] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(189), 4,
+    ACTIONS(193), 4,
       anon_sym_COLON,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1118] = 2,
-    ACTIONS(187), 2,
+  [1175] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(191), 3,
+    ACTIONS(195), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1128] = 2,
-    ACTIONS(187), 2,
+  [1188] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(193), 3,
+    ACTIONS(197), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1138] = 1,
-    ACTIONS(195), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1145] = 1,
-    ACTIONS(197), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1152] = 1,
+  [1201] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(199), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1159] = 1,
+  [1211] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(201), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1166] = 2,
-    ACTIONS(203), 1,
+  [1221] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(203), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [1231] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(205), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [1241] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(207), 1,
       anon_sym_COLON,
-    ACTIONS(205), 3,
+    ACTIONS(209), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1175] = 2,
-    ACTIONS(187), 2,
+  [1253] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(193), 2,
+    ACTIONS(197), 2,
       anon_sym_SEMI,
       aux_sym__statement_token1,
-  [1184] = 1,
-    ACTIONS(207), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1191] = 2,
-    ACTIONS(185), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1200] = 1,
-    ACTIONS(209), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [1207] = 2,
-    ACTIONS(185), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1216] = 2,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(191), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [1225] = 2,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(193), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [1234] = 1,
+  [1265] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(211), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1241] = 2,
+  [1275] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
     ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(189), 2,
       anon_sym_SEMI,
       aux_sym__statement_token1,
-  [1250] = 2,
-    ACTIONS(187), 2,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(191), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [1259] = 1,
+  [1287] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(213), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1266] = 1,
+  [1297] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(187), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1309] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(195), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [1321] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(197), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [1333] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(215), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1273] = 1,
+  [1343] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(193), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+  [1355] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(195), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [1367] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(217), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1280] = 1,
+  [1377] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(219), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1287] = 2,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(191), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-  [1296] = 1,
+  [1387] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(221), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1303] = 2,
-    ACTIONS(185), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1312] = 2,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(193), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [1321] = 2,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(189), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [1330] = 1,
+  [1397] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(223), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1337] = 1,
+  [1407] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(195), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+  [1419] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(225), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1344] = 1,
+  [1429] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(187), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1441] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(197), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [1453] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(193), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [1465] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(227), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1351] = 1,
+  [1475] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(229), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1358] = 2,
-    ACTIONS(231), 1,
-      anon_sym_COLON,
-    ACTIONS(205), 3,
+  [1485] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(231), 4,
       anon_sym_COMMA,
+      anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1367] = 1,
+  [1495] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(233), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [1374] = 3,
+  [1505] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(235), 1,
+      anon_sym_COLON,
+    ACTIONS(209), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [1517] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(237), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [1527] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(239), 1,
       aux_sym_identifier_token1,
-    ACTIONS(237), 1,
+    ACTIONS(241), 1,
       anon_sym_DQUOTE,
     STATE(149), 2,
       sym_identifier,
       sym_string,
-  [1385] = 4,
-    ACTIONS(239), 1,
-      anon_sym_COMMA,
-    ACTIONS(241), 1,
-      anon_sym_EQ_GT,
+  [1541] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(243), 1,
-      anon_sym_RBRACE,
-    STATE(62), 1,
-      aux_sym_array_repeat1,
-  [1398] = 4,
-    ACTIONS(239), 1,
       anon_sym_COMMA,
     ACTIONS(245), 1,
       anon_sym_EQ_GT,
     ACTIONS(247), 1,
       anon_sym_RBRACE,
+    STATE(62), 1,
+      aux_sym_array_repeat1,
+  [1557] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(243), 1,
+      anon_sym_COMMA,
+    ACTIONS(249), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(251), 1,
+      anon_sym_RBRACE,
     STATE(85), 1,
       aux_sym_array_repeat1,
-  [1411] = 2,
-    ACTIONS(187), 2,
+  [1573] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(189), 2,
+    ACTIONS(193), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [1420] = 3,
-    ACTIONS(249), 1,
+  [1585] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(253), 1,
       anon_sym_DQUOTE,
-    ACTIONS(251), 1,
+    ACTIONS(255), 1,
       aux_sym_symbol_token1,
     STATE(95), 1,
       aux_sym_symbol_repeat1,
-  [1430] = 3,
-    ACTIONS(239), 1,
+  [1598] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(243), 1,
       anon_sym_COMMA,
-    ACTIONS(253), 1,
+    ACTIONS(257), 1,
       anon_sym_RBRACE,
     STATE(107), 1,
       aux_sym_array_repeat1,
-  [1440] = 3,
-    ACTIONS(255), 1,
+  [1611] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(259), 1,
       anon_sym_COMMA,
-    ACTIONS(257), 1,
+    ACTIONS(261), 1,
       anon_sym_RBRACK,
     STATE(80), 1,
       aux_sym_array_repeat1,
-  [1450] = 3,
-    ACTIONS(259), 1,
+  [1624] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(263), 1,
       anon_sym_COMMA,
-    ACTIONS(262), 1,
+    ACTIONS(266), 1,
       anon_sym_RBRACE,
     STATE(64), 1,
       aux_sym_hash_repeat1,
-  [1460] = 3,
-    ACTIONS(264), 1,
+  [1637] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(268), 1,
       anon_sym_DQUOTE,
-    ACTIONS(266), 1,
+    ACTIONS(270), 1,
       aux_sym_symbol_token1,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1470] = 3,
-    ACTIONS(268), 1,
+  [1650] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(272), 1,
       anon_sym_COMMA,
-    ACTIONS(270), 1,
+    ACTIONS(274), 1,
       anon_sym_RBRACE,
     STATE(64), 1,
       aux_sym_hash_repeat1,
-  [1480] = 3,
-    ACTIONS(272), 1,
-      anon_sym_COMMA,
-    ACTIONS(275), 1,
-      anon_sym_RBRACE,
-    STATE(67), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1490] = 3,
-    ACTIONS(277), 1,
+  [1663] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(276), 1,
       anon_sym_COMMA,
     ACTIONS(279), 1,
       anon_sym_RBRACE,
+    STATE(67), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1676] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(281), 1,
+      anon_sym_COMMA,
+    ACTIONS(283), 1,
+      anon_sym_RBRACE,
     STATE(75), 1,
       aux_sym_namedTupleLiteral_repeat1,
-  [1500] = 3,
-    ACTIONS(277), 1,
-      anon_sym_COMMA,
+  [1689] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(281), 1,
+      anon_sym_COMMA,
+    ACTIONS(285), 1,
       anon_sym_RBRACE,
     STATE(67), 1,
       aux_sym_namedTupleLiteral_repeat1,
-  [1510] = 3,
-    ACTIONS(255), 1,
+  [1702] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(259), 1,
       anon_sym_COMMA,
-    ACTIONS(283), 1,
+    ACTIONS(287), 1,
       anon_sym_RBRACK,
     STATE(63), 1,
       aux_sym_array_repeat1,
-  [1520] = 3,
-    ACTIONS(266), 1,
+  [1715] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
       aux_sym_symbol_token1,
-    ACTIONS(285), 1,
+    ACTIONS(289), 1,
       anon_sym_DQUOTE,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1530] = 3,
-    ACTIONS(268), 1,
+  [1728] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(272), 1,
       anon_sym_COMMA,
-    ACTIONS(287), 1,
+    ACTIONS(291), 1,
       anon_sym_RBRACE,
     STATE(74), 1,
       aux_sym_hash_repeat1,
-  [1540] = 3,
-    ACTIONS(289), 1,
+  [1741] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(293), 1,
       anon_sym_DQUOTE,
-    ACTIONS(291), 1,
+    ACTIONS(295), 1,
       aux_sym_symbol_token1,
     STATE(98), 1,
       aux_sym_symbol_repeat1,
-  [1550] = 3,
-    ACTIONS(268), 1,
-      anon_sym_COMMA,
-    ACTIONS(293), 1,
-      anon_sym_RBRACE,
-    STATE(64), 1,
-      aux_sym_hash_repeat1,
-  [1560] = 3,
-    ACTIONS(277), 1,
-      anon_sym_COMMA,
-    ACTIONS(295), 1,
-      anon_sym_RBRACE,
-    STATE(67), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1570] = 3,
-    ACTIONS(277), 1,
+  [1754] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(272), 1,
       anon_sym_COMMA,
     ACTIONS(297), 1,
       anon_sym_RBRACE,
+    STATE(64), 1,
+      aux_sym_hash_repeat1,
+  [1767] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(281), 1,
+      anon_sym_COMMA,
+    ACTIONS(299), 1,
+      anon_sym_RBRACE,
+    STATE(67), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1780] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(281), 1,
+      anon_sym_COMMA,
+    ACTIONS(301), 1,
+      anon_sym_RBRACE,
     STATE(69), 1,
       aux_sym_namedTupleLiteral_repeat1,
-  [1580] = 3,
-    ACTIONS(299), 1,
+  [1793] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(303), 1,
       anon_sym_DQUOTE,
-    ACTIONS(301), 1,
+    ACTIONS(305), 1,
       aux_sym_symbol_token1,
     STATE(81), 1,
       aux_sym_symbol_repeat1,
-  [1590] = 3,
-    ACTIONS(268), 1,
+  [1806] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(272), 1,
       anon_sym_COMMA,
-    ACTIONS(303), 1,
+    ACTIONS(307), 1,
       anon_sym_RBRACE,
     STATE(66), 1,
       aux_sym_hash_repeat1,
-  [1600] = 3,
-    ACTIONS(305), 1,
+  [1819] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(309), 1,
       anon_sym_DQUOTE,
-    ACTIONS(307), 1,
+    ACTIONS(311), 1,
       aux_sym_symbol_token1,
     STATE(83), 1,
       aux_sym_symbol_repeat1,
-  [1610] = 3,
-    ACTIONS(309), 1,
+  [1832] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(313), 1,
       anon_sym_COMMA,
-    ACTIONS(312), 1,
+    ACTIONS(316), 1,
       anon_sym_RBRACK,
     STATE(80), 1,
       aux_sym_array_repeat1,
-  [1620] = 3,
-    ACTIONS(266), 1,
+  [1845] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
       aux_sym_symbol_token1,
-    ACTIONS(314), 1,
+    ACTIONS(318), 1,
       anon_sym_DQUOTE,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1630] = 1,
-    ACTIONS(312), 3,
+  [1858] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(316), 3,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_RBRACE,
-  [1636] = 3,
-    ACTIONS(266), 1,
+  [1867] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
       aux_sym_symbol_token1,
-    ACTIONS(316), 1,
+    ACTIONS(320), 1,
       anon_sym_DQUOTE,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1646] = 3,
-    ACTIONS(318), 1,
+  [1880] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(322), 1,
       anon_sym_DQUOTE,
-    ACTIONS(320), 1,
+    ACTIONS(324), 1,
       aux_sym_symbol_token1,
     STATE(87), 1,
       aux_sym_symbol_repeat1,
-  [1656] = 3,
-    ACTIONS(239), 1,
+  [1893] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(243), 1,
       anon_sym_COMMA,
-    ACTIONS(322), 1,
+    ACTIONS(326), 1,
       anon_sym_RBRACE,
     STATE(107), 1,
       aux_sym_array_repeat1,
-  [1666] = 3,
-    ACTIONS(324), 1,
+  [1906] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(328), 1,
       anon_sym_DQUOTE,
-    ACTIONS(326), 1,
+    ACTIONS(330), 1,
       aux_sym_symbol_token1,
     STATE(91), 1,
       aux_sym_symbol_repeat1,
-  [1676] = 3,
-    ACTIONS(266), 1,
+  [1919] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
       aux_sym_symbol_token1,
-    ACTIONS(328), 1,
+    ACTIONS(332), 1,
       anon_sym_DQUOTE,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1686] = 3,
-    ACTIONS(255), 1,
+  [1932] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(259), 1,
       anon_sym_COMMA,
-    ACTIONS(330), 1,
+    ACTIONS(334), 1,
       anon_sym_RBRACK,
     STATE(80), 1,
       aux_sym_array_repeat1,
-  [1696] = 3,
-    ACTIONS(332), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(335), 1,
-      aux_sym_symbol_token1,
+  [1945] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1706] = 3,
-    ACTIONS(266), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(338), 1,
+    ACTIONS(336), 2,
       anon_sym_DQUOTE,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [1716] = 3,
-    ACTIONS(266), 1,
       aux_sym_symbol_token1,
-    ACTIONS(340), 1,
+  [1956] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(339), 1,
       anon_sym_DQUOTE,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1726] = 3,
-    ACTIONS(342), 1,
+  [1969] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(341), 1,
       anon_sym_DQUOTE,
-    ACTIONS(344), 1,
+    STATE(89), 1,
+      aux_sym_symbol_repeat1,
+  [1982] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(343), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(345), 1,
       aux_sym_symbol_token1,
     STATE(94), 1,
       aux_sym_symbol_repeat1,
-  [1736] = 3,
-    ACTIONS(346), 1,
+  [1995] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(347), 1,
       anon_sym_DQUOTE,
-    ACTIONS(348), 1,
+    ACTIONS(349), 1,
       aux_sym_symbol_token1,
     STATE(65), 1,
       aux_sym_symbol_repeat1,
-  [1746] = 3,
-    ACTIONS(266), 1,
+  [2008] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
       aux_sym_symbol_token1,
-    ACTIONS(350), 1,
+    ACTIONS(351), 1,
       anon_sym_DQUOTE,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1756] = 3,
-    ACTIONS(266), 1,
+  [2021] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
       aux_sym_symbol_token1,
-    ACTIONS(352), 1,
+    ACTIONS(353), 1,
       anon_sym_DQUOTE,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1766] = 3,
-    ACTIONS(354), 1,
+  [2034] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(355), 1,
       anon_sym_DQUOTE,
-    ACTIONS(356), 1,
+    ACTIONS(357), 1,
       aux_sym_symbol_token1,
     STATE(100), 1,
       aux_sym_symbol_repeat1,
-  [1776] = 3,
-    ACTIONS(255), 1,
+  [2047] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(259), 1,
       anon_sym_COMMA,
-    ACTIONS(358), 1,
+    ACTIONS(359), 1,
       anon_sym_RBRACK,
     STATE(88), 1,
       aux_sym_array_repeat1,
-  [1786] = 3,
-    ACTIONS(266), 1,
+  [2060] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
       aux_sym_symbol_token1,
-    ACTIONS(360), 1,
+    ACTIONS(361), 1,
       anon_sym_DQUOTE,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1796] = 3,
-    ACTIONS(362), 1,
+  [2073] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(363), 1,
       anon_sym_DQUOTE,
-    ACTIONS(364), 1,
+    ACTIONS(365), 1,
       aux_sym_symbol_token1,
     STATE(90), 1,
       aux_sym_symbol_repeat1,
-  [1806] = 3,
-    ACTIONS(266), 1,
+  [2086] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(270), 1,
       aux_sym_symbol_token1,
-    ACTIONS(366), 1,
+    ACTIONS(367), 1,
       anon_sym_DQUOTE,
     STATE(89), 1,
       aux_sym_symbol_repeat1,
-  [1816] = 2,
-    ACTIONS(189), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1824] = 2,
+  [2099] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
     ACTIONS(193), 1,
       anon_sym_EQ_GT,
-    ACTIONS(187), 2,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1832] = 2,
-    ACTIONS(185), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(187), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1840] = 2,
+  [2110] = 3,
     ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(197), 1,
       anon_sym_EQ_GT,
-    ACTIONS(187), 2,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1848] = 2,
-    ACTIONS(189), 1,
+  [2121] = 3,
+    ACTIONS(187), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [2132] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(195), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(189), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [2143] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(193), 1,
       anon_sym_COLON,
-    ACTIONS(187), 2,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1856] = 2,
-    ACTIONS(185), 1,
+  [2154] = 3,
+    ACTIONS(187), 1,
       anon_sym_COLON,
-    ACTIONS(187), 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(189), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1864] = 3,
-    ACTIONS(312), 1,
+  [2165] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(316), 1,
       anon_sym_RBRACE,
-    ACTIONS(368), 1,
+    ACTIONS(369), 1,
       anon_sym_COMMA,
     STATE(107), 1,
       aux_sym_array_repeat1,
-  [1874] = 3,
-    ACTIONS(371), 1,
+  [2178] = 4,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(372), 1,
       anon_sym_DQUOTE,
-    ACTIONS(373), 1,
+    ACTIONS(374), 1,
       aux_sym_symbol_token1,
     STATE(71), 1,
       aux_sym_symbol_repeat1,
-  [1884] = 2,
-    ACTIONS(221), 1,
-      aux_sym__statement_token1,
-    ACTIONS(375), 1,
-      anon_sym_SEMI,
-  [1891] = 2,
-    ACTIONS(197), 1,
-      aux_sym__statement_token1,
-    ACTIONS(377), 1,
-      anon_sym_SEMI,
-  [1898] = 1,
-    ACTIONS(379), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [1903] = 1,
-    ACTIONS(381), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [1908] = 2,
-    ACTIONS(233), 1,
-      aux_sym__statement_token1,
-    ACTIONS(383), 1,
-      anon_sym_SEMI,
-  [1915] = 2,
-    ACTIONS(229), 1,
-      aux_sym__statement_token1,
-    ACTIONS(385), 1,
-      anon_sym_SEMI,
-  [1922] = 2,
-    ACTIONS(227), 1,
-      aux_sym__statement_token1,
-    ACTIONS(387), 1,
-      anon_sym_SEMI,
-  [1929] = 2,
-    ACTIONS(215), 1,
-      aux_sym__statement_token1,
-    ACTIONS(389), 1,
-      anon_sym_SEMI,
-  [1936] = 2,
+  [2191] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
     ACTIONS(225), 1,
       aux_sym__statement_token1,
-    ACTIONS(391), 1,
+    ACTIONS(376), 1,
       anon_sym_SEMI,
-  [1943] = 2,
-    ACTIONS(217), 1,
-      aux_sym__statement_token1,
-    ACTIONS(393), 1,
-      anon_sym_SEMI,
-  [1950] = 2,
-    ACTIONS(395), 1,
-      anon_sym_SEMI,
-    ACTIONS(397), 1,
-      aux_sym__statement_token1,
-  [1957] = 2,
-    ACTIONS(199), 1,
-      aux_sym__statement_token1,
-    ACTIONS(399), 1,
-      anon_sym_SEMI,
-  [1964] = 2,
-    ACTIONS(223), 1,
-      aux_sym__statement_token1,
-    ACTIONS(401), 1,
-      anon_sym_SEMI,
-  [1971] = 2,
-    ACTIONS(207), 1,
-      aux_sym__statement_token1,
-    ACTIONS(403), 1,
-      anon_sym_SEMI,
-  [1978] = 2,
-    ACTIONS(209), 1,
-      aux_sym__statement_token1,
-    ACTIONS(405), 1,
-      anon_sym_SEMI,
-  [1985] = 2,
-    ACTIONS(219), 1,
-      aux_sym__statement_token1,
-    ACTIONS(407), 1,
-      anon_sym_SEMI,
-  [1992] = 2,
-    ACTIONS(195), 1,
-      aux_sym__statement_token1,
-    ACTIONS(409), 1,
-      anon_sym_SEMI,
-  [1999] = 2,
+  [2201] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
     ACTIONS(201), 1,
       aux_sym__statement_token1,
-    ACTIONS(411), 1,
+    ACTIONS(378), 1,
       anon_sym_SEMI,
-  [2006] = 2,
+  [2211] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(380), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [2219] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(382), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [2227] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(237), 1,
+      aux_sym__statement_token1,
+    ACTIONS(384), 1,
+      anon_sym_SEMI,
+  [2237] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(233), 1,
+      aux_sym__statement_token1,
+    ACTIONS(386), 1,
+      anon_sym_SEMI,
+  [2247] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(231), 1,
+      aux_sym__statement_token1,
+    ACTIONS(388), 1,
+      anon_sym_SEMI,
+  [2257] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(219), 1,
+      aux_sym__statement_token1,
+    ACTIONS(390), 1,
+      anon_sym_SEMI,
+  [2267] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(229), 1,
+      aux_sym__statement_token1,
+    ACTIONS(392), 1,
+      anon_sym_SEMI,
+  [2277] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(221), 1,
+      aux_sym__statement_token1,
+    ACTIONS(394), 1,
+      anon_sym_SEMI,
+  [2287] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(396), 1,
+      anon_sym_SEMI,
+    ACTIONS(398), 1,
+      aux_sym__statement_token1,
+  [2297] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(203), 1,
+      aux_sym__statement_token1,
+    ACTIONS(400), 1,
+      anon_sym_SEMI,
+  [2307] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(227), 1,
+      aux_sym__statement_token1,
+    ACTIONS(402), 1,
+      anon_sym_SEMI,
+  [2317] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
     ACTIONS(211), 1,
       aux_sym__statement_token1,
-    ACTIONS(413), 1,
+    ACTIONS(404), 1,
       anon_sym_SEMI,
-  [2013] = 2,
+  [2327] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
     ACTIONS(213), 1,
       aux_sym__statement_token1,
-    ACTIONS(415), 1,
+    ACTIONS(406), 1,
       anon_sym_SEMI,
-  [2020] = 1,
-    ACTIONS(417), 1,
+  [2337] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(223), 1,
+      aux_sym__statement_token1,
+    ACTIONS(408), 1,
+      anon_sym_SEMI,
+  [2347] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(199), 1,
+      aux_sym__statement_token1,
+    ACTIONS(410), 1,
+      anon_sym_SEMI,
+  [2357] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(205), 1,
+      aux_sym__statement_token1,
+    ACTIONS(412), 1,
+      anon_sym_SEMI,
+  [2367] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(215), 1,
+      aux_sym__statement_token1,
+    ACTIONS(414), 1,
+      anon_sym_SEMI,
+  [2377] = 3,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(217), 1,
+      aux_sym__statement_token1,
+    ACTIONS(416), 1,
+      anon_sym_SEMI,
+  [2387] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(418), 1,
       anon_sym_RPAREN,
-  [2024] = 1,
-    ACTIONS(419), 1,
+  [2394] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(420), 1,
       aux_sym_commandLiteral_token2,
-  [2028] = 1,
-    ACTIONS(421), 1,
+  [2401] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(422), 1,
       anon_sym_EQ_GT,
-  [2032] = 1,
-    ACTIONS(423), 1,
+  [2408] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(424), 1,
       aux_sym_hash_token1,
-  [2036] = 1,
-    ACTIONS(417), 1,
+  [2415] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(418), 1,
       anon_sym_BQUOTE,
-  [2040] = 1,
-    ACTIONS(425), 1,
+  [2422] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(426), 1,
       anon_sym_SLASH,
-  [2044] = 1,
-    ACTIONS(231), 1,
+  [2429] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(235), 1,
       anon_sym_COLON,
-  [2048] = 1,
-    ACTIONS(427), 1,
+  [2436] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(428), 1,
       anon_sym_of,
-  [2052] = 1,
-    ACTIONS(429), 1,
+  [2443] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(430), 1,
       anon_sym_COLON,
-  [2056] = 1,
-    ACTIONS(431), 1,
+  [2450] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(432), 1,
       anon_sym_SLASH,
-  [2060] = 1,
-    ACTIONS(433), 1,
+  [2457] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(434), 1,
       aux_sym_hash_token1,
-  [2064] = 1,
-    ACTIONS(435), 1,
+  [2464] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(436), 1,
       aux_sym_regex_token1,
-  [2068] = 1,
-    ACTIONS(437), 1,
+  [2471] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(438), 1,
       aux_sym_commandLiteral_token1,
-  [2072] = 1,
-    ACTIONS(439), 1,
+  [2478] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(440), 1,
       aux_sym_hash_token1,
-  [2076] = 1,
-    ACTIONS(441), 1,
+  [2485] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(442), 1,
       ts_builtin_sym_end,
-  [2080] = 1,
-    ACTIONS(443), 1,
+  [2492] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(444), 1,
       aux_sym_commandLiteral_token2,
-  [2084] = 1,
-    ACTIONS(445), 1,
+  [2499] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(446), 1,
       aux_sym_commandLiteral_token1,
-  [2088] = 1,
-    ACTIONS(447), 1,
+  [2506] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(448), 1,
       anon_sym_EQ_GT,
-  [2092] = 1,
-    ACTIONS(449), 1,
+  [2513] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(450), 1,
       anon_sym_EQ_GT,
-  [2096] = 1,
-    ACTIONS(451), 1,
+  [2520] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(452), 1,
       aux_sym_regex_token1,
-  [2100] = 1,
-    ACTIONS(453), 1,
+  [2527] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(454), 1,
       anon_sym_COLON,
-  [2104] = 1,
-    ACTIONS(455), 1,
+  [2534] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(456), 1,
       anon_sym_RPAREN,
-  [2108] = 1,
-    ACTIONS(203), 1,
+  [2541] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(207), 1,
       anon_sym_COLON,
-  [2112] = 1,
-    ACTIONS(455), 1,
+  [2548] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(456), 1,
       anon_sym_BQUOTE,
-  [2116] = 1,
-    ACTIONS(457), 1,
+  [2555] = 2,
+    ACTIONS(191), 1,
+      sym_comment,
+    ACTIONS(458), 1,
       aux_sym_hash_token1,
-  [2120] = 1,
-    ACTIONS(459), 1,
+  [2562] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(460), 1,
       anon_sym_of,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(6)] = 0,
-  [SMALL_STATE(7)] = 79,
-  [SMALL_STATE(8)] = 158,
-  [SMALL_STATE(9)] = 237,
-  [SMALL_STATE(10)] = 316,
-  [SMALL_STATE(11)] = 395,
-  [SMALL_STATE(12)] = 474,
-  [SMALL_STATE(13)] = 553,
-  [SMALL_STATE(14)] = 632,
-  [SMALL_STATE(15)] = 711,
-  [SMALL_STATE(16)] = 790,
-  [SMALL_STATE(17)] = 869,
-  [SMALL_STATE(18)] = 906,
-  [SMALL_STATE(19)] = 944,
-  [SMALL_STATE(20)] = 982,
-  [SMALL_STATE(21)] = 1020,
-  [SMALL_STATE(22)] = 1058,
-  [SMALL_STATE(23)] = 1096,
-  [SMALL_STATE(24)] = 1107,
-  [SMALL_STATE(25)] = 1118,
-  [SMALL_STATE(26)] = 1128,
-  [SMALL_STATE(27)] = 1138,
-  [SMALL_STATE(28)] = 1145,
-  [SMALL_STATE(29)] = 1152,
-  [SMALL_STATE(30)] = 1159,
-  [SMALL_STATE(31)] = 1166,
-  [SMALL_STATE(32)] = 1175,
-  [SMALL_STATE(33)] = 1184,
-  [SMALL_STATE(34)] = 1191,
-  [SMALL_STATE(35)] = 1200,
-  [SMALL_STATE(36)] = 1207,
-  [SMALL_STATE(37)] = 1216,
-  [SMALL_STATE(38)] = 1225,
-  [SMALL_STATE(39)] = 1234,
-  [SMALL_STATE(40)] = 1241,
-  [SMALL_STATE(41)] = 1250,
-  [SMALL_STATE(42)] = 1259,
-  [SMALL_STATE(43)] = 1266,
-  [SMALL_STATE(44)] = 1273,
-  [SMALL_STATE(45)] = 1280,
-  [SMALL_STATE(46)] = 1287,
-  [SMALL_STATE(47)] = 1296,
-  [SMALL_STATE(48)] = 1303,
-  [SMALL_STATE(49)] = 1312,
-  [SMALL_STATE(50)] = 1321,
-  [SMALL_STATE(51)] = 1330,
-  [SMALL_STATE(52)] = 1337,
-  [SMALL_STATE(53)] = 1344,
-  [SMALL_STATE(54)] = 1351,
-  [SMALL_STATE(55)] = 1358,
-  [SMALL_STATE(56)] = 1367,
-  [SMALL_STATE(57)] = 1374,
-  [SMALL_STATE(58)] = 1385,
-  [SMALL_STATE(59)] = 1398,
-  [SMALL_STATE(60)] = 1411,
-  [SMALL_STATE(61)] = 1420,
-  [SMALL_STATE(62)] = 1430,
-  [SMALL_STATE(63)] = 1440,
-  [SMALL_STATE(64)] = 1450,
-  [SMALL_STATE(65)] = 1460,
-  [SMALL_STATE(66)] = 1470,
-  [SMALL_STATE(67)] = 1480,
-  [SMALL_STATE(68)] = 1490,
-  [SMALL_STATE(69)] = 1500,
-  [SMALL_STATE(70)] = 1510,
-  [SMALL_STATE(71)] = 1520,
-  [SMALL_STATE(72)] = 1530,
-  [SMALL_STATE(73)] = 1540,
-  [SMALL_STATE(74)] = 1550,
-  [SMALL_STATE(75)] = 1560,
-  [SMALL_STATE(76)] = 1570,
-  [SMALL_STATE(77)] = 1580,
-  [SMALL_STATE(78)] = 1590,
-  [SMALL_STATE(79)] = 1600,
-  [SMALL_STATE(80)] = 1610,
-  [SMALL_STATE(81)] = 1620,
-  [SMALL_STATE(82)] = 1630,
-  [SMALL_STATE(83)] = 1636,
-  [SMALL_STATE(84)] = 1646,
-  [SMALL_STATE(85)] = 1656,
-  [SMALL_STATE(86)] = 1666,
-  [SMALL_STATE(87)] = 1676,
-  [SMALL_STATE(88)] = 1686,
-  [SMALL_STATE(89)] = 1696,
-  [SMALL_STATE(90)] = 1706,
-  [SMALL_STATE(91)] = 1716,
-  [SMALL_STATE(92)] = 1726,
-  [SMALL_STATE(93)] = 1736,
-  [SMALL_STATE(94)] = 1746,
-  [SMALL_STATE(95)] = 1756,
-  [SMALL_STATE(96)] = 1766,
-  [SMALL_STATE(97)] = 1776,
-  [SMALL_STATE(98)] = 1786,
-  [SMALL_STATE(99)] = 1796,
-  [SMALL_STATE(100)] = 1806,
-  [SMALL_STATE(101)] = 1816,
-  [SMALL_STATE(102)] = 1824,
-  [SMALL_STATE(103)] = 1832,
-  [SMALL_STATE(104)] = 1840,
-  [SMALL_STATE(105)] = 1848,
-  [SMALL_STATE(106)] = 1856,
-  [SMALL_STATE(107)] = 1864,
-  [SMALL_STATE(108)] = 1874,
-  [SMALL_STATE(109)] = 1884,
-  [SMALL_STATE(110)] = 1891,
-  [SMALL_STATE(111)] = 1898,
-  [SMALL_STATE(112)] = 1903,
-  [SMALL_STATE(113)] = 1908,
-  [SMALL_STATE(114)] = 1915,
-  [SMALL_STATE(115)] = 1922,
-  [SMALL_STATE(116)] = 1929,
-  [SMALL_STATE(117)] = 1936,
-  [SMALL_STATE(118)] = 1943,
-  [SMALL_STATE(119)] = 1950,
-  [SMALL_STATE(120)] = 1957,
-  [SMALL_STATE(121)] = 1964,
-  [SMALL_STATE(122)] = 1971,
-  [SMALL_STATE(123)] = 1978,
-  [SMALL_STATE(124)] = 1985,
-  [SMALL_STATE(125)] = 1992,
-  [SMALL_STATE(126)] = 1999,
-  [SMALL_STATE(127)] = 2006,
-  [SMALL_STATE(128)] = 2013,
-  [SMALL_STATE(129)] = 2020,
-  [SMALL_STATE(130)] = 2024,
-  [SMALL_STATE(131)] = 2028,
-  [SMALL_STATE(132)] = 2032,
-  [SMALL_STATE(133)] = 2036,
-  [SMALL_STATE(134)] = 2040,
-  [SMALL_STATE(135)] = 2044,
-  [SMALL_STATE(136)] = 2048,
-  [SMALL_STATE(137)] = 2052,
-  [SMALL_STATE(138)] = 2056,
-  [SMALL_STATE(139)] = 2060,
-  [SMALL_STATE(140)] = 2064,
-  [SMALL_STATE(141)] = 2068,
-  [SMALL_STATE(142)] = 2072,
-  [SMALL_STATE(143)] = 2076,
-  [SMALL_STATE(144)] = 2080,
-  [SMALL_STATE(145)] = 2084,
-  [SMALL_STATE(146)] = 2088,
-  [SMALL_STATE(147)] = 2092,
-  [SMALL_STATE(148)] = 2096,
-  [SMALL_STATE(149)] = 2100,
-  [SMALL_STATE(150)] = 2104,
-  [SMALL_STATE(151)] = 2108,
-  [SMALL_STATE(152)] = 2112,
-  [SMALL_STATE(153)] = 2116,
-  [SMALL_STATE(154)] = 2120,
+  [SMALL_STATE(7)] = 82,
+  [SMALL_STATE(8)] = 164,
+  [SMALL_STATE(9)] = 246,
+  [SMALL_STATE(10)] = 328,
+  [SMALL_STATE(11)] = 410,
+  [SMALL_STATE(12)] = 492,
+  [SMALL_STATE(13)] = 574,
+  [SMALL_STATE(14)] = 656,
+  [SMALL_STATE(15)] = 738,
+  [SMALL_STATE(16)] = 820,
+  [SMALL_STATE(17)] = 902,
+  [SMALL_STATE(18)] = 942,
+  [SMALL_STATE(19)] = 983,
+  [SMALL_STATE(20)] = 1024,
+  [SMALL_STATE(21)] = 1065,
+  [SMALL_STATE(22)] = 1106,
+  [SMALL_STATE(23)] = 1147,
+  [SMALL_STATE(24)] = 1161,
+  [SMALL_STATE(25)] = 1175,
+  [SMALL_STATE(26)] = 1188,
+  [SMALL_STATE(27)] = 1201,
+  [SMALL_STATE(28)] = 1211,
+  [SMALL_STATE(29)] = 1221,
+  [SMALL_STATE(30)] = 1231,
+  [SMALL_STATE(31)] = 1241,
+  [SMALL_STATE(32)] = 1253,
+  [SMALL_STATE(33)] = 1265,
+  [SMALL_STATE(34)] = 1275,
+  [SMALL_STATE(35)] = 1287,
+  [SMALL_STATE(36)] = 1297,
+  [SMALL_STATE(37)] = 1309,
+  [SMALL_STATE(38)] = 1321,
+  [SMALL_STATE(39)] = 1333,
+  [SMALL_STATE(40)] = 1343,
+  [SMALL_STATE(41)] = 1355,
+  [SMALL_STATE(42)] = 1367,
+  [SMALL_STATE(43)] = 1377,
+  [SMALL_STATE(44)] = 1387,
+  [SMALL_STATE(45)] = 1397,
+  [SMALL_STATE(46)] = 1407,
+  [SMALL_STATE(47)] = 1419,
+  [SMALL_STATE(48)] = 1429,
+  [SMALL_STATE(49)] = 1441,
+  [SMALL_STATE(50)] = 1453,
+  [SMALL_STATE(51)] = 1465,
+  [SMALL_STATE(52)] = 1475,
+  [SMALL_STATE(53)] = 1485,
+  [SMALL_STATE(54)] = 1495,
+  [SMALL_STATE(55)] = 1505,
+  [SMALL_STATE(56)] = 1517,
+  [SMALL_STATE(57)] = 1527,
+  [SMALL_STATE(58)] = 1541,
+  [SMALL_STATE(59)] = 1557,
+  [SMALL_STATE(60)] = 1573,
+  [SMALL_STATE(61)] = 1585,
+  [SMALL_STATE(62)] = 1598,
+  [SMALL_STATE(63)] = 1611,
+  [SMALL_STATE(64)] = 1624,
+  [SMALL_STATE(65)] = 1637,
+  [SMALL_STATE(66)] = 1650,
+  [SMALL_STATE(67)] = 1663,
+  [SMALL_STATE(68)] = 1676,
+  [SMALL_STATE(69)] = 1689,
+  [SMALL_STATE(70)] = 1702,
+  [SMALL_STATE(71)] = 1715,
+  [SMALL_STATE(72)] = 1728,
+  [SMALL_STATE(73)] = 1741,
+  [SMALL_STATE(74)] = 1754,
+  [SMALL_STATE(75)] = 1767,
+  [SMALL_STATE(76)] = 1780,
+  [SMALL_STATE(77)] = 1793,
+  [SMALL_STATE(78)] = 1806,
+  [SMALL_STATE(79)] = 1819,
+  [SMALL_STATE(80)] = 1832,
+  [SMALL_STATE(81)] = 1845,
+  [SMALL_STATE(82)] = 1858,
+  [SMALL_STATE(83)] = 1867,
+  [SMALL_STATE(84)] = 1880,
+  [SMALL_STATE(85)] = 1893,
+  [SMALL_STATE(86)] = 1906,
+  [SMALL_STATE(87)] = 1919,
+  [SMALL_STATE(88)] = 1932,
+  [SMALL_STATE(89)] = 1945,
+  [SMALL_STATE(90)] = 1956,
+  [SMALL_STATE(91)] = 1969,
+  [SMALL_STATE(92)] = 1982,
+  [SMALL_STATE(93)] = 1995,
+  [SMALL_STATE(94)] = 2008,
+  [SMALL_STATE(95)] = 2021,
+  [SMALL_STATE(96)] = 2034,
+  [SMALL_STATE(97)] = 2047,
+  [SMALL_STATE(98)] = 2060,
+  [SMALL_STATE(99)] = 2073,
+  [SMALL_STATE(100)] = 2086,
+  [SMALL_STATE(101)] = 2099,
+  [SMALL_STATE(102)] = 2110,
+  [SMALL_STATE(103)] = 2121,
+  [SMALL_STATE(104)] = 2132,
+  [SMALL_STATE(105)] = 2143,
+  [SMALL_STATE(106)] = 2154,
+  [SMALL_STATE(107)] = 2165,
+  [SMALL_STATE(108)] = 2178,
+  [SMALL_STATE(109)] = 2191,
+  [SMALL_STATE(110)] = 2201,
+  [SMALL_STATE(111)] = 2211,
+  [SMALL_STATE(112)] = 2219,
+  [SMALL_STATE(113)] = 2227,
+  [SMALL_STATE(114)] = 2237,
+  [SMALL_STATE(115)] = 2247,
+  [SMALL_STATE(116)] = 2257,
+  [SMALL_STATE(117)] = 2267,
+  [SMALL_STATE(118)] = 2277,
+  [SMALL_STATE(119)] = 2287,
+  [SMALL_STATE(120)] = 2297,
+  [SMALL_STATE(121)] = 2307,
+  [SMALL_STATE(122)] = 2317,
+  [SMALL_STATE(123)] = 2327,
+  [SMALL_STATE(124)] = 2337,
+  [SMALL_STATE(125)] = 2347,
+  [SMALL_STATE(126)] = 2357,
+  [SMALL_STATE(127)] = 2367,
+  [SMALL_STATE(128)] = 2377,
+  [SMALL_STATE(129)] = 2387,
+  [SMALL_STATE(130)] = 2394,
+  [SMALL_STATE(131)] = 2401,
+  [SMALL_STATE(132)] = 2408,
+  [SMALL_STATE(133)] = 2415,
+  [SMALL_STATE(134)] = 2422,
+  [SMALL_STATE(135)] = 2429,
+  [SMALL_STATE(136)] = 2436,
+  [SMALL_STATE(137)] = 2443,
+  [SMALL_STATE(138)] = 2450,
+  [SMALL_STATE(139)] = 2457,
+  [SMALL_STATE(140)] = 2464,
+  [SMALL_STATE(141)] = 2471,
+  [SMALL_STATE(142)] = 2478,
+  [SMALL_STATE(143)] = 2485,
+  [SMALL_STATE(144)] = 2492,
+  [SMALL_STATE(145)] = 2499,
+  [SMALL_STATE(146)] = 2506,
+  [SMALL_STATE(147)] = 2513,
+  [SMALL_STATE(148)] = 2520,
+  [SMALL_STATE(149)] = 2527,
+  [SMALL_STATE(150)] = 2534,
+  [SMALL_STATE(151)] = 2541,
+  [SMALL_STATE(152)] = 2548,
+  [SMALL_STATE(153)] = 2555,
+  [SMALL_STATE(154)] = 2562,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(115),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
-  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
-  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(119),
-  [42] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(126),
-  [45] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(113),
-  [48] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(113),
-  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(114),
-  [54] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(114),
-  [57] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(21),
-  [60] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(73),
-  [63] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(115),
-  [66] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(115),
-  [69] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(11),
-  [72] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(3),
-  [75] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(148),
-  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(117),
-  [81] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(145),
-  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(144),
-  [87] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
-  [89] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
-  [91] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [93] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [95] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
-  [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [99] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
-  [101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [107] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
-  [109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [111] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
-  [115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
-  [123] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
-  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
-  [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
-  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [163] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statement, 2),
-  [165] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statement, 2),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [171] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
-  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
-  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
-  [185] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
-  [187] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 1),
-  [189] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
-  [191] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 4),
-  [193] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 3),
-  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 4),
-  [197] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_regex, 3),
-  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6),
-  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bool, 1),
-  [203] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
-  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 1),
-  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 5, .production_id = 1),
-  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
-  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commandLiteral, 3),
-  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 2),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6, .production_id = 2),
-  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 3),
-  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
-  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 2),
-  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
-  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char, 1),
-  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer, 1),
-  [231] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
-  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
-  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
-  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
-  [249] = {.entry = {.count = 1, .reusable = false}}, SHIFT(102),
-  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [259] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 3), SHIFT_REPEAT(8),
-  [262] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 3),
-  [264] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
-  [272] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 3), SHIFT_REPEAT(57),
-  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 3),
-  [277] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [281] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
-  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [289] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [299] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [301] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [303] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
-  [305] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [309] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(12),
-  [312] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
-  [314] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [316] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [318] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
-  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [322] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
-  [324] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
-  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [328] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [330] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [332] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 2), SHIFT_REPEAT(89),
-  [335] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_symbol_repeat1, 2), SHIFT_REPEAT(89),
-  [338] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [340] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [342] = {.entry = {.count = 1, .reusable = false}}, SHIFT(101),
-  [344] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [346] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [348] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [350] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
-  [352] = {.entry = {.count = 1, .reusable = false}}, SHIFT(104),
-  [354] = {.entry = {.count = 1, .reusable = false}}, SHIFT(105),
-  [356] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
-  [358] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [360] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [362] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [364] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
-  [366] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
-  [368] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(15),
-  [371] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [373] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [375] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
-  [377] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_regex, 3),
-  [379] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 4, .production_id = 1),
-  [381] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 4, .production_id = 1),
-  [383] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
-  [385] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer, 1),
-  [387] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_char, 1),
-  [389] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 2),
-  [391] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 1),
-  [393] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6, .production_id = 2),
-  [395] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [397] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [399] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6),
-  [401] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 2),
-  [403] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 1),
-  [405] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 5, .production_id = 1),
-  [407] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 3),
-  [409] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 4),
-  [411] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bool, 1),
-  [413] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 4),
-  [415] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commandLiteral, 3),
-  [417] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [419] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [421] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [423] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
-  [425] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
-  [427] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [429] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
-  [431] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [433] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [435] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [437] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
-  [439] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
-  [441] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [443] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [445] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
-  [447] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [449] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
-  [451] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [453] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [455] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [457] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [459] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
+  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(115),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
+  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(119),
+  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(126),
+  [47] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(113),
+  [50] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(113),
+  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(114),
+  [56] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(114),
+  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(21),
+  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(73),
+  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(115),
+  [68] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(115),
+  [71] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(11),
+  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(3),
+  [77] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(148),
+  [80] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(117),
+  [83] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(145),
+  [86] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(144),
+  [89] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
+  [91] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
+  [93] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
+  [95] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [97] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
+  [99] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [101] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [107] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [109] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
+  [111] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
+  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
+  [125] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
+  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
+  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
+  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
+  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statement, 2),
+  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statement, 2),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [173] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
+  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [183] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
+  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [187] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
+  [189] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 1),
+  [191] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [193] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
+  [195] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 4),
+  [197] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 3),
+  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 4),
+  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_regex, 3),
+  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6),
+  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bool, 1),
+  [207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
+  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 1),
+  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 5, .production_id = 1),
+  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
+  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commandLiteral, 3),
+  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 2),
+  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6, .production_id = 2),
+  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 3),
+  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
+  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 2),
+  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
+  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char, 1),
+  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer, 1),
+  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
+  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
+  [253] = {.entry = {.count = 1, .reusable = false}}, SHIFT(102),
+  [255] = {.entry = {.count = 1, .reusable = false}}, SHIFT(95),
+  [257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [263] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 3), SHIFT_REPEAT(8),
+  [266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 3),
+  [268] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [270] = {.entry = {.count = 1, .reusable = false}}, SHIFT(89),
+  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
+  [276] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 3), SHIFT_REPEAT(57),
+  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 3),
+  [281] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
+  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [289] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [293] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [295] = {.entry = {.count = 1, .reusable = false}}, SHIFT(98),
+  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [301] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [303] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
+  [305] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
+  [307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [309] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
+  [311] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
+  [313] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(12),
+  [316] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
+  [318] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [320] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
+  [322] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
+  [324] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
+  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [328] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
+  [330] = {.entry = {.count = 1, .reusable = false}}, SHIFT(91),
+  [332] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
+  [334] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [336] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 2), SHIFT_REPEAT(89),
+  [339] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [341] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [343] = {.entry = {.count = 1, .reusable = false}}, SHIFT(101),
+  [345] = {.entry = {.count = 1, .reusable = false}}, SHIFT(94),
+  [347] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [349] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
+  [351] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
+  [353] = {.entry = {.count = 1, .reusable = false}}, SHIFT(104),
+  [355] = {.entry = {.count = 1, .reusable = false}}, SHIFT(105),
+  [357] = {.entry = {.count = 1, .reusable = false}}, SHIFT(100),
+  [359] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [361] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [363] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
+  [365] = {.entry = {.count = 1, .reusable = false}}, SHIFT(90),
+  [367] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
+  [369] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(15),
+  [372] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
+  [374] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
+  [376] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
+  [378] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_regex, 3),
+  [380] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 4, .production_id = 1),
+  [382] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 4, .production_id = 1),
+  [384] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
+  [386] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer, 1),
+  [388] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_char, 1),
+  [390] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 2),
+  [392] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 1),
+  [394] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6, .production_id = 2),
+  [396] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [398] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [400] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6),
+  [402] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 2),
+  [404] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 1),
+  [406] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 5, .production_id = 1),
+  [408] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 3),
+  [410] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 4),
+  [412] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bool, 1),
+  [414] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 4),
+  [416] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commandLiteral, 3),
+  [418] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [420] = {.entry = {.count = 1, .reusable = false}}, SHIFT(150),
+  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [424] = {.entry = {.count = 1, .reusable = false}}, SHIFT(131),
+  [426] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
+  [430] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
+  [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [434] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [436] = {.entry = {.count = 1, .reusable = false}}, SHIFT(138),
+  [438] = {.entry = {.count = 1, .reusable = false}}, SHIFT(152),
+  [440] = {.entry = {.count = 1, .reusable = false}}, SHIFT(120),
+  [442] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [444] = {.entry = {.count = 1, .reusable = false}}, SHIFT(129),
+  [446] = {.entry = {.count = 1, .reusable = false}}, SHIFT(133),
+  [448] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [450] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
+  [452] = {.entry = {.count = 1, .reusable = false}}, SHIFT(134),
+  [454] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [456] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [458] = {.entry = {.count = 1, .reusable = false}}, SHIFT(147),
+  [460] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,11 +6,11 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 181
+#define STATE_COUNT 182
 #define LARGE_STATE_COUNT 22
-#define SYMBOL_COUNT 104
+#define SYMBOL_COUNT 108
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 77
+#define TOKEN_COUNT 81
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 4
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
@@ -66,60 +66,64 @@ enum {
   aux_sym_local_variable_token1 = 47,
   anon_sym_AT = 48,
   anon_sym_AT_AT = 49,
-  aux_sym_constant_token1 = 50,
-  anon_sym_EQ = 51,
-  anon_sym_PLUS = 52,
-  anon_sym_DASH = 53,
-  anon_sym_STAR = 54,
-  anon_sym_PERCENT = 55,
-  anon_sym_AMP = 56,
-  anon_sym_PIPE = 57,
-  anon_sym_CARET = 58,
-  anon_sym_STAR_STAR = 59,
-  anon_sym_GT_GT = 60,
-  anon_sym_LT_LT = 61,
-  anon_sym_EQ_EQ = 62,
-  anon_sym_BANG_EQ = 63,
-  anon_sym_LT = 64,
-  anon_sym_LT_EQ = 65,
-  anon_sym_GT = 66,
-  anon_sym_GT_EQ = 67,
-  anon_sym_LT_EQ_GT = 68,
-  anon_sym_EQ_EQ_EQ = 69,
-  anon_sym_LBRACK_RBRACK = 70,
-  anon_sym_LBRACK_RBRACK_QMARK = 71,
-  anon_sym_LBRACK_RBRACK_EQ = 72,
-  anon_sym_BANG = 73,
-  anon_sym_TILDE = 74,
-  anon_sym_BANG_TILDE = 75,
-  anon_sym_EQ_TILDE = 76,
-  sym_program = 77,
-  sym__statement = 78,
-  sym__expression = 79,
-  sym_identifier = 80,
-  sym_bool = 81,
-  sym_float = 82,
-  sym_integer = 83,
-  sym_symbol = 84,
-  sym_char = 85,
-  sym_string = 86,
-  sym_array = 87,
-  sym_hash = 88,
-  sym_regex = 89,
-  sym_tuple = 90,
-  sym_namedTupleLiteral = 91,
-  sym_commandLiteral = 92,
-  sym_local_variable = 93,
-  sym_instance_variable = 94,
-  sym_class_variable = 95,
-  sym_constant = 96,
-  sym_assignment = 97,
-  sym__operator = 98,
-  aux_sym_program_repeat1 = 99,
-  aux_sym_symbol_repeat1 = 100,
-  aux_sym_array_repeat1 = 101,
-  aux_sym_hash_repeat1 = 102,
-  aux_sym_namedTupleLiteral_repeat1 = 103,
+  anon_sym___LINE__ = 50,
+  anon_sym___END_LINE__ = 51,
+  anon_sym___FILE__ = 52,
+  anon_sym___DIR__ = 53,
+  aux_sym_constant_token1 = 54,
+  anon_sym_EQ = 55,
+  anon_sym_PLUS = 56,
+  anon_sym_DASH = 57,
+  anon_sym_STAR = 58,
+  anon_sym_PERCENT = 59,
+  anon_sym_AMP = 60,
+  anon_sym_PIPE = 61,
+  anon_sym_CARET = 62,
+  anon_sym_STAR_STAR = 63,
+  anon_sym_GT_GT = 64,
+  anon_sym_LT_LT = 65,
+  anon_sym_EQ_EQ = 66,
+  anon_sym_BANG_EQ = 67,
+  anon_sym_LT = 68,
+  anon_sym_LT_EQ = 69,
+  anon_sym_GT = 70,
+  anon_sym_GT_EQ = 71,
+  anon_sym_LT_EQ_GT = 72,
+  anon_sym_EQ_EQ_EQ = 73,
+  anon_sym_LBRACK_RBRACK = 74,
+  anon_sym_LBRACK_RBRACK_QMARK = 75,
+  anon_sym_LBRACK_RBRACK_EQ = 76,
+  anon_sym_BANG = 77,
+  anon_sym_TILDE = 78,
+  anon_sym_BANG_TILDE = 79,
+  anon_sym_EQ_TILDE = 80,
+  sym_program = 81,
+  sym__statement = 82,
+  sym__expression = 83,
+  sym_identifier = 84,
+  sym_bool = 85,
+  sym_float = 86,
+  sym_integer = 87,
+  sym_symbol = 88,
+  sym_char = 89,
+  sym_string = 90,
+  sym_array = 91,
+  sym_hash = 92,
+  sym_regex = 93,
+  sym_tuple = 94,
+  sym_namedTupleLiteral = 95,
+  sym_commandLiteral = 96,
+  sym_local_variable = 97,
+  sym_instance_variable = 98,
+  sym_class_variable = 99,
+  sym_constant = 100,
+  sym_assignment = 101,
+  sym__operator = 102,
+  aux_sym_program_repeat1 = 103,
+  aux_sym_symbol_repeat1 = 104,
+  aux_sym_array_repeat1 = 105,
+  aux_sym_hash_repeat1 = 106,
+  aux_sym_namedTupleLiteral_repeat1 = 107,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -173,6 +177,10 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_local_variable_token1] = "local_variable_token1",
   [anon_sym_AT] = "@",
   [anon_sym_AT_AT] = "@@",
+  [anon_sym___LINE__] = "__LINE__",
+  [anon_sym___END_LINE__] = "__END_LINE__",
+  [anon_sym___FILE__] = "__FILE__",
+  [anon_sym___DIR__] = "__DIR__",
   [aux_sym_constant_token1] = "constant_token1",
   [anon_sym_EQ] = "=",
   [anon_sym_PLUS] = "+",
@@ -280,6 +288,10 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_local_variable_token1] = aux_sym_local_variable_token1,
   [anon_sym_AT] = anon_sym_AT,
   [anon_sym_AT_AT] = anon_sym_AT_AT,
+  [anon_sym___LINE__] = anon_sym___LINE__,
+  [anon_sym___END_LINE__] = anon_sym___END_LINE__,
+  [anon_sym___FILE__] = anon_sym___FILE__,
+  [anon_sym___DIR__] = anon_sym___DIR__,
   [aux_sym_constant_token1] = aux_sym_constant_token1,
   [anon_sym_EQ] = anon_sym_EQ,
   [anon_sym_PLUS] = anon_sym_PLUS,
@@ -534,6 +546,22 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_AT_AT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym___LINE__] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym___END_LINE__] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym___FILE__] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym___DIR__] = {
     .visible = true,
     .named = false,
   },
@@ -809,83 +837,84 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(89);
-      if (lookahead == '!') ADVANCE(217);
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(87);
-      if (lookahead == '%') ADVANCE(199);
-      if (lookahead == '&') ADVANCE(200);
+      if (eof) ADVANCE(113);
+      if (lookahead == '!') ADVANCE(275);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(111);
+      if (lookahead == '%') ADVANCE(257);
+      if (lookahead == '&') ADVANCE(258);
       if (lookahead == '\'') ADVANCE(16);
-      if (lookahead == ')') ADVANCE(181);
-      if (lookahead == '*') ADVANCE(197);
-      if (lookahead == '+') ADVANCE(194);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == '-') ADVANCE(196);
-      if (lookahead == '/') ADVANCE(166);
+      if (lookahead == ')') ADVANCE(230);
+      if (lookahead == '*') ADVANCE(255);
+      if (lookahead == '+') ADVANCE(252);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == '-') ADVANCE(254);
+      if (lookahead == '/') ADVANCE(215);
       if (lookahead == '0') ADVANCE(31);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == ';') ADVANCE(90);
-      if (lookahead == '<') ADVANCE(208);
-      if (lookahead == '=') ADVANCE(192);
-      if (lookahead == '>') ADVANCE(210);
-      if (lookahead == '@') ADVANCE(187);
-      if (lookahead == 'T') ADVANCE(106);
-      if (lookahead == '[') ADVANCE(157);
-      if (lookahead == ']') ADVANCE(159);
-      if (lookahead == '^') ADVANCE(202);
-      if (lookahead == '`') ADVANCE(173);
-      if (lookahead == 'f') ADVANCE(95);
-      if (lookahead == 'n') ADVANCE(99);
-      if (lookahead == 't') ADVANCE(104);
-      if (lookahead == '{') ADVANCE(160);
-      if (lookahead == '|') ADVANCE(201);
-      if (lookahead == '}') ADVANCE(162);
-      if (lookahead == '~') ADVANCE(218);
+      if (lookahead == ':') ADVANCE(178);
+      if (lookahead == ';') ADVANCE(114);
+      if (lookahead == '<') ADVANCE(266);
+      if (lookahead == '=') ADVANCE(250);
+      if (lookahead == '>') ADVANCE(268);
+      if (lookahead == '@') ADVANCE(237);
+      if (lookahead == 'T') ADVANCE(155);
+      if (lookahead == '[') ADVANCE(206);
+      if (lookahead == ']') ADVANCE(208);
+      if (lookahead == '^') ADVANCE(260);
+      if (lookahead == '_') ADVANCE(134);
+      if (lookahead == '`') ADVANCE(222);
+      if (lookahead == 'f') ADVANCE(144);
+      if (lookahead == 'n') ADVANCE(148);
+      if (lookahead == 't') ADVANCE(153);
+      if (lookahead == '{') ADVANCE(209);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '}') ADVANCE(211);
+      if (lookahead == '~') ADVANCE(276);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(108);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(108);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(157);
       if (lookahead != 0 &&
-          lookahead > 159) ADVANCE(108);
+          lookahead > 159) ADVANCE(157);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(91);
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ';') ADVANCE(90);
+      if (lookahead == '\n') ADVANCE(115);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ';') ADVANCE(114);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(132);
-      if (lookahead != 0) ADVANCE(131);
+          lookahead == ' ') ADVANCE(181);
+      if (lookahead != 0) ADVANCE(180);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(92);
-      if (lookahead == '#') ADVANCE(87);
-      if (lookahead == ';') ADVANCE(90);
+      if (lookahead == '\n') ADVANCE(116);
+      if (lookahead == '#') ADVANCE(111);
+      if (lookahead == ';') ADVANCE(114);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
-      if (lookahead == '!') ADVANCE(217);
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(87);
-      if (lookahead == '%') ADVANCE(198);
-      if (lookahead == '&') ADVANCE(200);
-      if (lookahead == '*') ADVANCE(197);
-      if (lookahead == '+') ADVANCE(193);
-      if (lookahead == '-') ADVANCE(195);
-      if (lookahead == '/') ADVANCE(166);
-      if (lookahead == '<') ADVANCE(208);
+      if (lookahead == '!') ADVANCE(275);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(111);
+      if (lookahead == '%') ADVANCE(256);
+      if (lookahead == '&') ADVANCE(258);
+      if (lookahead == '*') ADVANCE(255);
+      if (lookahead == '+') ADVANCE(251);
+      if (lookahead == '-') ADVANCE(253);
+      if (lookahead == '/') ADVANCE(215);
+      if (lookahead == '<') ADVANCE(266);
       if (lookahead == '=') ADVANCE(60);
-      if (lookahead == '>') ADVANCE(210);
-      if (lookahead == '[') ADVANCE(62);
-      if (lookahead == '^') ADVANCE(202);
-      if (lookahead == '|') ADVANCE(201);
-      if (lookahead == '~') ADVANCE(218);
+      if (lookahead == '>') ADVANCE(268);
+      if (lookahead == '[') ADVANCE(77);
+      if (lookahead == '^') ADVANCE(260);
+      if (lookahead == '|') ADVANCE(259);
+      if (lookahead == '~') ADVANCE(276);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -895,117 +924,118 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\\' &&
           lookahead != ']' &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
       END_STATE();
     case 4:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(87);
-      if (lookahead == '%') ADVANCE(76);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(111);
+      if (lookahead == '%') ADVANCE(100);
       if (lookahead == '\'') ADVANCE(16);
-      if (lookahead == '/') ADVANCE(166);
+      if (lookahead == '/') ADVANCE(215);
       if (lookahead == '0') ADVANCE(31);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == '=') ADVANCE(191);
-      if (lookahead == '@') ADVANCE(187);
-      if (lookahead == 'T') ADVANCE(106);
-      if (lookahead == '[') ADVANCE(156);
-      if (lookahead == '`') ADVANCE(173);
-      if (lookahead == 'f') ADVANCE(95);
-      if (lookahead == 'n') ADVANCE(99);
-      if (lookahead == 't') ADVANCE(104);
-      if (lookahead == '{') ADVANCE(160);
-      if (lookahead == '}') ADVANCE(162);
+      if (lookahead == ':') ADVANCE(178);
+      if (lookahead == '=') ADVANCE(249);
+      if (lookahead == '@') ADVANCE(237);
+      if (lookahead == 'T') ADVANCE(155);
+      if (lookahead == '[') ADVANCE(205);
+      if (lookahead == '_') ADVANCE(134);
+      if (lookahead == '`') ADVANCE(222);
+      if (lookahead == 'f') ADVANCE(144);
+      if (lookahead == 'n') ADVANCE(148);
+      if (lookahead == 't') ADVANCE(153);
+      if (lookahead == '{') ADVANCE(209);
+      if (lookahead == '}') ADVANCE(211);
       if (lookahead == '+' ||
           lookahead == '-') ADVANCE(34);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(4)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(108);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(108);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(157);
       if (lookahead != 0 &&
-          lookahead > 159) ADVANCE(108);
+          lookahead > 159) ADVANCE(157);
       END_STATE();
     case 5:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == '=') ADVANCE(140);
-      if (lookahead == '}') ADVANCE(162);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == ':') ADVANCE(178);
+      if (lookahead == '=') ADVANCE(189);
+      if (lookahead == '}') ADVANCE(211);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(133);
-      if (lookahead != 0) ADVANCE(131);
+          lookahead == ' ') ADVANCE(182);
+      if (lookahead != 0) ADVANCE(180);
       END_STATE();
     case 6:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == '=') ADVANCE(140);
-      if (lookahead == '}') ADVANCE(162);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == '=') ADVANCE(189);
+      if (lookahead == '}') ADVANCE(211);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(134);
-      if (lookahead != 0) ADVANCE(131);
+          lookahead == ' ') ADVANCE(183);
+      if (lookahead != 0) ADVANCE(180);
       END_STATE();
     case 7:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == ']') ADVANCE(159);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == ']') ADVANCE(208);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(135);
-      if (lookahead != 0) ADVANCE(131);
+          lookahead == ' ') ADVANCE(184);
+      if (lookahead != 0) ADVANCE(180);
       END_STATE();
     case 8:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == '}') ADVANCE(162);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == '}') ADVANCE(211);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0) ADVANCE(131);
+          lookahead == ' ') ADVANCE(185);
+      if (lookahead != 0) ADVANCE(180);
       END_STATE();
     case 9:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ':') ADVANCE(178);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(137);
-      if (lookahead != 0) ADVANCE(131);
+          lookahead == ' ') ADVANCE(186);
+      if (lookahead != 0) ADVANCE(180);
       END_STATE();
     case 10:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == '=') ADVANCE(140);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == '=') ADVANCE(189);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(138);
-      if (lookahead != 0) ADVANCE(131);
+          lookahead == ' ') ADVANCE(187);
+      if (lookahead != 0) ADVANCE(180);
       END_STATE();
     case 11:
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(141);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(190);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(139);
-      if (lookahead != 0) ADVANCE(131);
+          lookahead == ' ') ADVANCE(188);
+      if (lookahead != 0) ADVANCE(180);
       END_STATE();
     case 12:
-      if (lookahead == '#') ADVANCE(87);
-      if (lookahead == '=') ADVANCE(191);
+      if (lookahead == '#') ADVANCE(111);
+      if (lookahead == '=') ADVANCE(249);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -1014,40 +1044,40 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead > '@' &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
       END_STATE();
     case 13:
-      if (lookahead == '#') ADVANCE(87);
-      if (lookahead == 'o') ADVANCE(67);
+      if (lookahead == '#') ADVANCE(111);
+      if (lookahead == 'o') ADVANCE(91);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(13)
       END_STATE();
     case 14:
-      if (lookahead == '#') ADVANCE(87);
+      if (lookahead == '#') ADVANCE(111);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(14)
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(183);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(232);
       END_STATE();
     case 15:
-      if (lookahead == '#') ADVANCE(164);
+      if (lookahead == '#') ADVANCE(213);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(15)
-      if (lookahead != 0) ADVANCE(165);
+      if (lookahead != 0) ADVANCE(214);
       END_STATE();
     case 16:
-      if (lookahead == '\'') ADVANCE(142);
+      if (lookahead == '\'') ADVANCE(191);
       if (lookahead == '\\') ADVANCE(17);
       if (lookahead != 0) ADVANCE(18);
       END_STATE();
     case 17:
-      if (lookahead == '\'') ADVANCE(155);
+      if (lookahead == '\'') ADVANCE(204);
       if (lookahead == '\\') ADVANCE(19);
       if (lookahead == 'a') ADVANCE(20);
       if (lookahead == 'b') ADVANCE(21);
@@ -1056,120 +1086,120 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'n') ADVANCE(24);
       if (lookahead == 'r') ADVANCE(25);
       if (lookahead == 't') ADVANCE(26);
-      if (lookahead == 'u') ADVANCE(77);
+      if (lookahead == 'u') ADVANCE(101);
       if (lookahead == 'v') ADVANCE(27);
       END_STATE();
     case 18:
-      if (lookahead == '\'') ADVANCE(154);
+      if (lookahead == '\'') ADVANCE(203);
       END_STATE();
     case 19:
-      if (lookahead == '\'') ADVANCE(144);
+      if (lookahead == '\'') ADVANCE(193);
       END_STATE();
     case 20:
-      if (lookahead == '\'') ADVANCE(145);
+      if (lookahead == '\'') ADVANCE(194);
       END_STATE();
     case 21:
-      if (lookahead == '\'') ADVANCE(146);
+      if (lookahead == '\'') ADVANCE(195);
       END_STATE();
     case 22:
-      if (lookahead == '\'') ADVANCE(147);
+      if (lookahead == '\'') ADVANCE(196);
       END_STATE();
     case 23:
-      if (lookahead == '\'') ADVANCE(148);
+      if (lookahead == '\'') ADVANCE(197);
       END_STATE();
     case 24:
-      if (lookahead == '\'') ADVANCE(149);
+      if (lookahead == '\'') ADVANCE(198);
       END_STATE();
     case 25:
-      if (lookahead == '\'') ADVANCE(150);
+      if (lookahead == '\'') ADVANCE(199);
       END_STATE();
     case 26:
-      if (lookahead == '\'') ADVANCE(151);
+      if (lookahead == '\'') ADVANCE(200);
       END_STATE();
     case 27:
-      if (lookahead == '\'') ADVANCE(152);
+      if (lookahead == '\'') ADVANCE(201);
       END_STATE();
     case 28:
-      if (lookahead == '\'') ADVANCE(153);
+      if (lookahead == '\'') ADVANCE(202);
       END_STATE();
     case 29:
-      if (lookahead == '\'') ADVANCE(153);
+      if (lookahead == '\'') ADVANCE(202);
       if (lookahead == '}') ADVANCE(28);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
       END_STATE();
     case 30:
-      if (lookahead == '(') ADVANCE(177);
+      if (lookahead == '(') ADVANCE(226);
       END_STATE();
     case 31:
-      if (lookahead == '.') ADVANCE(84);
-      if (lookahead == 'b') ADVANCE(80);
-      if (lookahead == 'e') ADVANCE(78);
+      if (lookahead == '.') ADVANCE(108);
+      if (lookahead == 'b') ADVANCE(104);
+      if (lookahead == 'e') ADVANCE(102);
       if (lookahead == 'f') ADVANCE(46);
-      if (lookahead == 'o') ADVANCE(81);
-      if (lookahead == 'x') ADVANCE(85);
+      if (lookahead == 'o') ADVANCE(105);
+      if (lookahead == 'x') ADVANCE(109);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(32);
       END_STATE();
     case 32:
-      if (lookahead == '.') ADVANCE(84);
-      if (lookahead == 'e') ADVANCE(78);
+      if (lookahead == '.') ADVANCE(108);
+      if (lookahead == 'e') ADVANCE(102);
       if (lookahead == 'f') ADVANCE(46);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(32);
       END_STATE();
     case 33:
-      if (lookahead == '.') ADVANCE(71);
+      if (lookahead == '.') ADVANCE(95);
       END_STATE();
     case 34:
       if (lookahead == '0') ADVANCE(31);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
       END_STATE();
     case 35:
       if (lookahead == '1') ADVANCE(56);
       if (lookahead == '3') ADVANCE(39);
       if (lookahead == '6') ADVANCE(49);
-      if (lookahead == '8') ADVANCE(127);
+      if (lookahead == '8') ADVANCE(176);
       END_STATE();
     case 36:
       if (lookahead == '1') ADVANCE(57);
       if (lookahead == '3') ADVANCE(41);
       if (lookahead == '6') ADVANCE(51);
-      if (lookahead == '8') ADVANCE(121);
+      if (lookahead == '8') ADVANCE(170);
       END_STATE();
     case 37:
       if (lookahead == '1') ADVANCE(58);
       if (lookahead == '3') ADVANCE(42);
       if (lookahead == '6') ADVANCE(52);
-      if (lookahead == '8') ADVANCE(123);
+      if (lookahead == '8') ADVANCE(172);
       END_STATE();
     case 38:
       if (lookahead == '1') ADVANCE(59);
       if (lookahead == '3') ADVANCE(43);
       if (lookahead == '6') ADVANCE(53);
-      if (lookahead == '8') ADVANCE(125);
+      if (lookahead == '8') ADVANCE(174);
       END_STATE();
     case 39:
-      if (lookahead == '2') ADVANCE(127);
+      if (lookahead == '2') ADVANCE(176);
       END_STATE();
     case 40:
-      if (lookahead == '2') ADVANCE(120);
+      if (lookahead == '2') ADVANCE(169);
       END_STATE();
     case 41:
-      if (lookahead == '2') ADVANCE(121);
+      if (lookahead == '2') ADVANCE(170);
       END_STATE();
     case 42:
-      if (lookahead == '2') ADVANCE(123);
+      if (lookahead == '2') ADVANCE(172);
       END_STATE();
     case 43:
-      if (lookahead == '2') ADVANCE(125);
+      if (lookahead == '2') ADVANCE(174);
       END_STATE();
     case 44:
-      if (lookahead == '2') ADVANCE(115);
+      if (lookahead == '2') ADVANCE(164);
       END_STATE();
     case 45:
-      if (lookahead == '2') ADVANCE(118);
+      if (lookahead == '2') ADVANCE(167);
       END_STATE();
     case 46:
       if (lookahead == '3') ADVANCE(40);
@@ -1184,926 +1214,1384 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '6') ADVANCE(55);
       END_STATE();
     case 49:
-      if (lookahead == '4') ADVANCE(127);
+      if (lookahead == '4') ADVANCE(176);
       END_STATE();
     case 50:
-      if (lookahead == '4') ADVANCE(120);
+      if (lookahead == '4') ADVANCE(169);
       END_STATE();
     case 51:
-      if (lookahead == '4') ADVANCE(121);
+      if (lookahead == '4') ADVANCE(170);
       END_STATE();
     case 52:
-      if (lookahead == '4') ADVANCE(123);
+      if (lookahead == '4') ADVANCE(172);
       END_STATE();
     case 53:
-      if (lookahead == '4') ADVANCE(125);
+      if (lookahead == '4') ADVANCE(174);
       END_STATE();
     case 54:
-      if (lookahead == '4') ADVANCE(115);
+      if (lookahead == '4') ADVANCE(164);
       END_STATE();
     case 55:
-      if (lookahead == '4') ADVANCE(118);
+      if (lookahead == '4') ADVANCE(167);
       END_STATE();
     case 56:
-      if (lookahead == '6') ADVANCE(127);
+      if (lookahead == '6') ADVANCE(176);
       END_STATE();
     case 57:
-      if (lookahead == '6') ADVANCE(121);
+      if (lookahead == '6') ADVANCE(170);
       END_STATE();
     case 58:
-      if (lookahead == '6') ADVANCE(123);
+      if (lookahead == '6') ADVANCE(172);
       END_STATE();
     case 59:
-      if (lookahead == '6') ADVANCE(125);
+      if (lookahead == '6') ADVANCE(174);
       END_STATE();
     case 60:
-      if (lookahead == '=') ADVANCE(206);
-      if (lookahead == '~') ADVANCE(220);
+      if (lookahead == '=') ADVANCE(264);
+      if (lookahead == '~') ADVANCE(278);
       END_STATE();
     case 61:
-      if (lookahead == '>') ADVANCE(161);
+      if (lookahead == '>') ADVANCE(210);
       END_STATE();
     case 62:
-      if (lookahead == ']') ADVANCE(214);
+      if (lookahead == 'D') ADVANCE(67);
+      if (lookahead == 'E') ADVANCE(73);
+      if (lookahead == 'F') ADVANCE(68);
+      if (lookahead == 'L') ADVANCE(69);
       END_STATE();
     case 63:
-      if (lookahead == 'e') ADVANCE(75);
+      if (lookahead == 'D') ADVANCE(82);
       END_STATE();
     case 64:
-      if (lookahead == 'e') ADVANCE(111);
+      if (lookahead == 'E') ADVANCE(84);
       END_STATE();
     case 65:
-      if (lookahead == 'e') ADVANCE(33);
+      if (lookahead == 'E') ADVANCE(85);
       END_STATE();
     case 66:
-      if (lookahead == 'e') ADVANCE(113);
+      if (lookahead == 'E') ADVANCE(86);
       END_STATE();
     case 67:
-      if (lookahead == 'f') ADVANCE(163);
+      if (lookahead == 'I') ADVANCE(76);
       END_STATE();
     case 68:
-      if (lookahead == 'l') ADVANCE(73);
+      if (lookahead == 'I') ADVANCE(71);
       END_STATE();
     case 69:
-      if (lookahead == 'l') ADVANCE(109);
+      if (lookahead == 'I') ADVANCE(74);
       END_STATE();
     case 70:
-      if (lookahead == 'l') ADVANCE(65);
+      if (lookahead == 'I') ADVANCE(75);
       END_STATE();
     case 71:
-      if (lookahead == 'n') ADVANCE(63);
+      if (lookahead == 'L') ADVANCE(64);
       END_STATE();
     case 72:
-      if (lookahead == 'p') ADVANCE(70);
+      if (lookahead == 'L') ADVANCE(70);
       END_STATE();
     case 73:
-      if (lookahead == 's') ADVANCE(66);
+      if (lookahead == 'N') ADVANCE(63);
       END_STATE();
     case 74:
-      if (lookahead == 'u') ADVANCE(64);
+      if (lookahead == 'N') ADVANCE(65);
       END_STATE();
     case 75:
-      if (lookahead == 'w') ADVANCE(172);
+      if (lookahead == 'N') ADVANCE(66);
       END_STATE();
     case 76:
-      if (lookahead == 'x') ADVANCE(30);
+      if (lookahead == 'R') ADVANCE(83);
       END_STATE();
     case 77:
-      if (lookahead == '{') ADVANCE(86);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
+      if (lookahead == ']') ADVANCE(272);
       END_STATE();
     case 78:
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(82);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
+      if (lookahead == '_') ADVANCE(245);
       END_STATE();
     case 79:
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(83);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
+      if (lookahead == '_') ADVANCE(243);
       END_STATE();
     case 80:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(122);
+      if (lookahead == '_') ADVANCE(239);
       END_STATE();
     case 81:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(124);
+      if (lookahead == '_') ADVANCE(241);
       END_STATE();
     case 82:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
+      if (lookahead == '_') ADVANCE(72);
       END_STATE();
     case 83:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
+      if (lookahead == '_') ADVANCE(78);
       END_STATE();
     case 84:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(116);
+      if (lookahead == '_') ADVANCE(79);
       END_STATE();
     case 85:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(126);
+      if (lookahead == '_') ADVANCE(80);
       END_STATE();
     case 86:
+      if (lookahead == '_') ADVANCE(81);
+      END_STATE();
+    case 87:
+      if (lookahead == 'e') ADVANCE(99);
+      END_STATE();
+    case 88:
+      if (lookahead == 'e') ADVANCE(160);
+      END_STATE();
+    case 89:
+      if (lookahead == 'e') ADVANCE(33);
+      END_STATE();
+    case 90:
+      if (lookahead == 'e') ADVANCE(162);
+      END_STATE();
+    case 91:
+      if (lookahead == 'f') ADVANCE(212);
+      END_STATE();
+    case 92:
+      if (lookahead == 'l') ADVANCE(97);
+      END_STATE();
+    case 93:
+      if (lookahead == 'l') ADVANCE(158);
+      END_STATE();
+    case 94:
+      if (lookahead == 'l') ADVANCE(89);
+      END_STATE();
+    case 95:
+      if (lookahead == 'n') ADVANCE(87);
+      END_STATE();
+    case 96:
+      if (lookahead == 'p') ADVANCE(94);
+      END_STATE();
+    case 97:
+      if (lookahead == 's') ADVANCE(90);
+      END_STATE();
+    case 98:
+      if (lookahead == 'u') ADVANCE(88);
+      END_STATE();
+    case 99:
+      if (lookahead == 'w') ADVANCE(221);
+      END_STATE();
+    case 100:
+      if (lookahead == 'x') ADVANCE(30);
+      END_STATE();
+    case 101:
+      if (lookahead == '{') ADVANCE(110);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
       END_STATE();
-    case 87:
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(182);
+    case 102:
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(106);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(168);
       END_STATE();
-    case 88:
-      if (eof) ADVANCE(89);
-      if (lookahead == '"') ADVANCE(130);
-      if (lookahead == '#') ADVANCE(87);
-      if (lookahead == '%') ADVANCE(76);
+    case 103:
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(107);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(166);
+      END_STATE();
+    case 104:
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(171);
+      END_STATE();
+    case 105:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(173);
+      END_STATE();
+    case 106:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(168);
+      END_STATE();
+    case 107:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(166);
+      END_STATE();
+    case 108:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(165);
+      END_STATE();
+    case 109:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(175);
+      END_STATE();
+    case 110:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
+      END_STATE();
+    case 111:
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(231);
+      END_STATE();
+    case 112:
+      if (eof) ADVANCE(113);
+      if (lookahead == '"') ADVANCE(179);
+      if (lookahead == '#') ADVANCE(111);
+      if (lookahead == '%') ADVANCE(100);
       if (lookahead == '\'') ADVANCE(16);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == '/') ADVANCE(166);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == '/') ADVANCE(215);
       if (lookahead == '0') ADVANCE(31);
-      if (lookahead == ':') ADVANCE(129);
+      if (lookahead == ':') ADVANCE(178);
       if (lookahead == '=') ADVANCE(61);
-      if (lookahead == '@') ADVANCE(187);
-      if (lookahead == 'T') ADVANCE(190);
-      if (lookahead == '[') ADVANCE(156);
-      if (lookahead == ']') ADVANCE(159);
-      if (lookahead == '`') ADVANCE(173);
-      if (lookahead == 'f') ADVANCE(184);
-      if (lookahead == 'n') ADVANCE(185);
-      if (lookahead == 't') ADVANCE(186);
-      if (lookahead == '{') ADVANCE(160);
-      if (lookahead == '}') ADVANCE(162);
+      if (lookahead == '@') ADVANCE(237);
+      if (lookahead == 'T') ADVANCE(248);
+      if (lookahead == '[') ADVANCE(205);
+      if (lookahead == ']') ADVANCE(208);
+      if (lookahead == '_') ADVANCE(233);
+      if (lookahead == '`') ADVANCE(222);
+      if (lookahead == 'f') ADVANCE(234);
+      if (lookahead == 'n') ADVANCE(235);
+      if (lookahead == 't') ADVANCE(236);
+      if (lookahead == '{') ADVANCE(209);
+      if (lookahead == '}') ADVANCE(211);
       if (('+' <= lookahead && lookahead <= '-')) ADVANCE(34);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(88)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
-      if (('_' <= lookahead && lookahead <= 'z')) ADVANCE(183);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(189);
-      END_STATE();
-    case 89:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 90:
-      ACCEPT_TOKEN(anon_sym_SEMI);
-      END_STATE();
-    case 91:
-      ACCEPT_TOKEN(aux_sym__statement_token1);
-      if (lookahead == '\n') ADVANCE(91);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(132);
-      END_STATE();
-    case 92:
-      ACCEPT_TOKEN(aux_sym__statement_token1);
-      if (lookahead == '\n') ADVANCE(92);
-      END_STATE();
-    case 93:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      END_STATE();
-    case 94:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '.') ADVANCE(71);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 95:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'a') ADVANCE(100);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 96:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(112);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(94);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 98:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(114);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 99:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'i') ADVANCE(101);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 100:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(105);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(110);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 102:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(97);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 103:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'p') ADVANCE(102);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 104:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'r') ADVANCE(107);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 105:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 's') ADVANCE(98);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 106:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(103);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 107:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(96);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 108:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 109:
-      ACCEPT_TOKEN(sym_nil);
-      END_STATE();
-    case 110:
-      ACCEPT_TOKEN(sym_nil);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(anon_sym_true);
-      END_STATE();
-    case 112:
-      ACCEPT_TOKEN(anon_sym_true);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
+          lookahead == ' ') SKIP(112)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(232);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(247);
       END_STATE();
     case 113:
-      ACCEPT_TOKEN(anon_sym_false);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 114:
-      ACCEPT_TOKEN(anon_sym_false);
+      ACCEPT_TOKEN(anon_sym_SEMI);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(aux_sym__statement_token1);
+      if (lookahead == '\n') ADVANCE(115);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(181);
+      END_STATE();
+    case 116:
+      ACCEPT_TOKEN(aux_sym__statement_token1);
+      if (lookahead == '\n') ADVANCE(116);
+      END_STATE();
+    case 117:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      END_STATE();
+    case 118:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '.') ADVANCE(95);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(93);
+          lookahead == '?') ADVANCE(117);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(108);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(aux_sym_float_token1);
-      END_STATE();
-    case 116:
-      ACCEPT_TOKEN(aux_sym_float_token1);
-      if (lookahead == 'e') ADVANCE(79);
-      if (lookahead == 'f') ADVANCE(47);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(116);
-      END_STATE();
-    case 117:
-      ACCEPT_TOKEN(aux_sym_float_token1);
-      if (lookahead == 'f') ADVANCE(47);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(117);
-      END_STATE();
-    case 118:
-      ACCEPT_TOKEN(aux_sym_float_token2);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
       END_STATE();
     case 119:
-      ACCEPT_TOKEN(aux_sym_float_token2);
-      if (lookahead == 'f') ADVANCE(48);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'D') ADVANCE(124);
+      if (lookahead == 'E') ADVANCE(130);
+      if (lookahead == 'F') ADVANCE(125);
+      if (lookahead == 'L') ADVANCE(126);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
       END_STATE();
     case 120:
-      ACCEPT_TOKEN(aux_sym_float_token3);
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'D') ADVANCE(139);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
       END_STATE();
     case 121:
-      ACCEPT_TOKEN(aux_sym_integer_token1);
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'E') ADVANCE(141);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
       END_STATE();
     case 122:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'E') ADVANCE(142);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'E') ADVANCE(143);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 124:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'I') ADVANCE(133);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 125:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'I') ADVANCE(128);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'I') ADVANCE(131);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'I') ADVANCE(132);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'L') ADVANCE(121);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 129:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'L') ADVANCE(127);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'N') ADVANCE(120);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'N') ADVANCE(122);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 132:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'N') ADVANCE(123);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'R') ADVANCE(140);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(119);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(246);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 136:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(244);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 137:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(240);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 138:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(242);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 139:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(129);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 140:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(135);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(136);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 142:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(137);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 143:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(138);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 144:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'a') ADVANCE(149);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 145:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'e') ADVANCE(161);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 146:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'e') ADVANCE(118);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 147:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'e') ADVANCE(163);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 148:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'i') ADVANCE(150);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 149:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'l') ADVANCE(154);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 150:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'l') ADVANCE(159);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 151:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'l') ADVANCE(146);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 152:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'p') ADVANCE(151);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 153:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'r') ADVANCE(156);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 154:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 's') ADVANCE(147);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 155:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'u') ADVANCE(152);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 156:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'u') ADVANCE(145);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 157:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 158:
+      ACCEPT_TOKEN(sym_nil);
+      END_STATE();
+    case 159:
+      ACCEPT_TOKEN(sym_nil);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 160:
+      ACCEPT_TOKEN(anon_sym_true);
+      END_STATE();
+    case 161:
+      ACCEPT_TOKEN(anon_sym_true);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 162:
+      ACCEPT_TOKEN(anon_sym_false);
+      END_STATE();
+    case 163:
+      ACCEPT_TOKEN(anon_sym_false);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 164:
+      ACCEPT_TOKEN(aux_sym_float_token1);
+      END_STATE();
+    case 165:
+      ACCEPT_TOKEN(aux_sym_float_token1);
+      if (lookahead == 'e') ADVANCE(103);
+      if (lookahead == 'f') ADVANCE(47);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(165);
+      END_STATE();
+    case 166:
+      ACCEPT_TOKEN(aux_sym_float_token1);
+      if (lookahead == 'f') ADVANCE(47);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(166);
+      END_STATE();
+    case 167:
+      ACCEPT_TOKEN(aux_sym_float_token2);
+      END_STATE();
+    case 168:
+      ACCEPT_TOKEN(aux_sym_float_token2);
+      if (lookahead == 'f') ADVANCE(48);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(168);
+      END_STATE();
+    case 169:
+      ACCEPT_TOKEN(aux_sym_float_token3);
+      END_STATE();
+    case 170:
+      ACCEPT_TOKEN(aux_sym_integer_token1);
+      END_STATE();
+    case 171:
       ACCEPT_TOKEN(aux_sym_integer_token1);
       if (lookahead == 'i') ADVANCE(36);
       if (lookahead == 'u') ADVANCE(36);
       if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(122);
+          lookahead == '1') ADVANCE(171);
       END_STATE();
-    case 123:
+    case 172:
       ACCEPT_TOKEN(aux_sym_integer_token2);
       END_STATE();
-    case 124:
+    case 173:
       ACCEPT_TOKEN(aux_sym_integer_token2);
       if (lookahead == 'i') ADVANCE(37);
       if (lookahead == 'u') ADVANCE(37);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(124);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(173);
       END_STATE();
-    case 125:
+    case 174:
       ACCEPT_TOKEN(aux_sym_integer_token3);
       END_STATE();
-    case 126:
+    case 175:
       ACCEPT_TOKEN(aux_sym_integer_token3);
       if (lookahead == 'i') ADVANCE(38);
       if (lookahead == 'u') ADVANCE(38);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(126);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(175);
       END_STATE();
-    case 127:
+    case 176:
       ACCEPT_TOKEN(aux_sym_integer_token4);
       END_STATE();
-    case 128:
+    case 177:
       ACCEPT_TOKEN(aux_sym_integer_token4);
-      if (lookahead == '.') ADVANCE(84);
-      if (lookahead == 'e') ADVANCE(78);
+      if (lookahead == '.') ADVANCE(108);
+      if (lookahead == 'e') ADVANCE(102);
       if (lookahead == 'f') ADVANCE(46);
       if (lookahead == 'i') ADVANCE(35);
       if (lookahead == 'u') ADVANCE(35);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(128);
+          lookahead == '_') ADVANCE(177);
       END_STATE();
-    case 129:
+    case 178:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 130:
+    case 179:
       ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
-    case 131:
+    case 180:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
       END_STATE();
-    case 132:
+    case 181:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '\n') ADVANCE(91);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ';') ADVANCE(90);
+      if (lookahead == '\n') ADVANCE(115);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ';') ADVANCE(114);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(132);
+          lookahead == ' ') ADVANCE(181);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
+          lookahead != '"') ADVANCE(180);
       END_STATE();
-    case 133:
+    case 182:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == '=') ADVANCE(140);
-      if (lookahead == '}') ADVANCE(162);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == ':') ADVANCE(178);
+      if (lookahead == '=') ADVANCE(189);
+      if (lookahead == '}') ADVANCE(211);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(133);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
-      END_STATE();
-    case 134:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == '=') ADVANCE(140);
-      if (lookahead == '}') ADVANCE(162);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(134);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
-      END_STATE();
-    case 135:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == ']') ADVANCE(159);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(135);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
-      END_STATE();
-    case 136:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ',') ADVANCE(158);
-      if (lookahead == '}') ADVANCE(162);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
-      END_STATE();
-    case 137:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == ':') ADVANCE(129);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(137);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
-      END_STATE();
-    case 138:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == '=') ADVANCE(140);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(138);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
-      END_STATE();
-    case 139:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(141);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(139);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(131);
-      END_STATE();
-    case 140:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '>') ADVANCE(161);
-      END_STATE();
-    case 141:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(182);
-      END_STATE();
-    case 142:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_SQUOTE);
-      END_STATE();
-    case 143:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE);
-      END_STATE();
-    case 144:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE);
-      END_STATE();
-    case 145:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHa_SQUOTE);
-      END_STATE();
-    case 146:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHb_SQUOTE);
-      END_STATE();
-    case 147:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHe_SQUOTE);
-      END_STATE();
-    case 148:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHf_SQUOTE);
-      END_STATE();
-    case 149:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHn_SQUOTE);
-      END_STATE();
-    case 150:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHr_SQUOTE);
-      END_STATE();
-    case 151:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHt_SQUOTE);
-      END_STATE();
-    case 152:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHv_SQUOTE);
-      END_STATE();
-    case 153:
-      ACCEPT_TOKEN(aux_sym_char_token1);
-      END_STATE();
-    case 154:
-      ACCEPT_TOKEN(aux_sym_char_token2);
-      END_STATE();
-    case 155:
-      ACCEPT_TOKEN(aux_sym_char_token2);
-      if (lookahead == '\'') ADVANCE(143);
-      END_STATE();
-    case 156:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      END_STATE();
-    case 157:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      if (lookahead == ']') ADVANCE(214);
-      END_STATE();
-    case 158:
-      ACCEPT_TOKEN(anon_sym_COMMA);
-      END_STATE();
-    case 159:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
-      END_STATE();
-    case 160:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      END_STATE();
-    case 161:
-      ACCEPT_TOKEN(anon_sym_EQ_GT);
-      END_STATE();
-    case 162:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      END_STATE();
-    case 163:
-      ACCEPT_TOKEN(anon_sym_of);
-      END_STATE();
-    case 164:
-      ACCEPT_TOKEN(aux_sym_hash_token1);
-      if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(182);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(164);
+          lookahead != '"') ADVANCE(180);
       END_STATE();
-    case 165:
+    case 183:
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == '=') ADVANCE(189);
+      if (lookahead == '}') ADVANCE(211);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(183);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(180);
+      END_STATE();
+    case 184:
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == ']') ADVANCE(208);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(184);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(180);
+      END_STATE();
+    case 185:
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ',') ADVANCE(207);
+      if (lookahead == '}') ADVANCE(211);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(185);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(180);
+      END_STATE();
+    case 186:
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == ':') ADVANCE(178);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(186);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(180);
+      END_STATE();
+    case 187:
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == '=') ADVANCE(189);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(187);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(180);
+      END_STATE();
+    case 188:
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(188);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(180);
+      END_STATE();
+    case 189:
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '>') ADVANCE(210);
+      END_STATE();
+    case 190:
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(231);
+      END_STATE();
+    case 191:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_SQUOTE);
+      END_STATE();
+    case 192:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE);
+      END_STATE();
+    case 193:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE);
+      END_STATE();
+    case 194:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHa_SQUOTE);
+      END_STATE();
+    case 195:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHb_SQUOTE);
+      END_STATE();
+    case 196:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHe_SQUOTE);
+      END_STATE();
+    case 197:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHf_SQUOTE);
+      END_STATE();
+    case 198:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHn_SQUOTE);
+      END_STATE();
+    case 199:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHr_SQUOTE);
+      END_STATE();
+    case 200:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHt_SQUOTE);
+      END_STATE();
+    case 201:
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHv_SQUOTE);
+      END_STATE();
+    case 202:
+      ACCEPT_TOKEN(aux_sym_char_token1);
+      END_STATE();
+    case 203:
+      ACCEPT_TOKEN(aux_sym_char_token2);
+      END_STATE();
+    case 204:
+      ACCEPT_TOKEN(aux_sym_char_token2);
+      if (lookahead == '\'') ADVANCE(192);
+      END_STATE();
+    case 205:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      END_STATE();
+    case 206:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == ']') ADVANCE(272);
+      END_STATE();
+    case 207:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      END_STATE();
+    case 208:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      END_STATE();
+    case 210:
+      ACCEPT_TOKEN(anon_sym_EQ_GT);
+      END_STATE();
+    case 211:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 212:
+      ACCEPT_TOKEN(anon_sym_of);
+      END_STATE();
+    case 213:
+      ACCEPT_TOKEN(aux_sym_hash_token1);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(231);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(213);
+      END_STATE();
+    case 214:
       ACCEPT_TOKEN(aux_sym_hash_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(165);
+          lookahead != ' ') ADVANCE(214);
       END_STATE();
-    case 166:
+    case 215:
       ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
-    case 167:
+    case 216:
       ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\n') ADVANCE(170);
-      if (lookahead == '/') ADVANCE(182);
-      if (lookahead == '\\') ADVANCE(168);
-      if (lookahead != 0) ADVANCE(167);
+      if (lookahead == '\n') ADVANCE(219);
+      if (lookahead == '/') ADVANCE(231);
+      if (lookahead == '\\') ADVANCE(217);
+      if (lookahead != 0) ADVANCE(216);
       END_STATE();
-    case 168:
+    case 217:
       ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\n') ADVANCE(170);
+      if (lookahead == '\n') ADVANCE(219);
       if (lookahead != 0 &&
-          lookahead != '\\') ADVANCE(167);
-      if (lookahead == '\\') ADVANCE(168);
+          lookahead != '\\') ADVANCE(216);
+      if (lookahead == '\\') ADVANCE(217);
       END_STATE();
-    case 169:
+    case 218:
       ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '#') ADVANCE(167);
-      if (lookahead == '\\') ADVANCE(171);
+      if (lookahead == '#') ADVANCE(216);
+      if (lookahead == '\\') ADVANCE(220);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(169);
+          lookahead == ' ') ADVANCE(218);
       if (lookahead != 0 &&
-          lookahead != '/') ADVANCE(170);
+          lookahead != '/') ADVANCE(219);
       END_STATE();
-    case 170:
+    case 219:
       ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\\') ADVANCE(171);
+      if (lookahead == '\\') ADVANCE(220);
       if (lookahead != 0 &&
-          lookahead != '/') ADVANCE(170);
+          lookahead != '/') ADVANCE(219);
       END_STATE();
-    case 171:
+    case 220:
       ACCEPT_TOKEN(aux_sym_regex_token1);
       if (lookahead != 0 &&
-          lookahead != '\\') ADVANCE(170);
-      if (lookahead == '\\') ADVANCE(171);
+          lookahead != '\\') ADVANCE(219);
+      if (lookahead == '\\') ADVANCE(220);
       END_STATE();
-    case 172:
+    case 221:
       ACCEPT_TOKEN(anon_sym_Tuple_DOTnew);
       END_STATE();
-    case 173:
+    case 222:
       ACCEPT_TOKEN(anon_sym_BQUOTE);
       END_STATE();
-    case 174:
+    case 223:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
-      if (lookahead == '\n') ADVANCE(176);
-      if (lookahead == '`') ADVANCE(182);
-      if (lookahead != 0) ADVANCE(174);
+      if (lookahead == '\n') ADVANCE(225);
+      if (lookahead == '`') ADVANCE(231);
+      if (lookahead != 0) ADVANCE(223);
       END_STATE();
-    case 175:
+    case 224:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
-      if (lookahead == '#') ADVANCE(174);
+      if (lookahead == '#') ADVANCE(223);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(175);
+          lookahead == ' ') ADVANCE(224);
       if (lookahead != 0 &&
-          lookahead != '`') ADVANCE(176);
+          lookahead != '`') ADVANCE(225);
       END_STATE();
-    case 176:
+    case 225:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
       if (lookahead != 0 &&
-          lookahead != '`') ADVANCE(176);
+          lookahead != '`') ADVANCE(225);
       END_STATE();
-    case 177:
+    case 226:
       ACCEPT_TOKEN(anon_sym_PERCENTx_LPAREN);
       END_STATE();
-    case 178:
+    case 227:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
-      if (lookahead == '\n') ADVANCE(180);
-      if (lookahead == ')') ADVANCE(182);
-      if (lookahead != 0) ADVANCE(178);
+      if (lookahead == '\n') ADVANCE(229);
+      if (lookahead == ')') ADVANCE(231);
+      if (lookahead != 0) ADVANCE(227);
       END_STATE();
-    case 179:
+    case 228:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
-      if (lookahead == '#') ADVANCE(178);
+      if (lookahead == '#') ADVANCE(227);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(179);
+          lookahead == ' ') ADVANCE(228);
       if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(180);
+          lookahead != ')') ADVANCE(229);
       END_STATE();
-    case 180:
+    case 229:
       ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
       if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(180);
+          lookahead != ')') ADVANCE(229);
       END_STATE();
-    case 181:
+    case 230:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 182:
+    case 231:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(182);
+          lookahead != '\n') ADVANCE(231);
       END_STATE();
-    case 183:
+    case 232:
       ACCEPT_TOKEN(aux_sym_local_variable_token1);
       END_STATE();
-    case 184:
+    case 233:
       ACCEPT_TOKEN(aux_sym_local_variable_token1);
-      if (lookahead == 'a') ADVANCE(68);
+      if (lookahead == '_') ADVANCE(62);
       END_STATE();
-    case 185:
+    case 234:
       ACCEPT_TOKEN(aux_sym_local_variable_token1);
-      if (lookahead == 'i') ADVANCE(69);
+      if (lookahead == 'a') ADVANCE(92);
       END_STATE();
-    case 186:
+    case 235:
       ACCEPT_TOKEN(aux_sym_local_variable_token1);
-      if (lookahead == 'r') ADVANCE(74);
+      if (lookahead == 'i') ADVANCE(93);
       END_STATE();
-    case 187:
+    case 236:
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
+      if (lookahead == 'r') ADVANCE(98);
+      END_STATE();
+    case 237:
       ACCEPT_TOKEN(anon_sym_AT);
-      if (lookahead == '@') ADVANCE(188);
+      if (lookahead == '@') ADVANCE(238);
       END_STATE();
-    case 188:
+    case 238:
       ACCEPT_TOKEN(anon_sym_AT_AT);
       END_STATE();
-    case 189:
+    case 239:
+      ACCEPT_TOKEN(anon_sym___LINE__);
+      END_STATE();
+    case 240:
+      ACCEPT_TOKEN(anon_sym___LINE__);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 241:
+      ACCEPT_TOKEN(anon_sym___END_LINE__);
+      END_STATE();
+    case 242:
+      ACCEPT_TOKEN(anon_sym___END_LINE__);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 243:
+      ACCEPT_TOKEN(anon_sym___FILE__);
+      END_STATE();
+    case 244:
+      ACCEPT_TOKEN(anon_sym___FILE__);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 245:
+      ACCEPT_TOKEN(anon_sym___DIR__);
+      END_STATE();
+    case 246:
+      ACCEPT_TOKEN(anon_sym___DIR__);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(117);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      END_STATE();
+    case 247:
       ACCEPT_TOKEN(aux_sym_constant_token1);
       END_STATE();
-    case 190:
+    case 248:
       ACCEPT_TOKEN(aux_sym_constant_token1);
-      if (lookahead == 'u') ADVANCE(72);
+      if (lookahead == 'u') ADVANCE(96);
       END_STATE();
-    case 191:
+    case 249:
       ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
-    case 192:
+    case 250:
       ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead == '=') ADVANCE(206);
-      if (lookahead == '>') ADVANCE(161);
-      if (lookahead == '~') ADVANCE(220);
+      if (lookahead == '=') ADVANCE(264);
+      if (lookahead == '>') ADVANCE(210);
+      if (lookahead == '~') ADVANCE(278);
       END_STATE();
-    case 193:
+    case 251:
       ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
-    case 194:
+    case 252:
       ACCEPT_TOKEN(anon_sym_PLUS);
       if (lookahead == '0') ADVANCE(31);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
       END_STATE();
-    case 195:
+    case 253:
       ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
-    case 196:
+    case 254:
       ACCEPT_TOKEN(anon_sym_DASH);
       if (lookahead == '0') ADVANCE(31);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(128);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
       END_STATE();
-    case 197:
+    case 255:
       ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '*') ADVANCE(203);
+      if (lookahead == '*') ADVANCE(261);
       END_STATE();
-    case 198:
+    case 256:
       ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
-    case 199:
+    case 257:
       ACCEPT_TOKEN(anon_sym_PERCENT);
       if (lookahead == 'x') ADVANCE(30);
       END_STATE();
-    case 200:
+    case 258:
       ACCEPT_TOKEN(anon_sym_AMP);
       END_STATE();
-    case 201:
+    case 259:
       ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
-    case 202:
+    case 260:
       ACCEPT_TOKEN(anon_sym_CARET);
       END_STATE();
-    case 203:
+    case 261:
       ACCEPT_TOKEN(anon_sym_STAR_STAR);
       END_STATE();
-    case 204:
+    case 262:
       ACCEPT_TOKEN(anon_sym_GT_GT);
       END_STATE();
-    case 205:
+    case 263:
       ACCEPT_TOKEN(anon_sym_LT_LT);
       END_STATE();
-    case 206:
+    case 264:
       ACCEPT_TOKEN(anon_sym_EQ_EQ);
-      if (lookahead == '=') ADVANCE(213);
+      if (lookahead == '=') ADVANCE(271);
       END_STATE();
-    case 207:
+    case 265:
       ACCEPT_TOKEN(anon_sym_BANG_EQ);
       END_STATE();
-    case 208:
+    case 266:
       ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '<') ADVANCE(205);
-      if (lookahead == '=') ADVANCE(209);
+      if (lookahead == '<') ADVANCE(263);
+      if (lookahead == '=') ADVANCE(267);
       END_STATE();
-    case 209:
+    case 267:
       ACCEPT_TOKEN(anon_sym_LT_EQ);
-      if (lookahead == '>') ADVANCE(212);
+      if (lookahead == '>') ADVANCE(270);
       END_STATE();
-    case 210:
+    case 268:
       ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '=') ADVANCE(211);
-      if (lookahead == '>') ADVANCE(204);
+      if (lookahead == '=') ADVANCE(269);
+      if (lookahead == '>') ADVANCE(262);
       END_STATE();
-    case 211:
+    case 269:
       ACCEPT_TOKEN(anon_sym_GT_EQ);
       END_STATE();
-    case 212:
+    case 270:
       ACCEPT_TOKEN(anon_sym_LT_EQ_GT);
       END_STATE();
-    case 213:
+    case 271:
       ACCEPT_TOKEN(anon_sym_EQ_EQ_EQ);
       END_STATE();
-    case 214:
+    case 272:
       ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK);
-      if (lookahead == '=') ADVANCE(216);
-      if (lookahead == '?') ADVANCE(215);
+      if (lookahead == '=') ADVANCE(274);
+      if (lookahead == '?') ADVANCE(273);
       END_STATE();
-    case 215:
+    case 273:
       ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_QMARK);
       END_STATE();
-    case 216:
+    case 274:
       ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_EQ);
       END_STATE();
-    case 217:
+    case 275:
       ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead == '=') ADVANCE(207);
-      if (lookahead == '~') ADVANCE(219);
+      if (lookahead == '=') ADVANCE(265);
+      if (lookahead == '~') ADVANCE(277);
       END_STATE();
-    case 218:
+    case 276:
       ACCEPT_TOKEN(anon_sym_TILDE);
       END_STATE();
-    case 219:
+    case 277:
       ACCEPT_TOKEN(anon_sym_BANG_TILDE);
       END_STATE();
-    case 220:
+    case 278:
       ACCEPT_TOKEN(anon_sym_EQ_TILDE);
       END_STATE();
     default:
@@ -2113,28 +2601,28 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 88},
+  [1] = {.lex_state = 112},
   [2] = {.lex_state = 4},
-  [3] = {.lex_state = 88},
-  [4] = {.lex_state = 88},
+  [3] = {.lex_state = 112},
+  [4] = {.lex_state = 112},
   [5] = {.lex_state = 4},
-  [6] = {.lex_state = 88},
-  [7] = {.lex_state = 88},
-  [8] = {.lex_state = 88},
-  [9] = {.lex_state = 88},
-  [10] = {.lex_state = 88},
-  [11] = {.lex_state = 88},
-  [12] = {.lex_state = 88},
-  [13] = {.lex_state = 88},
-  [14] = {.lex_state = 88},
-  [15] = {.lex_state = 88},
-  [16] = {.lex_state = 88},
-  [17] = {.lex_state = 88},
-  [18] = {.lex_state = 88},
-  [19] = {.lex_state = 88},
-  [20] = {.lex_state = 88},
-  [21] = {.lex_state = 88},
-  [22] = {.lex_state = 88},
+  [6] = {.lex_state = 112},
+  [7] = {.lex_state = 112},
+  [8] = {.lex_state = 112},
+  [9] = {.lex_state = 112},
+  [10] = {.lex_state = 112},
+  [11] = {.lex_state = 112},
+  [12] = {.lex_state = 112},
+  [13] = {.lex_state = 112},
+  [14] = {.lex_state = 112},
+  [15] = {.lex_state = 112},
+  [16] = {.lex_state = 112},
+  [17] = {.lex_state = 112},
+  [18] = {.lex_state = 112},
+  [19] = {.lex_state = 112},
+  [20] = {.lex_state = 112},
+  [21] = {.lex_state = 112},
+  [22] = {.lex_state = 112},
   [23] = {.lex_state = 3},
   [24] = {.lex_state = 3},
   [25] = {.lex_state = 3},
@@ -2146,88 +2634,88 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [31] = {.lex_state = 6},
   [32] = {.lex_state = 6},
   [33] = {.lex_state = 6},
-  [34] = {.lex_state = 88},
-  [35] = {.lex_state = 88},
-  [36] = {.lex_state = 88},
-  [37] = {.lex_state = 88},
-  [38] = {.lex_state = 88},
-  [39] = {.lex_state = 8},
-  [40] = {.lex_state = 88},
-  [41] = {.lex_state = 8},
-  [42] = {.lex_state = 8},
-  [43] = {.lex_state = 8},
-  [44] = {.lex_state = 1},
-  [45] = {.lex_state = 88},
+  [34] = {.lex_state = 112},
+  [35] = {.lex_state = 112},
+  [36] = {.lex_state = 112},
+  [37] = {.lex_state = 112},
+  [38] = {.lex_state = 112},
+  [39] = {.lex_state = 112},
+  [40] = {.lex_state = 112},
+  [41] = {.lex_state = 112},
+  [42] = {.lex_state = 112},
+  [43] = {.lex_state = 1},
+  [44] = {.lex_state = 112},
+  [45] = {.lex_state = 1},
   [46] = {.lex_state = 7},
-  [47] = {.lex_state = 88},
-  [48] = {.lex_state = 1},
-  [49] = {.lex_state = 7},
-  [50] = {.lex_state = 1},
-  [51] = {.lex_state = 3},
-  [52] = {.lex_state = 7},
-  [53] = {.lex_state = 88},
-  [54] = {.lex_state = 88},
-  [55] = {.lex_state = 88},
-  [56] = {.lex_state = 88},
-  [57] = {.lex_state = 88},
+  [47] = {.lex_state = 8},
+  [48] = {.lex_state = 112},
+  [49] = {.lex_state = 112},
+  [50] = {.lex_state = 112},
+  [51] = {.lex_state = 1},
+  [52] = {.lex_state = 112},
+  [53] = {.lex_state = 112},
+  [54] = {.lex_state = 8},
+  [55] = {.lex_state = 7},
+  [56] = {.lex_state = 7},
+  [57] = {.lex_state = 8},
   [58] = {.lex_state = 7},
-  [59] = {.lex_state = 88},
-  [60] = {.lex_state = 88},
-  [61] = {.lex_state = 88},
-  [62] = {.lex_state = 1},
-  [63] = {.lex_state = 88},
-  [64] = {.lex_state = 88},
-  [65] = {.lex_state = 88},
-  [66] = {.lex_state = 88},
-  [67] = {.lex_state = 88},
-  [68] = {.lex_state = 88},
+  [59] = {.lex_state = 112},
+  [60] = {.lex_state = 1},
+  [61] = {.lex_state = 112},
+  [62] = {.lex_state = 112},
+  [63] = {.lex_state = 3},
+  [64] = {.lex_state = 112},
+  [65] = {.lex_state = 112},
+  [66] = {.lex_state = 8},
+  [67] = {.lex_state = 112},
+  [68] = {.lex_state = 112},
   [69] = {.lex_state = 11},
-  [70] = {.lex_state = 11},
+  [70] = {.lex_state = 10},
   [71] = {.lex_state = 11},
-  [72] = {.lex_state = 11},
-  [73] = {.lex_state = 11},
+  [72] = {.lex_state = 0},
+  [73] = {.lex_state = 0},
   [74] = {.lex_state = 0},
-  [75] = {.lex_state = 0},
-  [76] = {.lex_state = 11},
+  [75] = {.lex_state = 11},
+  [76] = {.lex_state = 0},
   [77] = {.lex_state = 11},
-  [78] = {.lex_state = 0},
-  [79] = {.lex_state = 11},
+  [78] = {.lex_state = 11},
+  [79] = {.lex_state = 0},
   [80] = {.lex_state = 11},
-  [81] = {.lex_state = 11},
+  [81] = {.lex_state = 0},
   [82] = {.lex_state = 11},
   [83] = {.lex_state = 11},
-  [84] = {.lex_state = 0},
-  [85] = {.lex_state = 11},
-  [86] = {.lex_state = 0},
+  [84] = {.lex_state = 11},
+  [85] = {.lex_state = 0},
+  [86] = {.lex_state = 11},
   [87] = {.lex_state = 11},
   [88] = {.lex_state = 0},
   [89] = {.lex_state = 11},
-  [90] = {.lex_state = 0},
+  [90] = {.lex_state = 11},
   [91] = {.lex_state = 11},
   [92] = {.lex_state = 11},
-  [93] = {.lex_state = 0},
+  [93] = {.lex_state = 11},
   [94] = {.lex_state = 11},
-  [95] = {.lex_state = 0},
+  [95] = {.lex_state = 11},
   [96] = {.lex_state = 0},
-  [97] = {.lex_state = 11},
+  [97] = {.lex_state = 0},
   [98] = {.lex_state = 0},
   [99] = {.lex_state = 0},
   [100] = {.lex_state = 0},
   [101] = {.lex_state = 0},
-  [102] = {.lex_state = 0},
+  [102] = {.lex_state = 11},
   [103] = {.lex_state = 0},
   [104] = {.lex_state = 0},
   [105] = {.lex_state = 0},
   [106] = {.lex_state = 11},
-  [107] = {.lex_state = 11},
-  [108] = {.lex_state = 0},
+  [107] = {.lex_state = 0},
+  [108] = {.lex_state = 11},
   [109] = {.lex_state = 11},
   [110] = {.lex_state = 11},
-  [111] = {.lex_state = 11},
-  [112] = {.lex_state = 11},
-  [113] = {.lex_state = 9},
-  [114] = {.lex_state = 9},
-  [115] = {.lex_state = 10},
+  [111] = {.lex_state = 9},
+  [112] = {.lex_state = 9},
+  [113] = {.lex_state = 0},
+  [114] = {.lex_state = 11},
+  [115] = {.lex_state = 11},
   [116] = {.lex_state = 10},
   [117] = {.lex_state = 10},
   [118] = {.lex_state = 10},
@@ -2236,63 +2724,64 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [121] = {.lex_state = 2},
   [122] = {.lex_state = 2},
   [123] = {.lex_state = 2},
-  [124] = {.lex_state = 12},
+  [124] = {.lex_state = 2},
   [125] = {.lex_state = 2},
   [126] = {.lex_state = 2},
-  [127] = {.lex_state = 12},
-  [128] = {.lex_state = 2},
-  [129] = {.lex_state = 12},
+  [127] = {.lex_state = 2},
+  [128] = {.lex_state = 12},
+  [129] = {.lex_state = 2},
   [130] = {.lex_state = 2},
-  [131] = {.lex_state = 2},
+  [131] = {.lex_state = 12},
   [132] = {.lex_state = 2},
-  [133] = {.lex_state = 12},
+  [133] = {.lex_state = 2},
   [134] = {.lex_state = 2},
   [135] = {.lex_state = 2},
   [136] = {.lex_state = 0},
-  [137] = {.lex_state = 0},
-  [138] = {.lex_state = 2},
+  [137] = {.lex_state = 12},
+  [138] = {.lex_state = 12},
   [139] = {.lex_state = 2},
-  [140] = {.lex_state = 2},
+  [140] = {.lex_state = 0},
   [141] = {.lex_state = 2},
   [142] = {.lex_state = 2},
   [143] = {.lex_state = 2},
   [144] = {.lex_state = 0},
-  [145] = {.lex_state = 0},
-  [146] = {.lex_state = 88},
+  [145] = {.lex_state = 228},
+  [146] = {.lex_state = 15},
   [147] = {.lex_state = 15},
-  [148] = {.lex_state = 88},
-  [149] = {.lex_state = 0},
-  [150] = {.lex_state = 15},
-  [151] = {.lex_state = 0},
-  [152] = {.lex_state = 4},
-  [153] = {.lex_state = 4},
-  [154] = {.lex_state = 0},
+  [148] = {.lex_state = 4},
+  [149] = {.lex_state = 4},
+  [150] = {.lex_state = 4},
+  [151] = {.lex_state = 4},
+  [152] = {.lex_state = 0},
+  [153] = {.lex_state = 0},
+  [154] = {.lex_state = 112},
   [155] = {.lex_state = 0},
   [156] = {.lex_state = 0},
-  [157] = {.lex_state = 15},
-  [158] = {.lex_state = 14},
-  [159] = {.lex_state = 14},
-  [160] = {.lex_state = 169},
-  [161] = {.lex_state = 175},
-  [162] = {.lex_state = 179},
-  [163] = {.lex_state = 0},
-  [164] = {.lex_state = 179},
-  [165] = {.lex_state = 175},
-  [166] = {.lex_state = 4},
-  [167] = {.lex_state = 88},
-  [168] = {.lex_state = 4},
-  [169] = {.lex_state = 169},
+  [157] = {.lex_state = 0},
+  [158] = {.lex_state = 15},
+  [159] = {.lex_state = 4},
+  [160] = {.lex_state = 14},
+  [161] = {.lex_state = 218},
+  [162] = {.lex_state = 224},
+  [163] = {.lex_state = 4},
+  [164] = {.lex_state = 14},
+  [165] = {.lex_state = 0},
+  [166] = {.lex_state = 228},
+  [167] = {.lex_state = 0},
+  [168] = {.lex_state = 112},
+  [169] = {.lex_state = 224},
   [170] = {.lex_state = 4},
   [171] = {.lex_state = 4},
-  [172] = {.lex_state = 4},
-  [173] = {.lex_state = 4},
-  [174] = {.lex_state = 0},
-  [175] = {.lex_state = 0},
-  [176] = {.lex_state = 4},
-  [177] = {.lex_state = 0},
-  [178] = {.lex_state = 13},
-  [179] = {.lex_state = 15},
-  [180] = {.lex_state = 13},
+  [172] = {.lex_state = 218},
+  [173] = {.lex_state = 13},
+  [174] = {.lex_state = 4},
+  [175] = {.lex_state = 112},
+  [176] = {.lex_state = 0},
+  [177] = {.lex_state = 4},
+  [178] = {.lex_state = 0},
+  [179] = {.lex_state = 0},
+  [180] = {.lex_state = 15},
+  [181] = {.lex_state = 13},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -2340,6 +2829,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_local_variable_token1] = ACTIONS(1),
     [anon_sym_AT] = ACTIONS(1),
     [anon_sym_AT_AT] = ACTIONS(1),
+    [anon_sym___LINE__] = ACTIONS(1),
+    [anon_sym___END_LINE__] = ACTIONS(1),
+    [anon_sym___FILE__] = ACTIONS(1),
+    [anon_sym___DIR__] = ACTIONS(1),
     [aux_sym_constant_token1] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
     [anon_sym_PLUS] = ACTIONS(1),
@@ -2369,26 +2862,26 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_EQ_TILDE] = ACTIONS(1),
   },
   [1] = {
-    [sym_program] = STATE(154),
+    [sym_program] = STATE(176),
     [sym__statement] = STATE(4),
-    [sym__expression] = STATE(120),
-    [sym_bool] = STATE(120),
-    [sym_float] = STATE(120),
-    [sym_integer] = STATE(120),
-    [sym_symbol] = STATE(120),
-    [sym_char] = STATE(120),
-    [sym_string] = STATE(120),
-    [sym_array] = STATE(120),
-    [sym_hash] = STATE(120),
-    [sym_regex] = STATE(120),
-    [sym_tuple] = STATE(120),
-    [sym_namedTupleLiteral] = STATE(120),
-    [sym_commandLiteral] = STATE(120),
-    [sym_local_variable] = STATE(166),
-    [sym_instance_variable] = STATE(166),
-    [sym_class_variable] = STATE(166),
-    [sym_constant] = STATE(166),
-    [sym_assignment] = STATE(120),
+    [sym__expression] = STATE(122),
+    [sym_bool] = STATE(122),
+    [sym_float] = STATE(122),
+    [sym_integer] = STATE(122),
+    [sym_symbol] = STATE(122),
+    [sym_char] = STATE(122),
+    [sym_string] = STATE(122),
+    [sym_array] = STATE(122),
+    [sym_hash] = STATE(122),
+    [sym_regex] = STATE(122),
+    [sym_tuple] = STATE(122),
+    [sym_namedTupleLiteral] = STATE(122),
+    [sym_commandLiteral] = STATE(122),
+    [sym_local_variable] = STATE(150),
+    [sym_instance_variable] = STATE(150),
+    [sym_class_variable] = STATE(150),
+    [sym_constant] = STATE(150),
+    [sym_assignment] = STATE(122),
     [aux_sym_program_repeat1] = STATE(4),
     [ts_builtin_sym_end] = ACTIONS(5),
     [sym_nil] = ACTIONS(7),
@@ -2426,148 +2919,160 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
   [2] = {
-    [sym__expression] = STATE(37),
-    [sym_identifier] = STATE(177),
-    [sym_bool] = STATE(37),
-    [sym_float] = STATE(37),
-    [sym_integer] = STATE(37),
-    [sym_symbol] = STATE(37),
-    [sym_char] = STATE(37),
-    [sym_string] = STATE(36),
-    [sym_array] = STATE(37),
-    [sym_hash] = STATE(37),
-    [sym_regex] = STATE(37),
-    [sym_tuple] = STATE(37),
-    [sym_namedTupleLiteral] = STATE(37),
-    [sym_commandLiteral] = STATE(37),
-    [sym_local_variable] = STATE(170),
-    [sym_instance_variable] = STATE(170),
-    [sym_class_variable] = STATE(170),
-    [sym_constant] = STATE(170),
-    [sym_assignment] = STATE(37),
-    [aux_sym_identifier_token1] = ACTIONS(47),
-    [sym_nil] = ACTIONS(49),
-    [anon_sym_true] = ACTIONS(51),
-    [anon_sym_false] = ACTIONS(51),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(61),
-    [anon_sym_DQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_RBRACE] = ACTIONS(73),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym__expression] = STATE(67),
+    [sym_identifier] = STATE(178),
+    [sym_bool] = STATE(67),
+    [sym_float] = STATE(67),
+    [sym_integer] = STATE(67),
+    [sym_symbol] = STATE(67),
+    [sym_char] = STATE(67),
+    [sym_string] = STATE(40),
+    [sym_array] = STATE(67),
+    [sym_hash] = STATE(67),
+    [sym_regex] = STATE(67),
+    [sym_tuple] = STATE(67),
+    [sym_namedTupleLiteral] = STATE(67),
+    [sym_commandLiteral] = STATE(67),
+    [sym_local_variable] = STATE(171),
+    [sym_instance_variable] = STATE(171),
+    [sym_class_variable] = STATE(171),
+    [sym_constant] = STATE(171),
+    [sym_assignment] = STATE(67),
+    [aux_sym_identifier_token1] = ACTIONS(49),
+    [sym_nil] = ACTIONS(51),
+    [anon_sym_true] = ACTIONS(53),
+    [anon_sym_false] = ACTIONS(53),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(63),
+    [anon_sym_DQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_RBRACE] = ACTIONS(75),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
     [sym_comment] = ACTIONS(3),
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(85),
+    [anon_sym___END_LINE__] = ACTIONS(85),
+    [anon_sym___FILE__] = ACTIONS(85),
+    [anon_sym___DIR__] = ACTIONS(85),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
   [3] = {
     [sym__statement] = STATE(3),
-    [sym__expression] = STATE(120),
-    [sym_bool] = STATE(120),
-    [sym_float] = STATE(120),
-    [sym_integer] = STATE(120),
-    [sym_symbol] = STATE(120),
-    [sym_char] = STATE(120),
-    [sym_string] = STATE(120),
-    [sym_array] = STATE(120),
-    [sym_hash] = STATE(120),
-    [sym_regex] = STATE(120),
-    [sym_tuple] = STATE(120),
-    [sym_namedTupleLiteral] = STATE(120),
-    [sym_commandLiteral] = STATE(120),
-    [sym_local_variable] = STATE(166),
-    [sym_instance_variable] = STATE(166),
-    [sym_class_variable] = STATE(166),
-    [sym_constant] = STATE(166),
-    [sym_assignment] = STATE(120),
+    [sym__expression] = STATE(122),
+    [sym_bool] = STATE(122),
+    [sym_float] = STATE(122),
+    [sym_integer] = STATE(122),
+    [sym_symbol] = STATE(122),
+    [sym_char] = STATE(122),
+    [sym_string] = STATE(122),
+    [sym_array] = STATE(122),
+    [sym_hash] = STATE(122),
+    [sym_regex] = STATE(122),
+    [sym_tuple] = STATE(122),
+    [sym_namedTupleLiteral] = STATE(122),
+    [sym_commandLiteral] = STATE(122),
+    [sym_local_variable] = STATE(150),
+    [sym_instance_variable] = STATE(150),
+    [sym_class_variable] = STATE(150),
+    [sym_constant] = STATE(150),
+    [sym_assignment] = STATE(122),
     [aux_sym_program_repeat1] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(83),
-    [sym_nil] = ACTIONS(85),
-    [anon_sym_true] = ACTIONS(88),
-    [anon_sym_false] = ACTIONS(88),
-    [aux_sym_float_token1] = ACTIONS(91),
-    [aux_sym_float_token2] = ACTIONS(94),
-    [aux_sym_float_token3] = ACTIONS(94),
-    [aux_sym_integer_token1] = ACTIONS(97),
-    [aux_sym_integer_token2] = ACTIONS(97),
-    [aux_sym_integer_token3] = ACTIONS(97),
-    [aux_sym_integer_token4] = ACTIONS(100),
-    [anon_sym_COLON] = ACTIONS(103),
-    [anon_sym_DQUOTE] = ACTIONS(106),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(109),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(109),
-    [aux_sym_char_token1] = ACTIONS(109),
-    [aux_sym_char_token2] = ACTIONS(112),
-    [anon_sym_LBRACK] = ACTIONS(115),
-    [anon_sym_LBRACE] = ACTIONS(118),
-    [anon_sym_SLASH] = ACTIONS(121),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(124),
-    [anon_sym_BQUOTE] = ACTIONS(127),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(130),
+    [ts_builtin_sym_end] = ACTIONS(87),
+    [sym_nil] = ACTIONS(89),
+    [anon_sym_true] = ACTIONS(92),
+    [anon_sym_false] = ACTIONS(92),
+    [aux_sym_float_token1] = ACTIONS(95),
+    [aux_sym_float_token2] = ACTIONS(98),
+    [aux_sym_float_token3] = ACTIONS(98),
+    [aux_sym_integer_token1] = ACTIONS(101),
+    [aux_sym_integer_token2] = ACTIONS(101),
+    [aux_sym_integer_token3] = ACTIONS(101),
+    [aux_sym_integer_token4] = ACTIONS(104),
+    [anon_sym_COLON] = ACTIONS(107),
+    [anon_sym_DQUOTE] = ACTIONS(110),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(113),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(113),
+    [aux_sym_char_token1] = ACTIONS(113),
+    [aux_sym_char_token2] = ACTIONS(116),
+    [anon_sym_LBRACK] = ACTIONS(119),
+    [anon_sym_LBRACE] = ACTIONS(122),
+    [anon_sym_SLASH] = ACTIONS(125),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(128),
+    [anon_sym_BQUOTE] = ACTIONS(131),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(134),
     [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(133),
-    [anon_sym_AT] = ACTIONS(136),
-    [anon_sym_AT_AT] = ACTIONS(139),
-    [aux_sym_constant_token1] = ACTIONS(142),
+    [aux_sym_local_variable_token1] = ACTIONS(137),
+    [anon_sym_AT] = ACTIONS(140),
+    [anon_sym_AT_AT] = ACTIONS(143),
+    [anon_sym___LINE__] = ACTIONS(146),
+    [anon_sym___END_LINE__] = ACTIONS(146),
+    [anon_sym___FILE__] = ACTIONS(146),
+    [anon_sym___DIR__] = ACTIONS(146),
+    [aux_sym_constant_token1] = ACTIONS(149),
   },
   [4] = {
     [sym__statement] = STATE(3),
-    [sym__expression] = STATE(120),
-    [sym_bool] = STATE(120),
-    [sym_float] = STATE(120),
-    [sym_integer] = STATE(120),
-    [sym_symbol] = STATE(120),
-    [sym_char] = STATE(120),
-    [sym_string] = STATE(120),
-    [sym_array] = STATE(120),
-    [sym_hash] = STATE(120),
-    [sym_regex] = STATE(120),
-    [sym_tuple] = STATE(120),
-    [sym_namedTupleLiteral] = STATE(120),
-    [sym_commandLiteral] = STATE(120),
-    [sym_local_variable] = STATE(166),
-    [sym_instance_variable] = STATE(166),
-    [sym_class_variable] = STATE(166),
-    [sym_constant] = STATE(166),
-    [sym_assignment] = STATE(120),
+    [sym__expression] = STATE(122),
+    [sym_bool] = STATE(122),
+    [sym_float] = STATE(122),
+    [sym_integer] = STATE(122),
+    [sym_symbol] = STATE(122),
+    [sym_char] = STATE(122),
+    [sym_string] = STATE(122),
+    [sym_array] = STATE(122),
+    [sym_hash] = STATE(122),
+    [sym_regex] = STATE(122),
+    [sym_tuple] = STATE(122),
+    [sym_namedTupleLiteral] = STATE(122),
+    [sym_commandLiteral] = STATE(122),
+    [sym_local_variable] = STATE(150),
+    [sym_instance_variable] = STATE(150),
+    [sym_class_variable] = STATE(150),
+    [sym_constant] = STATE(150),
+    [sym_assignment] = STATE(122),
     [aux_sym_program_repeat1] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(145),
+    [ts_builtin_sym_end] = ACTIONS(152),
     [sym_nil] = ACTIONS(7),
     [anon_sym_true] = ACTIONS(9),
     [anon_sym_false] = ACTIONS(9),
@@ -2603,703 +3108,215 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
   [5] = {
-    [sym__expression] = STATE(38),
-    [sym_identifier] = STATE(145),
-    [sym_bool] = STATE(38),
-    [sym_float] = STATE(38),
-    [sym_integer] = STATE(38),
-    [sym_symbol] = STATE(38),
-    [sym_char] = STATE(38),
-    [sym_string] = STATE(40),
-    [sym_array] = STATE(38),
-    [sym_hash] = STATE(38),
-    [sym_regex] = STATE(38),
-    [sym_tuple] = STATE(38),
-    [sym_namedTupleLiteral] = STATE(38),
-    [sym_commandLiteral] = STATE(38),
-    [sym_local_variable] = STATE(170),
-    [sym_instance_variable] = STATE(170),
-    [sym_class_variable] = STATE(170),
-    [sym_constant] = STATE(170),
-    [sym_assignment] = STATE(38),
-    [aux_sym_identifier_token1] = ACTIONS(47),
-    [sym_nil] = ACTIONS(147),
-    [anon_sym_true] = ACTIONS(51),
-    [anon_sym_false] = ACTIONS(51),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(61),
-    [anon_sym_DQUOTE] = ACTIONS(63),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_RBRACE] = ACTIONS(149),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym__expression] = STATE(44),
+    [sym_identifier] = STATE(167),
+    [sym_bool] = STATE(44),
+    [sym_float] = STATE(44),
+    [sym_integer] = STATE(44),
+    [sym_symbol] = STATE(44),
+    [sym_char] = STATE(44),
+    [sym_string] = STATE(42),
+    [sym_array] = STATE(44),
+    [sym_hash] = STATE(44),
+    [sym_regex] = STATE(44),
+    [sym_tuple] = STATE(44),
+    [sym_namedTupleLiteral] = STATE(44),
+    [sym_commandLiteral] = STATE(44),
+    [sym_local_variable] = STATE(171),
+    [sym_instance_variable] = STATE(171),
+    [sym_class_variable] = STATE(171),
+    [sym_constant] = STATE(171),
+    [sym_assignment] = STATE(44),
+    [aux_sym_identifier_token1] = ACTIONS(49),
+    [sym_nil] = ACTIONS(154),
+    [anon_sym_true] = ACTIONS(53),
+    [anon_sym_false] = ACTIONS(53),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(63),
+    [anon_sym_DQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_RBRACE] = ACTIONS(156),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
     [sym_comment] = ACTIONS(3),
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(85),
+    [anon_sym___END_LINE__] = ACTIONS(85),
+    [anon_sym___FILE__] = ACTIONS(85),
+    [anon_sym___DIR__] = ACTIONS(85),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
   [6] = {
-    [sym__expression] = STATE(57),
-    [sym_bool] = STATE(57),
-    [sym_float] = STATE(57),
-    [sym_integer] = STATE(57),
-    [sym_symbol] = STATE(57),
-    [sym_char] = STATE(57),
-    [sym_string] = STATE(57),
-    [sym_array] = STATE(57),
-    [sym_hash] = STATE(57),
-    [sym_regex] = STATE(57),
-    [sym_tuple] = STATE(57),
-    [sym_namedTupleLiteral] = STATE(57),
-    [sym_commandLiteral] = STATE(57),
-    [sym_local_variable] = STATE(168),
-    [sym_instance_variable] = STATE(168),
-    [sym_class_variable] = STATE(168),
-    [sym_constant] = STATE(168),
-    [sym_assignment] = STATE(57),
-    [sym_nil] = ACTIONS(151),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(155),
-    [anon_sym_DQUOTE] = ACTIONS(157),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
-  },
-  [7] = {
-    [sym__expression] = STATE(136),
-    [sym_bool] = STATE(136),
-    [sym_float] = STATE(136),
-    [sym_integer] = STATE(136),
-    [sym_symbol] = STATE(136),
-    [sym_char] = STATE(136),
-    [sym_string] = STATE(136),
-    [sym_array] = STATE(136),
-    [sym_hash] = STATE(136),
-    [sym_regex] = STATE(136),
-    [sym_tuple] = STATE(136),
-    [sym_namedTupleLiteral] = STATE(136),
-    [sym_commandLiteral] = STATE(136),
-    [sym_local_variable] = STATE(173),
-    [sym_instance_variable] = STATE(173),
-    [sym_class_variable] = STATE(173),
-    [sym_constant] = STATE(173),
-    [sym_assignment] = STATE(136),
-    [sym_nil] = ACTIONS(159),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(161),
-    [anon_sym_DQUOTE] = ACTIONS(163),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
-  },
-  [8] = {
-    [sym__expression] = STATE(57),
-    [sym_bool] = STATE(57),
-    [sym_float] = STATE(57),
-    [sym_integer] = STATE(57),
-    [sym_symbol] = STATE(57),
-    [sym_char] = STATE(57),
-    [sym_string] = STATE(57),
-    [sym_array] = STATE(57),
-    [sym_hash] = STATE(57),
-    [sym_regex] = STATE(57),
-    [sym_tuple] = STATE(57),
-    [sym_namedTupleLiteral] = STATE(57),
-    [sym_commandLiteral] = STATE(57),
-    [sym_local_variable] = STATE(173),
-    [sym_instance_variable] = STATE(173),
-    [sym_class_variable] = STATE(173),
-    [sym_constant] = STATE(173),
-    [sym_assignment] = STATE(57),
-    [sym_nil] = ACTIONS(151),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(161),
-    [anon_sym_DQUOTE] = ACTIONS(163),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
-  },
-  [9] = {
-    [sym__expression] = STATE(90),
-    [sym_bool] = STATE(90),
-    [sym_float] = STATE(90),
-    [sym_integer] = STATE(90),
-    [sym_symbol] = STATE(90),
-    [sym_char] = STATE(90),
-    [sym_string] = STATE(90),
-    [sym_array] = STATE(90),
-    [sym_hash] = STATE(90),
-    [sym_regex] = STATE(90),
-    [sym_tuple] = STATE(90),
-    [sym_namedTupleLiteral] = STATE(90),
-    [sym_commandLiteral] = STATE(90),
-    [sym_local_variable] = STATE(173),
-    [sym_instance_variable] = STATE(173),
-    [sym_class_variable] = STATE(173),
-    [sym_constant] = STATE(173),
-    [sym_assignment] = STATE(90),
-    [sym_nil] = ACTIONS(165),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(161),
-    [anon_sym_DQUOTE] = ACTIONS(163),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
-  },
-  [10] = {
-    [sym__expression] = STATE(96),
-    [sym_bool] = STATE(96),
-    [sym_float] = STATE(96),
-    [sym_integer] = STATE(96),
-    [sym_symbol] = STATE(96),
-    [sym_char] = STATE(96),
-    [sym_string] = STATE(96),
-    [sym_array] = STATE(96),
-    [sym_hash] = STATE(96),
-    [sym_regex] = STATE(96),
-    [sym_tuple] = STATE(96),
-    [sym_namedTupleLiteral] = STATE(96),
-    [sym_commandLiteral] = STATE(96),
-    [sym_local_variable] = STATE(168),
-    [sym_instance_variable] = STATE(168),
-    [sym_class_variable] = STATE(168),
-    [sym_constant] = STATE(168),
-    [sym_assignment] = STATE(96),
-    [sym_nil] = ACTIONS(167),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(155),
-    [anon_sym_DQUOTE] = ACTIONS(157),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
-  },
-  [11] = {
-    [sym__expression] = STATE(57),
-    [sym_bool] = STATE(57),
-    [sym_float] = STATE(57),
-    [sym_integer] = STATE(57),
-    [sym_symbol] = STATE(57),
-    [sym_char] = STATE(57),
-    [sym_string] = STATE(57),
-    [sym_array] = STATE(57),
-    [sym_hash] = STATE(57),
-    [sym_regex] = STATE(57),
-    [sym_tuple] = STATE(57),
-    [sym_namedTupleLiteral] = STATE(57),
-    [sym_commandLiteral] = STATE(57),
+    [sym__expression] = STATE(107),
+    [sym_bool] = STATE(107),
+    [sym_float] = STATE(107),
+    [sym_integer] = STATE(107),
+    [sym_symbol] = STATE(107),
+    [sym_char] = STATE(107),
+    [sym_string] = STATE(107),
+    [sym_array] = STATE(107),
+    [sym_hash] = STATE(107),
+    [sym_regex] = STATE(107),
+    [sym_tuple] = STATE(107),
+    [sym_namedTupleLiteral] = STATE(107),
+    [sym_commandLiteral] = STATE(107),
     [sym_local_variable] = STATE(170),
     [sym_instance_variable] = STATE(170),
     [sym_class_variable] = STATE(170),
     [sym_constant] = STATE(170),
-    [sym_assignment] = STATE(57),
-    [sym_nil] = ACTIONS(151),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(61),
-    [anon_sym_DQUOTE] = ACTIONS(169),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym_assignment] = STATE(107),
+    [sym_nil] = ACTIONS(158),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(162),
+    [anon_sym_DQUOTE] = ACTIONS(164),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
     [sym_comment] = ACTIONS(3),
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
-  [12] = {
-    [sym__expression] = STATE(101),
-    [sym_bool] = STATE(101),
-    [sym_float] = STATE(101),
-    [sym_integer] = STATE(101),
-    [sym_symbol] = STATE(101),
-    [sym_char] = STATE(101),
-    [sym_string] = STATE(101),
-    [sym_array] = STATE(101),
-    [sym_hash] = STATE(101),
-    [sym_regex] = STATE(101),
-    [sym_tuple] = STATE(101),
-    [sym_namedTupleLiteral] = STATE(101),
-    [sym_commandLiteral] = STATE(101),
-    [sym_local_variable] = STATE(173),
-    [sym_instance_variable] = STATE(173),
-    [sym_class_variable] = STATE(173),
-    [sym_constant] = STATE(173),
-    [sym_assignment] = STATE(101),
-    [sym_nil] = ACTIONS(171),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(161),
-    [anon_sym_DQUOTE] = ACTIONS(163),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+  [7] = {
+    [sym__expression] = STATE(98),
+    [sym_bool] = STATE(98),
+    [sym_float] = STATE(98),
+    [sym_integer] = STATE(98),
+    [sym_symbol] = STATE(98),
+    [sym_char] = STATE(98),
+    [sym_string] = STATE(98),
+    [sym_array] = STATE(98),
+    [sym_hash] = STATE(98),
+    [sym_regex] = STATE(98),
+    [sym_tuple] = STATE(98),
+    [sym_namedTupleLiteral] = STATE(98),
+    [sym_commandLiteral] = STATE(98),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym_assignment] = STATE(98),
+    [sym_nil] = ACTIONS(166),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(162),
+    [anon_sym_DQUOTE] = ACTIONS(164),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
     [sym_comment] = ACTIONS(3),
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
-  [13] = {
-    [sym__expression] = STATE(103),
-    [sym_bool] = STATE(103),
-    [sym_float] = STATE(103),
-    [sym_integer] = STATE(103),
-    [sym_symbol] = STATE(103),
-    [sym_char] = STATE(103),
-    [sym_string] = STATE(103),
-    [sym_array] = STATE(103),
-    [sym_hash] = STATE(103),
-    [sym_regex] = STATE(103),
-    [sym_tuple] = STATE(103),
-    [sym_namedTupleLiteral] = STATE(103),
-    [sym_commandLiteral] = STATE(103),
-    [sym_local_variable] = STATE(173),
-    [sym_instance_variable] = STATE(173),
-    [sym_class_variable] = STATE(173),
-    [sym_constant] = STATE(173),
-    [sym_assignment] = STATE(103),
-    [sym_nil] = ACTIONS(173),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(161),
-    [anon_sym_DQUOTE] = ACTIONS(163),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
-  },
-  [14] = {
-    [sym__expression] = STATE(84),
-    [sym_bool] = STATE(84),
-    [sym_float] = STATE(84),
-    [sym_integer] = STATE(84),
-    [sym_symbol] = STATE(84),
-    [sym_char] = STATE(84),
-    [sym_string] = STATE(84),
-    [sym_array] = STATE(84),
-    [sym_hash] = STATE(84),
-    [sym_regex] = STATE(84),
-    [sym_tuple] = STATE(84),
-    [sym_namedTupleLiteral] = STATE(84),
-    [sym_commandLiteral] = STATE(84),
-    [sym_local_variable] = STATE(173),
-    [sym_instance_variable] = STATE(173),
-    [sym_class_variable] = STATE(173),
-    [sym_constant] = STATE(173),
-    [sym_assignment] = STATE(84),
-    [sym_nil] = ACTIONS(175),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(161),
-    [anon_sym_DQUOTE] = ACTIONS(163),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
-  },
-  [15] = {
-    [sym__expression] = STATE(108),
-    [sym_bool] = STATE(108),
-    [sym_float] = STATE(108),
-    [sym_integer] = STATE(108),
-    [sym_symbol] = STATE(108),
-    [sym_char] = STATE(108),
-    [sym_string] = STATE(108),
-    [sym_array] = STATE(108),
-    [sym_hash] = STATE(108),
-    [sym_regex] = STATE(108),
-    [sym_tuple] = STATE(108),
-    [sym_namedTupleLiteral] = STATE(108),
-    [sym_commandLiteral] = STATE(108),
-    [sym_local_variable] = STATE(168),
-    [sym_instance_variable] = STATE(168),
-    [sym_class_variable] = STATE(168),
-    [sym_constant] = STATE(168),
-    [sym_assignment] = STATE(108),
-    [sym_nil] = ACTIONS(177),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(155),
-    [anon_sym_DQUOTE] = ACTIONS(157),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
-  },
-  [16] = {
-    [sym__expression] = STATE(57),
-    [sym_bool] = STATE(57),
-    [sym_float] = STATE(57),
-    [sym_integer] = STATE(57),
-    [sym_symbol] = STATE(57),
-    [sym_char] = STATE(57),
-    [sym_string] = STATE(57),
-    [sym_array] = STATE(57),
-    [sym_hash] = STATE(57),
-    [sym_regex] = STATE(57),
-    [sym_tuple] = STATE(57),
-    [sym_namedTupleLiteral] = STATE(57),
-    [sym_commandLiteral] = STATE(57),
-    [sym_local_variable] = STATE(176),
-    [sym_instance_variable] = STATE(176),
-    [sym_class_variable] = STATE(176),
-    [sym_constant] = STATE(176),
-    [sym_assignment] = STATE(57),
-    [sym_nil] = ACTIONS(151),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(179),
-    [anon_sym_DQUOTE] = ACTIONS(181),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
-  },
-  [17] = {
-    [sym__expression] = STATE(134),
-    [sym_bool] = STATE(134),
-    [sym_float] = STATE(134),
-    [sym_integer] = STATE(134),
-    [sym_symbol] = STATE(134),
-    [sym_char] = STATE(134),
-    [sym_string] = STATE(134),
-    [sym_array] = STATE(134),
-    [sym_hash] = STATE(134),
-    [sym_regex] = STATE(134),
-    [sym_tuple] = STATE(134),
-    [sym_namedTupleLiteral] = STATE(134),
-    [sym_commandLiteral] = STATE(134),
-    [sym_local_variable] = STATE(166),
-    [sym_instance_variable] = STATE(166),
-    [sym_class_variable] = STATE(166),
-    [sym_constant] = STATE(166),
-    [sym_assignment] = STATE(134),
-    [sym_nil] = ACTIONS(183),
+  [8] = {
+    [sym__expression] = STATE(142),
+    [sym_bool] = STATE(142),
+    [sym_float] = STATE(142),
+    [sym_integer] = STATE(142),
+    [sym_symbol] = STATE(142),
+    [sym_char] = STATE(142),
+    [sym_string] = STATE(142),
+    [sym_array] = STATE(142),
+    [sym_hash] = STATE(142),
+    [sym_regex] = STATE(142),
+    [sym_tuple] = STATE(142),
+    [sym_namedTupleLiteral] = STATE(142),
+    [sym_commandLiteral] = STATE(142),
+    [sym_local_variable] = STATE(150),
+    [sym_instance_variable] = STATE(150),
+    [sym_class_variable] = STATE(150),
+    [sym_constant] = STATE(150),
+    [sym_assignment] = STATE(142),
+    [sym_nil] = ACTIONS(168),
     [anon_sym_true] = ACTIONS(9),
     [anon_sym_false] = ACTIONS(9),
     [aux_sym_float_token1] = ACTIONS(11),
@@ -3334,231 +3351,791 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [9] = {
+    [sym__expression] = STATE(48),
+    [sym_bool] = STATE(48),
+    [sym_float] = STATE(48),
+    [sym_integer] = STATE(48),
+    [sym_symbol] = STATE(48),
+    [sym_char] = STATE(48),
+    [sym_string] = STATE(48),
+    [sym_array] = STATE(48),
+    [sym_hash] = STATE(48),
+    [sym_regex] = STATE(48),
+    [sym_tuple] = STATE(48),
+    [sym_namedTupleLiteral] = STATE(48),
+    [sym_commandLiteral] = STATE(48),
+    [sym_local_variable] = STATE(174),
+    [sym_instance_variable] = STATE(174),
+    [sym_class_variable] = STATE(174),
+    [sym_constant] = STATE(174),
+    [sym_assignment] = STATE(48),
+    [sym_nil] = ACTIONS(170),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(172),
+    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [10] = {
+    [sym__expression] = STATE(113),
+    [sym_bool] = STATE(113),
+    [sym_float] = STATE(113),
+    [sym_integer] = STATE(113),
+    [sym_symbol] = STATE(113),
+    [sym_char] = STATE(113),
+    [sym_string] = STATE(113),
+    [sym_array] = STATE(113),
+    [sym_hash] = STATE(113),
+    [sym_regex] = STATE(113),
+    [sym_tuple] = STATE(113),
+    [sym_namedTupleLiteral] = STATE(113),
+    [sym_commandLiteral] = STATE(113),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym_assignment] = STATE(113),
+    [sym_nil] = ACTIONS(176),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(162),
+    [anon_sym_DQUOTE] = ACTIONS(164),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [11] = {
+    [sym__expression] = STATE(48),
+    [sym_bool] = STATE(48),
+    [sym_float] = STATE(48),
+    [sym_integer] = STATE(48),
+    [sym_symbol] = STATE(48),
+    [sym_char] = STATE(48),
+    [sym_string] = STATE(48),
+    [sym_array] = STATE(48),
+    [sym_hash] = STATE(48),
+    [sym_regex] = STATE(48),
+    [sym_tuple] = STATE(48),
+    [sym_namedTupleLiteral] = STATE(48),
+    [sym_commandLiteral] = STATE(48),
+    [sym_local_variable] = STATE(177),
+    [sym_instance_variable] = STATE(177),
+    [sym_class_variable] = STATE(177),
+    [sym_constant] = STATE(177),
+    [sym_assignment] = STATE(48),
+    [sym_nil] = ACTIONS(170),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(178),
+    [anon_sym_DQUOTE] = ACTIONS(180),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [12] = {
+    [sym__expression] = STATE(48),
+    [sym_bool] = STATE(48),
+    [sym_float] = STATE(48),
+    [sym_integer] = STATE(48),
+    [sym_symbol] = STATE(48),
+    [sym_char] = STATE(48),
+    [sym_string] = STATE(48),
+    [sym_array] = STATE(48),
+    [sym_hash] = STATE(48),
+    [sym_regex] = STATE(48),
+    [sym_tuple] = STATE(48),
+    [sym_namedTupleLiteral] = STATE(48),
+    [sym_commandLiteral] = STATE(48),
+    [sym_local_variable] = STATE(171),
+    [sym_instance_variable] = STATE(171),
+    [sym_class_variable] = STATE(171),
+    [sym_constant] = STATE(171),
+    [sym_assignment] = STATE(48),
+    [sym_nil] = ACTIONS(170),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(63),
+    [anon_sym_DQUOTE] = ACTIONS(182),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [13] = {
+    [sym__expression] = STATE(101),
+    [sym_bool] = STATE(101),
+    [sym_float] = STATE(101),
+    [sym_integer] = STATE(101),
+    [sym_symbol] = STATE(101),
+    [sym_char] = STATE(101),
+    [sym_string] = STATE(101),
+    [sym_array] = STATE(101),
+    [sym_hash] = STATE(101),
+    [sym_regex] = STATE(101),
+    [sym_tuple] = STATE(101),
+    [sym_namedTupleLiteral] = STATE(101),
+    [sym_commandLiteral] = STATE(101),
+    [sym_local_variable] = STATE(174),
+    [sym_instance_variable] = STATE(174),
+    [sym_class_variable] = STATE(174),
+    [sym_constant] = STATE(174),
+    [sym_assignment] = STATE(101),
+    [sym_nil] = ACTIONS(184),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(172),
+    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [14] = {
+    [sym__expression] = STATE(103),
+    [sym_bool] = STATE(103),
+    [sym_float] = STATE(103),
+    [sym_integer] = STATE(103),
+    [sym_symbol] = STATE(103),
+    [sym_char] = STATE(103),
+    [sym_string] = STATE(103),
+    [sym_array] = STATE(103),
+    [sym_hash] = STATE(103),
+    [sym_regex] = STATE(103),
+    [sym_tuple] = STATE(103),
+    [sym_namedTupleLiteral] = STATE(103),
+    [sym_commandLiteral] = STATE(103),
+    [sym_local_variable] = STATE(174),
+    [sym_instance_variable] = STATE(174),
+    [sym_class_variable] = STATE(174),
+    [sym_constant] = STATE(174),
+    [sym_assignment] = STATE(103),
+    [sym_nil] = ACTIONS(186),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(172),
+    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [15] = {
+    [sym__expression] = STATE(98),
+    [sym_bool] = STATE(98),
+    [sym_float] = STATE(98),
+    [sym_integer] = STATE(98),
+    [sym_symbol] = STATE(98),
+    [sym_char] = STATE(98),
+    [sym_string] = STATE(98),
+    [sym_array] = STATE(98),
+    [sym_hash] = STATE(98),
+    [sym_regex] = STATE(98),
+    [sym_tuple] = STATE(98),
+    [sym_namedTupleLiteral] = STATE(98),
+    [sym_commandLiteral] = STATE(98),
+    [sym_local_variable] = STATE(174),
+    [sym_instance_variable] = STATE(174),
+    [sym_class_variable] = STATE(174),
+    [sym_constant] = STATE(174),
+    [sym_assignment] = STATE(98),
+    [sym_nil] = ACTIONS(166),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(172),
+    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [16] = {
+    [sym__expression] = STATE(154),
+    [sym_bool] = STATE(154),
+    [sym_float] = STATE(154),
+    [sym_integer] = STATE(154),
+    [sym_symbol] = STATE(154),
+    [sym_char] = STATE(154),
+    [sym_string] = STATE(154),
+    [sym_array] = STATE(154),
+    [sym_hash] = STATE(154),
+    [sym_regex] = STATE(154),
+    [sym_tuple] = STATE(154),
+    [sym_namedTupleLiteral] = STATE(154),
+    [sym_commandLiteral] = STATE(154),
+    [sym_local_variable] = STATE(177),
+    [sym_instance_variable] = STATE(177),
+    [sym_class_variable] = STATE(177),
+    [sym_constant] = STATE(177),
+    [sym_assignment] = STATE(154),
+    [sym_nil] = ACTIONS(188),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(178),
+    [anon_sym_DQUOTE] = ACTIONS(180),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [17] = {
+    [sym__expression] = STATE(136),
+    [sym_bool] = STATE(136),
+    [sym_float] = STATE(136),
+    [sym_integer] = STATE(136),
+    [sym_symbol] = STATE(136),
+    [sym_char] = STATE(136),
+    [sym_string] = STATE(136),
+    [sym_array] = STATE(136),
+    [sym_hash] = STATE(136),
+    [sym_regex] = STATE(136),
+    [sym_tuple] = STATE(136),
+    [sym_namedTupleLiteral] = STATE(136),
+    [sym_commandLiteral] = STATE(136),
+    [sym_local_variable] = STATE(174),
+    [sym_instance_variable] = STATE(174),
+    [sym_class_variable] = STATE(174),
+    [sym_constant] = STATE(174),
+    [sym_assignment] = STATE(136),
+    [sym_nil] = ACTIONS(190),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(172),
+    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
   [18] = {
-    [sym__expression] = STATE(146),
-    [sym_bool] = STATE(146),
-    [sym_float] = STATE(146),
-    [sym_integer] = STATE(146),
-    [sym_symbol] = STATE(146),
-    [sym_char] = STATE(146),
-    [sym_string] = STATE(146),
-    [sym_array] = STATE(146),
-    [sym_hash] = STATE(146),
-    [sym_regex] = STATE(146),
-    [sym_tuple] = STATE(146),
-    [sym_namedTupleLiteral] = STATE(146),
-    [sym_commandLiteral] = STATE(146),
-    [sym_local_variable] = STATE(176),
-    [sym_instance_variable] = STATE(176),
-    [sym_class_variable] = STATE(176),
-    [sym_constant] = STATE(176),
-    [sym_assignment] = STATE(146),
-    [sym_nil] = ACTIONS(185),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(179),
-    [anon_sym_DQUOTE] = ACTIONS(181),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym__expression] = STATE(74),
+    [sym_bool] = STATE(74),
+    [sym_float] = STATE(74),
+    [sym_integer] = STATE(74),
+    [sym_symbol] = STATE(74),
+    [sym_char] = STATE(74),
+    [sym_string] = STATE(74),
+    [sym_array] = STATE(74),
+    [sym_hash] = STATE(74),
+    [sym_regex] = STATE(74),
+    [sym_tuple] = STATE(74),
+    [sym_namedTupleLiteral] = STATE(74),
+    [sym_commandLiteral] = STATE(74),
+    [sym_local_variable] = STATE(174),
+    [sym_instance_variable] = STATE(174),
+    [sym_class_variable] = STATE(174),
+    [sym_constant] = STATE(174),
+    [sym_assignment] = STATE(74),
+    [sym_nil] = ACTIONS(192),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(172),
+    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
     [sym_comment] = ACTIONS(3),
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
   [19] = {
-    [sym__expression] = STATE(84),
-    [sym_bool] = STATE(84),
-    [sym_float] = STATE(84),
-    [sym_integer] = STATE(84),
-    [sym_symbol] = STATE(84),
-    [sym_char] = STATE(84),
-    [sym_string] = STATE(84),
-    [sym_array] = STATE(84),
-    [sym_hash] = STATE(84),
-    [sym_regex] = STATE(84),
-    [sym_tuple] = STATE(84),
-    [sym_namedTupleLiteral] = STATE(84),
-    [sym_commandLiteral] = STATE(84),
-    [sym_local_variable] = STATE(168),
-    [sym_instance_variable] = STATE(168),
-    [sym_class_variable] = STATE(168),
-    [sym_constant] = STATE(168),
-    [sym_assignment] = STATE(84),
-    [sym_nil] = ACTIONS(175),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(155),
-    [anon_sym_DQUOTE] = ACTIONS(157),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym__expression] = STATE(76),
+    [sym_bool] = STATE(76),
+    [sym_float] = STATE(76),
+    [sym_integer] = STATE(76),
+    [sym_symbol] = STATE(76),
+    [sym_char] = STATE(76),
+    [sym_string] = STATE(76),
+    [sym_array] = STATE(76),
+    [sym_hash] = STATE(76),
+    [sym_regex] = STATE(76),
+    [sym_tuple] = STATE(76),
+    [sym_namedTupleLiteral] = STATE(76),
+    [sym_commandLiteral] = STATE(76),
+    [sym_local_variable] = STATE(174),
+    [sym_instance_variable] = STATE(174),
+    [sym_class_variable] = STATE(174),
+    [sym_constant] = STATE(174),
+    [sym_assignment] = STATE(76),
+    [sym_nil] = ACTIONS(194),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(172),
+    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
     [sym_comment] = ACTIONS(3),
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
   [20] = {
-    [sym__expression] = STATE(137),
-    [sym_bool] = STATE(137),
-    [sym_float] = STATE(137),
-    [sym_integer] = STATE(137),
-    [sym_symbol] = STATE(137),
-    [sym_char] = STATE(137),
-    [sym_string] = STATE(137),
-    [sym_array] = STATE(137),
-    [sym_hash] = STATE(137),
-    [sym_regex] = STATE(137),
-    [sym_tuple] = STATE(137),
-    [sym_namedTupleLiteral] = STATE(137),
-    [sym_commandLiteral] = STATE(137),
-    [sym_local_variable] = STATE(173),
-    [sym_instance_variable] = STATE(173),
-    [sym_class_variable] = STATE(173),
-    [sym_constant] = STATE(173),
-    [sym_assignment] = STATE(137),
-    [sym_nil] = ACTIONS(187),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(161),
-    [anon_sym_DQUOTE] = ACTIONS(163),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym__expression] = STATE(140),
+    [sym_bool] = STATE(140),
+    [sym_float] = STATE(140),
+    [sym_integer] = STATE(140),
+    [sym_symbol] = STATE(140),
+    [sym_char] = STATE(140),
+    [sym_string] = STATE(140),
+    [sym_array] = STATE(140),
+    [sym_hash] = STATE(140),
+    [sym_regex] = STATE(140),
+    [sym_tuple] = STATE(140),
+    [sym_namedTupleLiteral] = STATE(140),
+    [sym_commandLiteral] = STATE(140),
+    [sym_local_variable] = STATE(174),
+    [sym_instance_variable] = STATE(174),
+    [sym_class_variable] = STATE(174),
+    [sym_constant] = STATE(174),
+    [sym_assignment] = STATE(140),
+    [sym_nil] = ACTIONS(196),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(172),
+    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
     [sym_comment] = ACTIONS(3),
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
   [21] = {
-    [sym__expression] = STATE(88),
-    [sym_bool] = STATE(88),
-    [sym_float] = STATE(88),
-    [sym_integer] = STATE(88),
-    [sym_symbol] = STATE(88),
-    [sym_char] = STATE(88),
-    [sym_string] = STATE(88),
-    [sym_array] = STATE(88),
-    [sym_hash] = STATE(88),
-    [sym_regex] = STATE(88),
-    [sym_tuple] = STATE(88),
-    [sym_namedTupleLiteral] = STATE(88),
-    [sym_commandLiteral] = STATE(88),
-    [sym_local_variable] = STATE(173),
-    [sym_instance_variable] = STATE(173),
-    [sym_class_variable] = STATE(173),
-    [sym_constant] = STATE(173),
-    [sym_assignment] = STATE(88),
-    [sym_nil] = ACTIONS(189),
-    [anon_sym_true] = ACTIONS(153),
-    [anon_sym_false] = ACTIONS(153),
-    [aux_sym_float_token1] = ACTIONS(53),
-    [aux_sym_float_token2] = ACTIONS(55),
-    [aux_sym_float_token3] = ACTIONS(55),
-    [aux_sym_integer_token1] = ACTIONS(57),
-    [aux_sym_integer_token2] = ACTIONS(57),
-    [aux_sym_integer_token3] = ACTIONS(57),
-    [aux_sym_integer_token4] = ACTIONS(59),
-    [anon_sym_COLON] = ACTIONS(161),
-    [anon_sym_DQUOTE] = ACTIONS(163),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(65),
-    [aux_sym_char_token1] = ACTIONS(65),
-    [aux_sym_char_token2] = ACTIONS(67),
-    [anon_sym_LBRACK] = ACTIONS(69),
-    [anon_sym_LBRACE] = ACTIONS(71),
-    [anon_sym_SLASH] = ACTIONS(75),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(77),
-    [anon_sym_BQUOTE] = ACTIONS(79),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(81),
+    [sym__expression] = STATE(48),
+    [sym_bool] = STATE(48),
+    [sym_float] = STATE(48),
+    [sym_integer] = STATE(48),
+    [sym_symbol] = STATE(48),
+    [sym_char] = STATE(48),
+    [sym_string] = STATE(48),
+    [sym_array] = STATE(48),
+    [sym_hash] = STATE(48),
+    [sym_regex] = STATE(48),
+    [sym_tuple] = STATE(48),
+    [sym_namedTupleLiteral] = STATE(48),
+    [sym_commandLiteral] = STATE(48),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym_assignment] = STATE(48),
+    [sym_nil] = ACTIONS(170),
+    [anon_sym_true] = ACTIONS(160),
+    [anon_sym_false] = ACTIONS(160),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(162),
+    [anon_sym_DQUOTE] = ACTIONS(164),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
     [sym_comment] = ACTIONS(3),
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
     [anon_sym_AT_AT] = ACTIONS(43),
-    [aux_sym_constant_token1] = ACTIONS(45),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
 };
 
@@ -3566,7 +4143,7 @@ static const uint16_t ts_small_parse_table[] = {
   [0] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(193), 7,
+    ACTIONS(200), 7,
       aux_sym_float_token2,
       aux_sym_float_token3,
       aux_sym_integer_token4,
@@ -3574,7 +4151,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_local_variable_token1,
       anon_sym_AT,
       aux_sym_constant_token1,
-    ACTIONS(191), 29,
+    ACTIONS(198), 33,
       ts_builtin_sym_end,
       sym_nil,
       anon_sym_true,
@@ -3604,14 +4181,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_BQUOTE,
       anon_sym_PERCENTx_LPAREN,
       anon_sym_AT_AT,
-  [44] = 5,
+      anon_sym___LINE__,
+      anon_sym___END_LINE__,
+      anon_sym___FILE__,
+      anon_sym___DIR__,
+  [48] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(197), 1,
+    ACTIONS(204), 1,
       anon_sym_DQUOTE,
-    STATE(34), 1,
+    STATE(59), 1,
       sym__operator,
-    ACTIONS(199), 7,
+    ACTIONS(206), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3619,7 +4200,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(195), 20,
+    ACTIONS(202), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3640,14 +4221,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [85] = 5,
+  [89] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(201), 1,
+    ACTIONS(210), 1,
       anon_sym_DQUOTE,
-    STATE(34), 1,
+    STATE(135), 1,
       sym__operator,
-    ACTIONS(199), 7,
+    ACTIONS(212), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3655,7 +4236,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(195), 20,
+    ACTIONS(208), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3676,14 +4257,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [126] = 5,
+  [130] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(205), 1,
+    ACTIONS(214), 1,
       anon_sym_DQUOTE,
-    STATE(128), 1,
+    STATE(59), 1,
       sym__operator,
-    ACTIONS(207), 7,
+    ACTIONS(206), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3691,7 +4272,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(203), 20,
+    ACTIONS(202), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3712,14 +4293,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [167] = 5,
+  [171] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(209), 1,
+    ACTIONS(216), 1,
       anon_sym_DQUOTE,
-    STATE(34), 1,
+    STATE(59), 1,
       sym__operator,
-    ACTIONS(199), 7,
+    ACTIONS(206), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3727,7 +4308,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(195), 20,
+    ACTIONS(202), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3748,14 +4329,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [208] = 5,
+  [212] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(211), 1,
+    ACTIONS(218), 1,
       anon_sym_DQUOTE,
-    STATE(34), 1,
+    STATE(59), 1,
       sym__operator,
-    ACTIONS(199), 7,
+    ACTIONS(206), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -3763,7 +4344,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(195), 20,
+    ACTIONS(202), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -3784,1331 +4365,1337 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [249] = 3,
-    ACTIONS(217), 1,
+  [253] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(213), 4,
+    ACTIONS(220), 4,
       anon_sym_COLON,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [263] = 3,
-    ACTIONS(217), 1,
+  [267] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(219), 4,
+    ACTIONS(226), 4,
       anon_sym_COLON,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [277] = 3,
-    ACTIONS(217), 1,
+  [281] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(221), 3,
+    ACTIONS(226), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [290] = 3,
-    ACTIONS(217), 1,
+  [294] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(223), 3,
+    ACTIONS(220), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [303] = 3,
-    ACTIONS(217), 1,
+  [307] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(213), 3,
+    ACTIONS(228), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [316] = 3,
-    ACTIONS(217), 1,
+  [320] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(219), 3,
+    ACTIONS(230), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [329] = 2,
+  [333] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(225), 4,
+    ACTIONS(232), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [339] = 2,
+  [343] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(227), 4,
+    ACTIONS(234), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [349] = 3,
+  [353] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(229), 1,
+    ACTIONS(236), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [363] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(238), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [373] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(240), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [383] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(242), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [393] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(244), 1,
       anon_sym_COLON,
-    ACTIONS(231), 3,
+    ACTIONS(246), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [361] = 5,
+  [405] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(233), 1,
+    ACTIONS(248), 4,
       anon_sym_COMMA,
-    ACTIONS(235), 1,
+      anon_sym_RBRACK,
       anon_sym_EQ_GT,
-    ACTIONS(237), 1,
+      anon_sym_RBRACE,
+  [415] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      anon_sym_COLON,
+    ACTIONS(246), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [427] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(230), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+  [439] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(252), 1,
+      anon_sym_COMMA,
+    ACTIONS(254), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(256), 1,
+      anon_sym_RBRACE,
+    STATE(97), 1,
+      aux_sym_array_repeat1,
+  [455] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(220), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [467] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(228), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [479] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(226), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [491] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(258), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [501] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(260), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [511] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(262), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [521] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(226), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+  [533] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(264), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [543] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(266), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [553] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(230), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [565] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(220), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [577] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(230), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [589] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(220), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [601] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(226), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [613] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(268), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [623] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(228), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+  [635] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(270), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [645] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(272), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [655] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(274), 1,
+      aux_sym_identifier_token1,
+    ACTIONS(276), 1,
+      anon_sym_DQUOTE,
+    STATE(152), 2,
+      sym_identifier,
+      sym_string,
+  [669] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(278), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [679] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(280), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [689] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(228), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [701] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(252), 1,
+      anon_sym_COMMA,
+    ACTIONS(282), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(284), 1,
       anon_sym_RBRACE,
     STATE(104), 1,
       aux_sym_array_repeat1,
-  [377] = 5,
+  [717] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(233), 1,
+    ACTIONS(286), 4,
       anon_sym_COMMA,
-    ACTIONS(239), 1,
+      anon_sym_RBRACK,
       anon_sym_EQ_GT,
-    ACTIONS(241), 1,
       anon_sym_RBRACE,
-    STATE(78), 1,
+  [727] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(288), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(290), 1,
+      aux_sym_symbol_token1,
+    STATE(102), 1,
+      aux_sym_symbol_repeat1,
+  [740] = 3,
+    ACTIONS(220), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [751] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(292), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(294), 1,
+      aux_sym_symbol_token1,
+    STATE(114), 1,
+      aux_sym_symbol_repeat1,
+  [764] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(296), 1,
+      anon_sym_COMMA,
+    ACTIONS(299), 1,
+      anon_sym_RBRACK,
+    STATE(72), 1,
       aux_sym_array_repeat1,
-  [393] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(223), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [405] = 3,
+  [777] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(243), 1,
-      anon_sym_COLON,
-    ACTIONS(231), 3,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
+    ACTIONS(299), 1,
       anon_sym_RBRACE,
-  [417] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(219), 2,
+    ACTIONS(301), 1,
       anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [429] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(221), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [441] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(213), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [453] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(213), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [465] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(245), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [475] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(213), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [487] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(247), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [497] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(221), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-  [509] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(221), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [521] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(219), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-  [533] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(249), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(251), 1,
-      anon_sym_DQUOTE,
-    STATE(163), 2,
-      sym_identifier,
-      sym_string,
-  [547] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(219), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [559] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(253), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [569] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(255), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [579] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(257), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [589] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(259), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [599] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(261), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [609] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(223), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [621] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(263), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [631] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(265), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [641] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(267), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [651] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(223), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-  [663] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(269), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [673] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(271), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [683] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(273), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [693] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(275), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [703] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(277), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [713] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(279), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [723] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(281), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(283), 1,
-      aux_sym_symbol_token1,
-    STATE(92), 1,
-      aux_sym_symbol_repeat1,
-  [736] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(285), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(287), 1,
-      aux_sym_symbol_token1,
-    STATE(81), 1,
-      aux_sym_symbol_repeat1,
-  [749] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(289), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(291), 1,
-      aux_sym_symbol_token1,
-    STATE(106), 1,
-      aux_sym_symbol_repeat1,
-  [762] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(293), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(295), 1,
-      aux_sym_symbol_token1,
     STATE(73), 1,
-      aux_sym_symbol_repeat1,
-  [775] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    STATE(73), 1,
-      aux_sym_symbol_repeat1,
-    ACTIONS(297), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [786] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(300), 1,
-      anon_sym_COMMA,
-    ACTIONS(303), 1,
-      anon_sym_RBRACE,
-    STATE(74), 1,
       aux_sym_array_repeat1,
-  [799] = 4,
+  [790] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(305), 1,
+    ACTIONS(304), 1,
       anon_sym_COMMA,
-    ACTIONS(307), 1,
-      anon_sym_RBRACK,
-    STATE(86), 1,
-      aux_sym_array_repeat1,
-  [812] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(295), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(309), 1,
-      anon_sym_DQUOTE,
-    STATE(73), 1,
-      aux_sym_symbol_repeat1,
-  [825] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(311), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(313), 1,
-      aux_sym_symbol_token1,
-    STATE(76), 1,
-      aux_sym_symbol_repeat1,
-  [838] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(233), 1,
-      anon_sym_COMMA,
-    ACTIONS(315), 1,
+    ACTIONS(306), 1,
       anon_sym_RBRACE,
-    STATE(74), 1,
-      aux_sym_array_repeat1,
-  [851] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(295), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(317), 1,
-      anon_sym_DQUOTE,
-    STATE(73), 1,
-      aux_sym_symbol_repeat1,
-  [864] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(319), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(321), 1,
-      aux_sym_symbol_token1,
     STATE(79), 1,
-      aux_sym_symbol_repeat1,
-  [877] = 4,
-    ACTIONS(217), 1,
+      aux_sym_hash_repeat1,
+  [803] = 4,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(295), 1,
+    ACTIONS(290), 1,
       aux_sym_symbol_token1,
-    ACTIONS(323), 1,
+    ACTIONS(308), 1,
       anon_sym_DQUOTE,
-    STATE(73), 1,
+    STATE(102), 1,
       aux_sym_symbol_repeat1,
-  [890] = 4,
-    ACTIONS(217), 1,
+  [816] = 4,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(295), 1,
+    ACTIONS(310), 1,
+      anon_sym_COMMA,
+    ACTIONS(312), 1,
+      anon_sym_RBRACE,
+    STATE(81), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [829] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(314), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(316), 1,
       aux_sym_symbol_token1,
-    ACTIONS(325), 1,
-      anon_sym_DQUOTE,
-    STATE(73), 1,
+    STATE(75), 1,
       aux_sym_symbol_repeat1,
-  [903] = 4,
-    ACTIONS(217), 1,
+  [842] = 4,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(327), 1,
+    ACTIONS(290), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(318), 1,
       anon_sym_DQUOTE,
-    ACTIONS(329), 1,
+    STATE(102), 1,
+      aux_sym_symbol_repeat1,
+  [855] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(304), 1,
+      anon_sym_COMMA,
+    ACTIONS(320), 1,
+      anon_sym_RBRACE,
+    STATE(85), 1,
+      aux_sym_hash_repeat1,
+  [868] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(322), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(324), 1,
+      aux_sym_symbol_token1,
+    STATE(78), 1,
+      aux_sym_symbol_repeat1,
+  [881] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(310), 1,
+      anon_sym_COMMA,
+    ACTIONS(326), 1,
+      anon_sym_RBRACE,
+    STATE(88), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [894] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(290), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(328), 1,
+      anon_sym_DQUOTE,
+    STATE(102), 1,
+      aux_sym_symbol_repeat1,
+  [907] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(290), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(330), 1,
+      anon_sym_DQUOTE,
+    STATE(102), 1,
+      aux_sym_symbol_repeat1,
+  [920] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(332), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(334), 1,
       aux_sym_symbol_token1,
     STATE(82), 1,
       aux_sym_symbol_repeat1,
-  [916] = 2,
+  [933] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(303), 3,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_RBRACE,
-  [925] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(295), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(331), 1,
-      anon_sym_DQUOTE,
-    STATE(73), 1,
-      aux_sym_symbol_repeat1,
-  [938] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(303), 1,
-      anon_sym_RBRACK,
-    ACTIONS(333), 1,
-      anon_sym_COMMA,
-    STATE(86), 1,
-      aux_sym_array_repeat1,
-  [951] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(295), 1,
-      aux_sym_symbol_token1,
     ACTIONS(336), 1,
-      anon_sym_DQUOTE,
-    STATE(73), 1,
-      aux_sym_symbol_repeat1,
-  [964] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(338), 1,
       anon_sym_COMMA,
-    ACTIONS(340), 1,
+    ACTIONS(339), 1,
       anon_sym_RBRACE,
-    STATE(93), 1,
-      aux_sym_hash_repeat1,
-  [977] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(342), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(344), 1,
-      aux_sym_symbol_token1,
     STATE(85), 1,
+      aux_sym_hash_repeat1,
+  [946] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(341), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(343), 1,
+      aux_sym_symbol_token1,
+    STATE(83), 1,
       aux_sym_symbol_repeat1,
-  [990] = 4,
+  [959] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(290), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(345), 1,
+      anon_sym_DQUOTE,
+    STATE(102), 1,
+      aux_sym_symbol_repeat1,
+  [972] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(346), 1,
+    ACTIONS(347), 1,
       anon_sym_COMMA,
-    ACTIONS(348), 1,
-      anon_sym_RBRACE,
-    STATE(95), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1003] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
     ACTIONS(350), 1,
-      anon_sym_DQUOTE,
+      anon_sym_RBRACE,
+    STATE(88), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [985] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(290), 1,
+      aux_sym_symbol_token1,
     ACTIONS(352), 1,
+      anon_sym_DQUOTE,
+    STATE(102), 1,
+      aux_sym_symbol_repeat1,
+  [998] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(354), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(356), 1,
       aux_sym_symbol_token1,
     STATE(87), 1,
       aux_sym_symbol_repeat1,
-  [1016] = 4,
-    ACTIONS(217), 1,
+  [1011] = 4,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(295), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(354), 1,
-      anon_sym_DQUOTE,
-    STATE(73), 1,
-      aux_sym_symbol_repeat1,
-  [1029] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(338), 1,
-      anon_sym_COMMA,
-    ACTIONS(356), 1,
-      anon_sym_RBRACE,
-    STATE(99), 1,
-      aux_sym_hash_repeat1,
-  [1042] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(295), 1,
-      aux_sym_symbol_token1,
     ACTIONS(358), 1,
       anon_sym_DQUOTE,
-    STATE(73), 1,
-      aux_sym_symbol_repeat1,
-  [1055] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(346), 1,
-      anon_sym_COMMA,
     ACTIONS(360), 1,
-      anon_sym_RBRACE,
-    STATE(102), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1068] = 4,
-    ACTIONS(3), 1,
+      aux_sym_symbol_token1,
+    STATE(89), 1,
+      aux_sym_symbol_repeat1,
+  [1024] = 4,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(305), 1,
-      anon_sym_COMMA,
+    ACTIONS(290), 1,
+      aux_sym_symbol_token1,
     ACTIONS(362), 1,
-      anon_sym_RBRACK,
-    STATE(75), 1,
-      aux_sym_array_repeat1,
-  [1081] = 4,
-    ACTIONS(217), 1,
+      anon_sym_DQUOTE,
+    STATE(102), 1,
+      aux_sym_symbol_repeat1,
+  [1037] = 4,
+    ACTIONS(224), 1,
       sym_comment,
+    ACTIONS(290), 1,
+      aux_sym_symbol_token1,
     ACTIONS(364), 1,
       anon_sym_DQUOTE,
-    ACTIONS(366), 1,
-      aux_sym_symbol_token1,
-    STATE(94), 1,
-      aux_sym_symbol_repeat1,
-  [1094] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(346), 1,
-      anon_sym_COMMA,
-    ACTIONS(368), 1,
-      anon_sym_RBRACE,
     STATE(102), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1107] = 4,
-    ACTIONS(3), 1,
+      aux_sym_symbol_repeat1,
+  [1050] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(366), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(368), 1,
+      aux_sym_symbol_token1,
+    STATE(92), 1,
+      aux_sym_symbol_repeat1,
+  [1063] = 4,
+    ACTIONS(224), 1,
       sym_comment,
     ACTIONS(370), 1,
-      anon_sym_COMMA,
-    ACTIONS(373), 1,
-      anon_sym_RBRACE,
-    STATE(99), 1,
-      aux_sym_hash_repeat1,
-  [1120] = 4,
+      anon_sym_DQUOTE,
+    ACTIONS(372), 1,
+      aux_sym_symbol_token1,
+    STATE(93), 1,
+      aux_sym_symbol_repeat1,
+  [1076] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(338), 1,
+    ACTIONS(310), 1,
       anon_sym_COMMA,
-    ACTIONS(375), 1,
+    ACTIONS(374), 1,
       anon_sym_RBRACE,
-    STATE(99), 1,
-      aux_sym_hash_repeat1,
-  [1133] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(346), 1,
-      anon_sym_COMMA,
-    ACTIONS(377), 1,
-      anon_sym_RBRACE,
-    STATE(98), 1,
+    STATE(88), 1,
       aux_sym_namedTupleLiteral_repeat1,
-  [1146] = 4,
+  [1089] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(379), 1,
+    ACTIONS(252), 1,
+      anon_sym_COMMA,
+    ACTIONS(376), 1,
+      anon_sym_RBRACE,
+    STATE(73), 1,
+      aux_sym_array_repeat1,
+  [1102] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(299), 3,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_RBRACE,
+  [1111] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(304), 1,
+      anon_sym_COMMA,
+    ACTIONS(378), 1,
+      anon_sym_RBRACE,
+    STATE(85), 1,
+      aux_sym_hash_repeat1,
+  [1124] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(380), 1,
       anon_sym_COMMA,
     ACTIONS(382), 1,
-      anon_sym_RBRACE,
-    STATE(102), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1159] = 4,
+      anon_sym_RBRACK,
+    STATE(72), 1,
+      aux_sym_array_repeat1,
+  [1137] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(338), 1,
+    ACTIONS(310), 1,
       anon_sym_COMMA,
     ACTIONS(384), 1,
       anon_sym_RBRACE,
-    STATE(100), 1,
-      aux_sym_hash_repeat1,
-  [1172] = 4,
+    STATE(96), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1150] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    STATE(102), 1,
+      aux_sym_symbol_repeat1,
+    ACTIONS(386), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1161] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(233), 1,
+    ACTIONS(304), 1,
       anon_sym_COMMA,
-    ACTIONS(386), 1,
+    ACTIONS(389), 1,
       anon_sym_RBRACE,
-    STATE(74), 1,
-      aux_sym_array_repeat1,
-  [1185] = 4,
+    STATE(99), 1,
+      aux_sym_hash_repeat1,
+  [1174] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(305), 1,
+    ACTIONS(252), 1,
       anon_sym_COMMA,
-    ACTIONS(388), 1,
+    ACTIONS(391), 1,
+      anon_sym_RBRACE,
+    STATE(73), 1,
+      aux_sym_array_repeat1,
+  [1187] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(380), 1,
+      anon_sym_COMMA,
+    ACTIONS(393), 1,
       anon_sym_RBRACK,
-    STATE(86), 1,
+    STATE(72), 1,
       aux_sym_array_repeat1,
-  [1198] = 4,
-    ACTIONS(217), 1,
+  [1200] = 4,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(295), 1,
+    ACTIONS(290), 1,
       aux_sym_symbol_token1,
-    ACTIONS(390), 1,
+    ACTIONS(395), 1,
       anon_sym_DQUOTE,
-    STATE(73), 1,
+    STATE(102), 1,
       aux_sym_symbol_repeat1,
-  [1211] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(295), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(392), 1,
-      anon_sym_DQUOTE,
-    STATE(73), 1,
-      aux_sym_symbol_repeat1,
-  [1224] = 4,
+  [1213] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(305), 1,
+    ACTIONS(380), 1,
       anon_sym_COMMA,
-    ACTIONS(394), 1,
+    ACTIONS(397), 1,
       anon_sym_RBRACK,
     STATE(105), 1,
       aux_sym_array_repeat1,
-  [1237] = 4,
-    ACTIONS(217), 1,
+  [1226] = 4,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(396), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(398), 1,
+    ACTIONS(290), 1,
       aux_sym_symbol_token1,
-    STATE(72), 1,
-      aux_sym_symbol_repeat1,
-  [1250] = 4,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(295), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(400), 1,
+    ACTIONS(399), 1,
       anon_sym_DQUOTE,
-    STATE(73), 1,
+    STATE(102), 1,
       aux_sym_symbol_repeat1,
-  [1263] = 4,
-    ACTIONS(217), 1,
+  [1239] = 4,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(402), 1,
+    ACTIONS(401), 1,
       anon_sym_DQUOTE,
-    ACTIONS(404), 1,
+    ACTIONS(403), 1,
       aux_sym_symbol_token1,
-    STATE(107), 1,
+    STATE(106), 1,
       aux_sym_symbol_repeat1,
-  [1276] = 4,
-    ACTIONS(217), 1,
+  [1252] = 4,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(406), 1,
+    ACTIONS(405), 1,
       anon_sym_DQUOTE,
-    ACTIONS(408), 1,
+    ACTIONS(407), 1,
       aux_sym_symbol_token1,
-    STATE(110), 1,
+    STATE(108), 1,
       aux_sym_symbol_repeat1,
-  [1289] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(219), 1,
+  [1265] = 3,
+    ACTIONS(220), 1,
       anon_sym_COLON,
-    ACTIONS(215), 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1300] = 3,
-    ACTIONS(213), 1,
+  [1276] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(226), 1,
       anon_sym_COLON,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1311] = 3,
-    ACTIONS(217), 1,
+  [1287] = 4,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(219), 1,
+    ACTIONS(380), 1,
+      anon_sym_COMMA,
+    ACTIONS(409), 1,
+      anon_sym_RBRACK,
+    STATE(100), 1,
+      aux_sym_array_repeat1,
+  [1300] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(290), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(411), 1,
+      anon_sym_DQUOTE,
+    STATE(102), 1,
+      aux_sym_symbol_repeat1,
+  [1313] = 4,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(413), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(415), 1,
+      aux_sym_symbol_token1,
+    STATE(69), 1,
+      aux_sym_symbol_repeat1,
+  [1326] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(228), 1,
       anon_sym_EQ_GT,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1322] = 3,
-    ACTIONS(213), 1,
+  [1337] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(226), 1,
       anon_sym_EQ_GT,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1333] = 3,
-    ACTIONS(217), 1,
+  [1348] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(221), 1,
+    ACTIONS(230), 1,
       anon_sym_EQ_GT,
-    ACTIONS(215), 2,
+    ACTIONS(222), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-  [1344] = 3,
-    ACTIONS(217), 1,
+  [1359] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(223), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(215), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1355] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(269), 1,
+    ACTIONS(264), 1,
       aux_sym__statement_token1,
-    ACTIONS(410), 1,
+    ACTIONS(417), 1,
       anon_sym_SEMI,
-  [1365] = 3,
-    ACTIONS(217), 1,
+  [1369] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(412), 1,
-      anon_sym_SEMI,
-    ACTIONS(414), 1,
+    ACTIONS(260), 1,
       aux_sym__statement_token1,
-  [1375] = 3,
-    ACTIONS(217), 1,
+    ACTIONS(419), 1,
+      anon_sym_SEMI,
+  [1379] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(273), 1,
+    ACTIONS(278), 1,
       aux_sym__statement_token1,
-    ACTIONS(416), 1,
+    ACTIONS(421), 1,
       anon_sym_SEMI,
-  [1385] = 3,
-    ACTIONS(217), 1,
+  [1389] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(275), 1,
-      aux_sym__statement_token1,
-    ACTIONS(418), 1,
+    ACTIONS(423), 1,
       anon_sym_SEMI,
-  [1395] = 3,
-    ACTIONS(217), 1,
+    ACTIONS(425), 1,
+      aux_sym__statement_token1,
+  [1399] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(277), 1,
+    ACTIONS(242), 1,
       aux_sym__statement_token1,
-    ACTIONS(420), 1,
+    ACTIONS(427), 1,
       anon_sym_SEMI,
-  [1405] = 3,
+  [1409] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(280), 1,
+      aux_sym__statement_token1,
+    ACTIONS(429), 1,
+      anon_sym_SEMI,
+  [1419] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(286), 1,
+      aux_sym__statement_token1,
+    ACTIONS(431), 1,
+      anon_sym_SEMI,
+  [1429] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(270), 1,
+      aux_sym__statement_token1,
+    ACTIONS(433), 1,
+      anon_sym_SEMI,
+  [1439] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(240), 1,
+      aux_sym__statement_token1,
+    ACTIONS(435), 1,
+      anon_sym_SEMI,
+  [1449] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(422), 1,
+    ACTIONS(437), 1,
       aux_sym_identifier_token1,
-    ACTIONS(424), 1,
+    ACTIONS(439), 1,
       anon_sym_EQ,
-  [1415] = 3,
-    ACTIONS(217), 1,
+  [1459] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(279), 1,
+    ACTIONS(238), 1,
       aux_sym__statement_token1,
-    ACTIONS(426), 1,
+    ACTIONS(441), 1,
       anon_sym_SEMI,
-  [1425] = 3,
-    ACTIONS(217), 1,
+  [1469] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(253), 1,
+    ACTIONS(236), 1,
       aux_sym__statement_token1,
-    ACTIONS(428), 1,
+    ACTIONS(443), 1,
       anon_sym_SEMI,
-  [1435] = 3,
+  [1479] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(430), 1,
+    ACTIONS(445), 1,
       aux_sym_identifier_token1,
-    ACTIONS(432), 1,
+    ACTIONS(447), 1,
       anon_sym_EQ,
-  [1445] = 3,
-    ACTIONS(217), 1,
+  [1489] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(225), 1,
+    ACTIONS(234), 1,
       aux_sym__statement_token1,
-    ACTIONS(434), 1,
+    ACTIONS(449), 1,
       anon_sym_SEMI,
-  [1455] = 3,
+  [1499] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(232), 1,
+      aux_sym__statement_token1,
+    ACTIONS(451), 1,
+      anon_sym_SEMI,
+  [1509] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(248), 1,
+      aux_sym__statement_token1,
+    ACTIONS(453), 1,
+      anon_sym_SEMI,
+  [1519] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(268), 1,
+      aux_sym__statement_token1,
+    ACTIONS(455), 1,
+      anon_sym_SEMI,
+  [1529] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(436), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(438), 1,
-      anon_sym_EQ,
-  [1465] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(255), 1,
-      aux_sym__statement_token1,
-    ACTIONS(440), 1,
-      anon_sym_SEMI,
-  [1475] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(257), 1,
-      aux_sym__statement_token1,
-    ACTIONS(442), 1,
-      anon_sym_SEMI,
-  [1485] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(259), 1,
-      aux_sym__statement_token1,
-    ACTIONS(444), 1,
-      anon_sym_SEMI,
-  [1495] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(446), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(448), 1,
-      anon_sym_EQ,
-  [1505] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(261), 1,
-      aux_sym__statement_token1,
-    ACTIONS(450), 1,
-      anon_sym_SEMI,
-  [1515] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(271), 1,
-      aux_sym__statement_token1,
-    ACTIONS(452), 1,
-      anon_sym_SEMI,
-  [1525] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(454), 2,
+    ACTIONS(457), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [1533] = 2,
+  [1537] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(456), 2,
+    ACTIONS(459), 1,
+      aux_sym_identifier_token1,
+    ACTIONS(461), 1,
+      anon_sym_EQ,
+  [1547] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(463), 1,
+      aux_sym_identifier_token1,
+    ACTIONS(465), 1,
+      anon_sym_EQ,
+  [1557] = 3,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(272), 1,
+      aux_sym__statement_token1,
+    ACTIONS(467), 1,
+      anon_sym_SEMI,
+  [1567] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(469), 2,
       anon_sym_COMMA,
       anon_sym_RBRACE,
-  [1541] = 3,
-    ACTIONS(217), 1,
+  [1575] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(245), 1,
+    ACTIONS(266), 1,
       aux_sym__statement_token1,
-    ACTIONS(458), 1,
+    ACTIONS(471), 1,
       anon_sym_SEMI,
-  [1551] = 3,
-    ACTIONS(217), 1,
+  [1585] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(263), 1,
+    ACTIONS(258), 1,
       aux_sym__statement_token1,
-    ACTIONS(460), 1,
+    ACTIONS(473), 1,
       anon_sym_SEMI,
-  [1561] = 3,
-    ACTIONS(217), 1,
+  [1595] = 3,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(267), 1,
+    ACTIONS(262), 1,
       aux_sym__statement_token1,
-    ACTIONS(462), 1,
+    ACTIONS(475), 1,
       anon_sym_SEMI,
-  [1571] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(247), 1,
-      aux_sym__statement_token1,
-    ACTIONS(464), 1,
-      anon_sym_SEMI,
-  [1581] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(265), 1,
-      aux_sym__statement_token1,
-    ACTIONS(466), 1,
-      anon_sym_SEMI,
-  [1591] = 3,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(227), 1,
-      aux_sym__statement_token1,
-    ACTIONS(468), 1,
-      anon_sym_SEMI,
-  [1601] = 2,
+  [1605] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(470), 1,
+    ACTIONS(477), 1,
       anon_sym_RPAREN,
-  [1608] = 2,
-    ACTIONS(3), 1,
+  [1612] = 2,
+    ACTIONS(224), 1,
       sym_comment,
-    ACTIONS(243), 1,
-      anon_sym_COLON,
-  [1615] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(472), 1,
-      anon_sym_EQ_GT,
-  [1622] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(474), 1,
-      aux_sym_hash_token1,
-  [1629] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(476), 1,
-      anon_sym_EQ_GT,
-  [1636] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(478), 1,
-      anon_sym_SLASH,
-  [1643] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(480), 1,
-      aux_sym_hash_token1,
-  [1650] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(482), 1,
-      anon_sym_COLON,
-  [1657] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(484), 1,
-      anon_sym_EQ,
-  [1664] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(486), 1,
-      anon_sym_EQ,
-  [1671] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(488), 1,
-      ts_builtin_sym_end,
-  [1678] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(470), 1,
-      anon_sym_BQUOTE,
-  [1685] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(490), 1,
-      anon_sym_SLASH,
-  [1692] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(492), 1,
-      aux_sym_hash_token1,
-  [1699] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(494), 1,
-      aux_sym_local_variable_token1,
-  [1706] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(496), 1,
-      aux_sym_local_variable_token1,
-  [1713] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(498), 1,
-      aux_sym_regex_token1,
-  [1720] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(500), 1,
-      aux_sym_commandLiteral_token1,
-  [1727] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(502), 1,
+    ACTIONS(479), 1,
       aux_sym_commandLiteral_token2,
-  [1734] = 2,
+  [1619] = 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(481), 1,
+      aux_sym_hash_token1,
+  [1626] = 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(483), 1,
+      aux_sym_hash_token1,
+  [1633] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(504), 1,
+    ACTIONS(485), 1,
+      anon_sym_EQ,
+  [1640] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(487), 1,
+      anon_sym_EQ,
+  [1647] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(489), 1,
+      anon_sym_EQ,
+  [1654] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(491), 1,
+      anon_sym_EQ,
+  [1661] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(493), 1,
       anon_sym_COLON,
-  [1741] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(506), 1,
-      aux_sym_commandLiteral_token2,
-  [1748] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(508), 1,
-      aux_sym_commandLiteral_token1,
-  [1755] = 2,
+  [1668] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(510), 1,
-      anon_sym_EQ,
-  [1762] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(512), 1,
-      anon_sym_EQ_GT,
-  [1769] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(514), 1,
-      anon_sym_EQ,
-  [1776] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(516), 1,
-      aux_sym_regex_token1,
-  [1783] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(518), 1,
-      anon_sym_EQ,
-  [1790] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(520), 1,
-      anon_sym_EQ,
-  [1797] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(522), 1,
-      anon_sym_EQ,
-  [1804] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(524), 1,
-      anon_sym_EQ,
-  [1811] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(526), 1,
+    ACTIONS(495), 1,
       anon_sym_RPAREN,
-  [1818] = 2,
+  [1675] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(526), 1,
+    ACTIONS(497), 1,
+      anon_sym_EQ_GT,
+  [1682] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(495), 1,
       anon_sym_BQUOTE,
-  [1825] = 2,
+  [1689] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(528), 1,
+    ACTIONS(499), 1,
+      anon_sym_SLASH,
+  [1696] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(477), 1,
+      anon_sym_BQUOTE,
+  [1703] = 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(501), 1,
+      aux_sym_hash_token1,
+  [1710] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(447), 1,
       anon_sym_EQ,
-  [1832] = 2,
+  [1717] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(229), 1,
+    ACTIONS(503), 1,
+      aux_sym_local_variable_token1,
+  [1724] = 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(505), 1,
+      aux_sym_regex_token1,
+  [1731] = 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(507), 1,
+      aux_sym_commandLiteral_token1,
+  [1738] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(509), 1,
+      anon_sym_EQ,
+  [1745] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(511), 1,
+      aux_sym_local_variable_token1,
+  [1752] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(513), 1,
+      anon_sym_SLASH,
+  [1759] = 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(515), 1,
+      aux_sym_commandLiteral_token2,
+  [1766] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(250), 1,
       anon_sym_COLON,
-  [1839] = 2,
+  [1773] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(530), 1,
+    ACTIONS(517), 1,
+      anon_sym_EQ_GT,
+  [1780] = 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(519), 1,
+      aux_sym_commandLiteral_token1,
+  [1787] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(521), 1,
+      anon_sym_EQ,
+  [1794] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(523), 1,
+      anon_sym_EQ,
+  [1801] = 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(525), 1,
+      aux_sym_regex_token1,
+  [1808] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(527), 1,
       anon_sym_of,
-  [1846] = 2,
-    ACTIONS(217), 1,
-      sym_comment,
-    ACTIONS(532), 1,
-      aux_sym_hash_token1,
-  [1853] = 2,
+  [1815] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(534), 1,
+    ACTIONS(529), 1,
+      anon_sym_EQ,
+  [1822] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(531), 1,
+      anon_sym_EQ_GT,
+  [1829] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(533), 1,
+      ts_builtin_sym_end,
+  [1836] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(535), 1,
+      anon_sym_EQ,
+  [1843] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(244), 1,
+      anon_sym_COLON,
+  [1850] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(537), 1,
+      anon_sym_COLON,
+  [1857] = 2,
+    ACTIONS(224), 1,
+      sym_comment,
+    ACTIONS(539), 1,
+      aux_sym_hash_token1,
+  [1864] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(541), 1,
       anon_sym_of,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(22)] = 0,
-  [SMALL_STATE(23)] = 44,
-  [SMALL_STATE(24)] = 85,
-  [SMALL_STATE(25)] = 126,
-  [SMALL_STATE(26)] = 167,
-  [SMALL_STATE(27)] = 208,
-  [SMALL_STATE(28)] = 249,
-  [SMALL_STATE(29)] = 263,
-  [SMALL_STATE(30)] = 277,
-  [SMALL_STATE(31)] = 290,
-  [SMALL_STATE(32)] = 303,
-  [SMALL_STATE(33)] = 316,
-  [SMALL_STATE(34)] = 329,
-  [SMALL_STATE(35)] = 339,
-  [SMALL_STATE(36)] = 349,
-  [SMALL_STATE(37)] = 361,
-  [SMALL_STATE(38)] = 377,
-  [SMALL_STATE(39)] = 393,
-  [SMALL_STATE(40)] = 405,
-  [SMALL_STATE(41)] = 417,
-  [SMALL_STATE(42)] = 429,
-  [SMALL_STATE(43)] = 441,
-  [SMALL_STATE(44)] = 453,
-  [SMALL_STATE(45)] = 465,
-  [SMALL_STATE(46)] = 475,
-  [SMALL_STATE(47)] = 487,
-  [SMALL_STATE(48)] = 497,
-  [SMALL_STATE(49)] = 509,
-  [SMALL_STATE(50)] = 521,
-  [SMALL_STATE(51)] = 533,
-  [SMALL_STATE(52)] = 547,
-  [SMALL_STATE(53)] = 559,
-  [SMALL_STATE(54)] = 569,
-  [SMALL_STATE(55)] = 579,
-  [SMALL_STATE(56)] = 589,
-  [SMALL_STATE(57)] = 599,
-  [SMALL_STATE(58)] = 609,
-  [SMALL_STATE(59)] = 621,
-  [SMALL_STATE(60)] = 631,
-  [SMALL_STATE(61)] = 641,
-  [SMALL_STATE(62)] = 651,
-  [SMALL_STATE(63)] = 663,
-  [SMALL_STATE(64)] = 673,
-  [SMALL_STATE(65)] = 683,
-  [SMALL_STATE(66)] = 693,
-  [SMALL_STATE(67)] = 703,
-  [SMALL_STATE(68)] = 713,
-  [SMALL_STATE(69)] = 723,
-  [SMALL_STATE(70)] = 736,
-  [SMALL_STATE(71)] = 749,
-  [SMALL_STATE(72)] = 762,
-  [SMALL_STATE(73)] = 775,
-  [SMALL_STATE(74)] = 786,
-  [SMALL_STATE(75)] = 799,
-  [SMALL_STATE(76)] = 812,
-  [SMALL_STATE(77)] = 825,
-  [SMALL_STATE(78)] = 838,
-  [SMALL_STATE(79)] = 851,
-  [SMALL_STATE(80)] = 864,
-  [SMALL_STATE(81)] = 877,
-  [SMALL_STATE(82)] = 890,
-  [SMALL_STATE(83)] = 903,
-  [SMALL_STATE(84)] = 916,
-  [SMALL_STATE(85)] = 925,
-  [SMALL_STATE(86)] = 938,
-  [SMALL_STATE(87)] = 951,
-  [SMALL_STATE(88)] = 964,
-  [SMALL_STATE(89)] = 977,
-  [SMALL_STATE(90)] = 990,
-  [SMALL_STATE(91)] = 1003,
-  [SMALL_STATE(92)] = 1016,
-  [SMALL_STATE(93)] = 1029,
-  [SMALL_STATE(94)] = 1042,
-  [SMALL_STATE(95)] = 1055,
-  [SMALL_STATE(96)] = 1068,
-  [SMALL_STATE(97)] = 1081,
-  [SMALL_STATE(98)] = 1094,
-  [SMALL_STATE(99)] = 1107,
-  [SMALL_STATE(100)] = 1120,
-  [SMALL_STATE(101)] = 1133,
-  [SMALL_STATE(102)] = 1146,
-  [SMALL_STATE(103)] = 1159,
-  [SMALL_STATE(104)] = 1172,
-  [SMALL_STATE(105)] = 1185,
-  [SMALL_STATE(106)] = 1198,
-  [SMALL_STATE(107)] = 1211,
-  [SMALL_STATE(108)] = 1224,
-  [SMALL_STATE(109)] = 1237,
-  [SMALL_STATE(110)] = 1250,
-  [SMALL_STATE(111)] = 1263,
+  [SMALL_STATE(23)] = 48,
+  [SMALL_STATE(24)] = 89,
+  [SMALL_STATE(25)] = 130,
+  [SMALL_STATE(26)] = 171,
+  [SMALL_STATE(27)] = 212,
+  [SMALL_STATE(28)] = 253,
+  [SMALL_STATE(29)] = 267,
+  [SMALL_STATE(30)] = 281,
+  [SMALL_STATE(31)] = 294,
+  [SMALL_STATE(32)] = 307,
+  [SMALL_STATE(33)] = 320,
+  [SMALL_STATE(34)] = 333,
+  [SMALL_STATE(35)] = 343,
+  [SMALL_STATE(36)] = 353,
+  [SMALL_STATE(37)] = 363,
+  [SMALL_STATE(38)] = 373,
+  [SMALL_STATE(39)] = 383,
+  [SMALL_STATE(40)] = 393,
+  [SMALL_STATE(41)] = 405,
+  [SMALL_STATE(42)] = 415,
+  [SMALL_STATE(43)] = 427,
+  [SMALL_STATE(44)] = 439,
+  [SMALL_STATE(45)] = 455,
+  [SMALL_STATE(46)] = 467,
+  [SMALL_STATE(47)] = 479,
+  [SMALL_STATE(48)] = 491,
+  [SMALL_STATE(49)] = 501,
+  [SMALL_STATE(50)] = 511,
+  [SMALL_STATE(51)] = 521,
+  [SMALL_STATE(52)] = 533,
+  [SMALL_STATE(53)] = 543,
+  [SMALL_STATE(54)] = 553,
+  [SMALL_STATE(55)] = 565,
+  [SMALL_STATE(56)] = 577,
+  [SMALL_STATE(57)] = 589,
+  [SMALL_STATE(58)] = 601,
+  [SMALL_STATE(59)] = 613,
+  [SMALL_STATE(60)] = 623,
+  [SMALL_STATE(61)] = 635,
+  [SMALL_STATE(62)] = 645,
+  [SMALL_STATE(63)] = 655,
+  [SMALL_STATE(64)] = 669,
+  [SMALL_STATE(65)] = 679,
+  [SMALL_STATE(66)] = 689,
+  [SMALL_STATE(67)] = 701,
+  [SMALL_STATE(68)] = 717,
+  [SMALL_STATE(69)] = 727,
+  [SMALL_STATE(70)] = 740,
+  [SMALL_STATE(71)] = 751,
+  [SMALL_STATE(72)] = 764,
+  [SMALL_STATE(73)] = 777,
+  [SMALL_STATE(74)] = 790,
+  [SMALL_STATE(75)] = 803,
+  [SMALL_STATE(76)] = 816,
+  [SMALL_STATE(77)] = 829,
+  [SMALL_STATE(78)] = 842,
+  [SMALL_STATE(79)] = 855,
+  [SMALL_STATE(80)] = 868,
+  [SMALL_STATE(81)] = 881,
+  [SMALL_STATE(82)] = 894,
+  [SMALL_STATE(83)] = 907,
+  [SMALL_STATE(84)] = 920,
+  [SMALL_STATE(85)] = 933,
+  [SMALL_STATE(86)] = 946,
+  [SMALL_STATE(87)] = 959,
+  [SMALL_STATE(88)] = 972,
+  [SMALL_STATE(89)] = 985,
+  [SMALL_STATE(90)] = 998,
+  [SMALL_STATE(91)] = 1011,
+  [SMALL_STATE(92)] = 1024,
+  [SMALL_STATE(93)] = 1037,
+  [SMALL_STATE(94)] = 1050,
+  [SMALL_STATE(95)] = 1063,
+  [SMALL_STATE(96)] = 1076,
+  [SMALL_STATE(97)] = 1089,
+  [SMALL_STATE(98)] = 1102,
+  [SMALL_STATE(99)] = 1111,
+  [SMALL_STATE(100)] = 1124,
+  [SMALL_STATE(101)] = 1137,
+  [SMALL_STATE(102)] = 1150,
+  [SMALL_STATE(103)] = 1161,
+  [SMALL_STATE(104)] = 1174,
+  [SMALL_STATE(105)] = 1187,
+  [SMALL_STATE(106)] = 1200,
+  [SMALL_STATE(107)] = 1213,
+  [SMALL_STATE(108)] = 1226,
+  [SMALL_STATE(109)] = 1239,
+  [SMALL_STATE(110)] = 1252,
+  [SMALL_STATE(111)] = 1265,
   [SMALL_STATE(112)] = 1276,
-  [SMALL_STATE(113)] = 1289,
+  [SMALL_STATE(113)] = 1287,
   [SMALL_STATE(114)] = 1300,
-  [SMALL_STATE(115)] = 1311,
-  [SMALL_STATE(116)] = 1322,
-  [SMALL_STATE(117)] = 1333,
-  [SMALL_STATE(118)] = 1344,
-  [SMALL_STATE(119)] = 1355,
-  [SMALL_STATE(120)] = 1365,
-  [SMALL_STATE(121)] = 1375,
-  [SMALL_STATE(122)] = 1385,
-  [SMALL_STATE(123)] = 1395,
-  [SMALL_STATE(124)] = 1405,
-  [SMALL_STATE(125)] = 1415,
-  [SMALL_STATE(126)] = 1425,
-  [SMALL_STATE(127)] = 1435,
-  [SMALL_STATE(128)] = 1445,
-  [SMALL_STATE(129)] = 1455,
-  [SMALL_STATE(130)] = 1465,
-  [SMALL_STATE(131)] = 1475,
-  [SMALL_STATE(132)] = 1485,
-  [SMALL_STATE(133)] = 1495,
-  [SMALL_STATE(134)] = 1505,
-  [SMALL_STATE(135)] = 1515,
-  [SMALL_STATE(136)] = 1525,
-  [SMALL_STATE(137)] = 1533,
-  [SMALL_STATE(138)] = 1541,
-  [SMALL_STATE(139)] = 1551,
-  [SMALL_STATE(140)] = 1561,
-  [SMALL_STATE(141)] = 1571,
-  [SMALL_STATE(142)] = 1581,
-  [SMALL_STATE(143)] = 1591,
-  [SMALL_STATE(144)] = 1601,
-  [SMALL_STATE(145)] = 1608,
-  [SMALL_STATE(146)] = 1615,
-  [SMALL_STATE(147)] = 1622,
-  [SMALL_STATE(148)] = 1629,
-  [SMALL_STATE(149)] = 1636,
-  [SMALL_STATE(150)] = 1643,
-  [SMALL_STATE(151)] = 1650,
-  [SMALL_STATE(152)] = 1657,
-  [SMALL_STATE(153)] = 1664,
-  [SMALL_STATE(154)] = 1671,
-  [SMALL_STATE(155)] = 1678,
-  [SMALL_STATE(156)] = 1685,
-  [SMALL_STATE(157)] = 1692,
-  [SMALL_STATE(158)] = 1699,
-  [SMALL_STATE(159)] = 1706,
-  [SMALL_STATE(160)] = 1713,
-  [SMALL_STATE(161)] = 1720,
-  [SMALL_STATE(162)] = 1727,
-  [SMALL_STATE(163)] = 1734,
-  [SMALL_STATE(164)] = 1741,
-  [SMALL_STATE(165)] = 1748,
-  [SMALL_STATE(166)] = 1755,
-  [SMALL_STATE(167)] = 1762,
-  [SMALL_STATE(168)] = 1769,
-  [SMALL_STATE(169)] = 1776,
-  [SMALL_STATE(170)] = 1783,
-  [SMALL_STATE(171)] = 1790,
-  [SMALL_STATE(172)] = 1797,
-  [SMALL_STATE(173)] = 1804,
-  [SMALL_STATE(174)] = 1811,
-  [SMALL_STATE(175)] = 1818,
-  [SMALL_STATE(176)] = 1825,
-  [SMALL_STATE(177)] = 1832,
-  [SMALL_STATE(178)] = 1839,
-  [SMALL_STATE(179)] = 1846,
-  [SMALL_STATE(180)] = 1853,
+  [SMALL_STATE(115)] = 1313,
+  [SMALL_STATE(116)] = 1326,
+  [SMALL_STATE(117)] = 1337,
+  [SMALL_STATE(118)] = 1348,
+  [SMALL_STATE(119)] = 1359,
+  [SMALL_STATE(120)] = 1369,
+  [SMALL_STATE(121)] = 1379,
+  [SMALL_STATE(122)] = 1389,
+  [SMALL_STATE(123)] = 1399,
+  [SMALL_STATE(124)] = 1409,
+  [SMALL_STATE(125)] = 1419,
+  [SMALL_STATE(126)] = 1429,
+  [SMALL_STATE(127)] = 1439,
+  [SMALL_STATE(128)] = 1449,
+  [SMALL_STATE(129)] = 1459,
+  [SMALL_STATE(130)] = 1469,
+  [SMALL_STATE(131)] = 1479,
+  [SMALL_STATE(132)] = 1489,
+  [SMALL_STATE(133)] = 1499,
+  [SMALL_STATE(134)] = 1509,
+  [SMALL_STATE(135)] = 1519,
+  [SMALL_STATE(136)] = 1529,
+  [SMALL_STATE(137)] = 1537,
+  [SMALL_STATE(138)] = 1547,
+  [SMALL_STATE(139)] = 1557,
+  [SMALL_STATE(140)] = 1567,
+  [SMALL_STATE(141)] = 1575,
+  [SMALL_STATE(142)] = 1585,
+  [SMALL_STATE(143)] = 1595,
+  [SMALL_STATE(144)] = 1605,
+  [SMALL_STATE(145)] = 1612,
+  [SMALL_STATE(146)] = 1619,
+  [SMALL_STATE(147)] = 1626,
+  [SMALL_STATE(148)] = 1633,
+  [SMALL_STATE(149)] = 1640,
+  [SMALL_STATE(150)] = 1647,
+  [SMALL_STATE(151)] = 1654,
+  [SMALL_STATE(152)] = 1661,
+  [SMALL_STATE(153)] = 1668,
+  [SMALL_STATE(154)] = 1675,
+  [SMALL_STATE(155)] = 1682,
+  [SMALL_STATE(156)] = 1689,
+  [SMALL_STATE(157)] = 1696,
+  [SMALL_STATE(158)] = 1703,
+  [SMALL_STATE(159)] = 1710,
+  [SMALL_STATE(160)] = 1717,
+  [SMALL_STATE(161)] = 1724,
+  [SMALL_STATE(162)] = 1731,
+  [SMALL_STATE(163)] = 1738,
+  [SMALL_STATE(164)] = 1745,
+  [SMALL_STATE(165)] = 1752,
+  [SMALL_STATE(166)] = 1759,
+  [SMALL_STATE(167)] = 1766,
+  [SMALL_STATE(168)] = 1773,
+  [SMALL_STATE(169)] = 1780,
+  [SMALL_STATE(170)] = 1787,
+  [SMALL_STATE(171)] = 1794,
+  [SMALL_STATE(172)] = 1801,
+  [SMALL_STATE(173)] = 1808,
+  [SMALL_STATE(174)] = 1815,
+  [SMALL_STATE(175)] = 1822,
+  [SMALL_STATE(176)] = 1829,
+  [SMALL_STATE(177)] = 1836,
+  [SMALL_STATE(178)] = 1843,
+  [SMALL_STATE(179)] = 1850,
+  [SMALL_STATE(180)] = 1857,
+  [SMALL_STATE(181)] = 1864,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -5116,258 +5703,261 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
   [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
   [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(122),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(124),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
   [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
-  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(123),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(125),
   [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
   [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
-  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(127),
-  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(159),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(124),
-  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(151),
-  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
-  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [59] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
-  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [67] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
-  [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [71] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
-  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [79] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
+  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(128),
+  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(164),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(131),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(179),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
+  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [57] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
+  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
+  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
+  [71] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [79] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
   [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
-  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(120),
-  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(135),
-  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(121),
-  [94] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(121),
-  [97] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(122),
-  [100] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(122),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(25),
-  [106] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(71),
-  [109] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(123),
-  [112] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(123),
-  [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(10),
-  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(5),
-  [121] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(169),
-  [124] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(125),
-  [127] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(165),
-  [130] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(164),
-  [133] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(127),
-  [136] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(159),
-  [139] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(158),
-  [142] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(124),
-  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
-  [147] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
-  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
-  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statement, 2),
-  [193] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statement, 2),
-  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [203] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [207] = {.entry = {.count = 1, .reusable = false}}, SHIFT(128),
-  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
-  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
-  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 1),
-  [217] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
-  [221] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 3),
-  [223] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 4),
-  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 2),
-  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6),
-  [229] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
-  [233] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 3),
-  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6, .production_id = 3),
-  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
-  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 3),
-  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_regex, 3),
-  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commandLiteral, 3),
-  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 3, .production_id = 1),
-  [263] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
-  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 4),
-  [267] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 5, .production_id = 2),
-  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 2),
-  [271] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bool, 1),
-  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
-  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer, 1),
-  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char, 1),
-  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
-  [281] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [283] = {.entry = {.count = 1, .reusable = false}}, SHIFT(92),
-  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(117),
-  [287] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
-  [289] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [291] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
-  [293] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [295] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
-  [297] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 2), SHIFT_REPEAT(73),
-  [300] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(14),
-  [303] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
-  [305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
-  [309] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
-  [311] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
-  [313] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
-  [315] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [317] = {.entry = {.count = 1, .reusable = false}}, SHIFT(115),
-  [319] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
-  [321] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
-  [323] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
-  [325] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [327] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [329] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
-  [331] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
-  [333] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(19),
-  [336] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [338] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [340] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [342] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
-  [344] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
-  [346] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [348] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [350] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [352] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
-  [354] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
-  [356] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [358] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [360] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [362] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [83] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
+  [85] = {.entry = {.count = 1, .reusable = false}}, SHIFT(159),
+  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
+  [89] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(122),
+  [92] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(139),
+  [95] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(121),
+  [98] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(121),
+  [101] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(124),
+  [104] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(124),
+  [107] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(24),
+  [110] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(71),
+  [113] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(125),
+  [116] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(125),
+  [119] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(10),
+  [122] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(5),
+  [125] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(172),
+  [128] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(126),
+  [131] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(169),
+  [134] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(166),
+  [137] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(128),
+  [140] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(164),
+  [143] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(160),
+  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(159),
+  [149] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(131),
+  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
+  [154] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
+  [190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
+  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statement, 2),
+  [200] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statement, 2),
+  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [206] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
+  [208] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [210] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
+  [212] = {.entry = {.count = 1, .reusable = false}}, SHIFT(135),
+  [214] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [220] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
+  [222] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 1),
+  [224] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [226] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
+  [228] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 4),
+  [230] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 3),
+  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6, .production_id = 3),
+  [234] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6),
+  [236] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 2),
+  [238] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 5, .production_id = 2),
+  [240] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 4),
+  [242] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
+  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [246] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
+  [248] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 3),
+  [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 3, .production_id = 1),
+  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commandLiteral, 3),
+  [262] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_regex, 3),
+  [264] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 3),
+  [266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
+  [268] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 2),
+  [270] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
+  [272] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bool, 1),
+  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
+  [280] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer, 1),
+  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [284] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [286] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char, 1),
+  [288] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
+  [290] = {.entry = {.count = 1, .reusable = false}}, SHIFT(102),
+  [292] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
+  [294] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
+  [296] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(7),
+  [299] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
+  [301] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(15),
+  [304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [308] = {.entry = {.count = 1, .reusable = false}}, SHIFT(111),
+  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
+  [314] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
+  [316] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
+  [318] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
+  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
+  [322] = {.entry = {.count = 1, .reusable = false}}, SHIFT(117),
+  [324] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
+  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
+  [328] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
+  [330] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
+  [332] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
+  [334] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
+  [336] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 4), SHIFT_REPEAT(16),
+  [339] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 4),
+  [341] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
+  [343] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
+  [345] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [347] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 4), SHIFT_REPEAT(63),
+  [350] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 4),
+  [352] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
+  [354] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [356] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
+  [358] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
+  [360] = {.entry = {.count = 1, .reusable = false}}, SHIFT(89),
+  [362] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
   [364] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
-  [366] = {.entry = {.count = 1, .reusable = false}}, SHIFT(94),
-  [368] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [370] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 4), SHIFT_REPEAT(18),
-  [373] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 4),
-  [375] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [377] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [379] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 4), SHIFT_REPEAT(51),
-  [382] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 4),
-  [384] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [386] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [388] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [390] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [392] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
-  [394] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [396] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [398] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
-  [400] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
-  [402] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [404] = {.entry = {.count = 1, .reusable = false}}, SHIFT(107),
-  [406] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [408] = {.entry = {.count = 1, .reusable = false}}, SHIFT(110),
-  [410] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 2),
-  [412] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [414] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [416] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
-  [418] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer, 1),
-  [420] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_char, 1),
-  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [424] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 1),
-  [426] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 1),
-  [428] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
-  [430] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [432] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 1),
-  [434] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 2),
-  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
-  [438] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 2),
-  [440] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 3),
-  [442] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_regex, 3),
-  [444] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commandLiteral, 3),
-  [446] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
-  [448] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 2),
-  [450] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assignment, 3, .production_id = 1),
-  [452] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bool, 1),
-  [454] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 4, .production_id = 2),
-  [456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 4, .production_id = 2),
-  [458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 3),
-  [460] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 4),
-  [462] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 5, .production_id = 2),
-  [464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6, .production_id = 3),
-  [466] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 4),
-  [468] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6),
-  [470] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [472] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [474] = {.entry = {.count = 1, .reusable = false}}, SHIFT(143),
-  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
-  [480] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [482] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
-  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 3),
-  [486] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 3),
-  [488] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [490] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [492] = {.entry = {.count = 1, .reusable = false}}, SHIFT(148),
-  [494] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
-  [496] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [498] = {.entry = {.count = 1, .reusable = false}}, SHIFT(156),
-  [500] = {.entry = {.count = 1, .reusable = false}}, SHIFT(155),
-  [502] = {.entry = {.count = 1, .reusable = false}}, SHIFT(144),
-  [504] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [506] = {.entry = {.count = 1, .reusable = false}}, SHIFT(174),
-  [508] = {.entry = {.count = 1, .reusable = false}}, SHIFT(175),
-  [510] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [512] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [514] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [516] = {.entry = {.count = 1, .reusable = false}}, SHIFT(149),
-  [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [520] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 2),
-  [522] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 2),
-  [524] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [528] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [530] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
-  [532] = {.entry = {.count = 1, .reusable = false}}, SHIFT(167),
-  [534] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [366] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
+  [368] = {.entry = {.count = 1, .reusable = false}}, SHIFT(92),
+  [370] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [372] = {.entry = {.count = 1, .reusable = false}}, SHIFT(93),
+  [374] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [376] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [378] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [380] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [382] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [384] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [386] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 2), SHIFT_REPEAT(102),
+  [389] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [391] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [393] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [395] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [397] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [399] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
+  [401] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
+  [403] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
+  [405] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [407] = {.entry = {.count = 1, .reusable = false}}, SHIFT(108),
+  [409] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [411] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [413] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
+  [415] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
+  [417] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 3),
+  [419] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commandLiteral, 3),
+  [421] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
+  [423] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [425] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [427] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 4),
+  [429] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer, 1),
+  [431] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_char, 1),
+  [433] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 1),
+  [435] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 4),
+  [437] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
+  [439] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 1),
+  [441] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 5, .production_id = 2),
+  [443] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 2),
+  [445] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [447] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 1),
+  [449] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6),
+  [451] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6, .production_id = 3),
+  [453] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 3),
+  [455] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 2),
+  [457] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 4, .production_id = 2),
+  [459] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [461] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 2),
+  [463] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
+  [465] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 2),
+  [467] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bool, 1),
+  [469] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 4, .production_id = 2),
+  [471] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
+  [473] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assignment, 3, .production_id = 1),
+  [475] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_regex, 3),
+  [477] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
+  [479] = {.entry = {.count = 1, .reusable = false}}, SHIFT(153),
+  [481] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
+  [483] = {.entry = {.count = 1, .reusable = false}}, SHIFT(175),
+  [485] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 3),
+  [487] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 3),
+  [489] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [491] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 2),
+  [493] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [495] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [497] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [499] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [501] = {.entry = {.count = 1, .reusable = false}}, SHIFT(132),
+  [503] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [505] = {.entry = {.count = 1, .reusable = false}}, SHIFT(156),
+  [507] = {.entry = {.count = 1, .reusable = false}}, SHIFT(155),
+  [509] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 2),
+  [511] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [513] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
+  [515] = {.entry = {.count = 1, .reusable = false}}, SHIFT(144),
+  [517] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [519] = {.entry = {.count = 1, .reusable = false}}, SHIFT(157),
+  [521] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [523] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [525] = {.entry = {.count = 1, .reusable = false}}, SHIFT(165),
+  [527] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
+  [529] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [531] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
+  [533] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [535] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [537] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
+  [539] = {.entry = {.count = 1, .reusable = false}}, SHIFT(168),
+  [541] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,15 +6,15 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 182
-#define LARGE_STATE_COUNT 22
-#define SYMBOL_COUNT 108
+#define STATE_COUNT 250
+#define LARGE_STATE_COUNT 30
+#define SYMBOL_COUNT 112
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 81
+#define TOKEN_COUNT 83
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 4
+#define FIELD_COUNT 5
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
-#define PRODUCTION_ID_COUNT 5
+#define PRODUCTION_ID_COUNT 6
 
 enum {
   anon_sym_SEMI = 1,
@@ -54,76 +54,80 @@ enum {
   anon_sym_RBRACE = 35,
   anon_sym_of = 36,
   aux_sym_hash_token1 = 37,
-  anon_sym_SLASH = 38,
-  aux_sym_regex_token1 = 39,
-  anon_sym_Tuple_DOTnew = 40,
-  anon_sym_BQUOTE = 41,
-  aux_sym_commandLiteral_token1 = 42,
-  anon_sym_PERCENTx_LPAREN = 43,
-  aux_sym_commandLiteral_token2 = 44,
-  anon_sym_RPAREN = 45,
-  sym_comment = 46,
-  aux_sym_local_variable_token1 = 47,
-  anon_sym_AT = 48,
-  anon_sym_AT_AT = 49,
-  anon_sym___LINE__ = 50,
-  anon_sym___END_LINE__ = 51,
-  anon_sym___FILE__ = 52,
-  anon_sym___DIR__ = 53,
-  aux_sym_constant_token1 = 54,
-  anon_sym_EQ = 55,
-  anon_sym_PLUS = 56,
-  anon_sym_DASH = 57,
-  anon_sym_STAR = 58,
-  anon_sym_PERCENT = 59,
-  anon_sym_AMP = 60,
-  anon_sym_PIPE = 61,
-  anon_sym_CARET = 62,
-  anon_sym_STAR_STAR = 63,
-  anon_sym_GT_GT = 64,
-  anon_sym_LT_LT = 65,
-  anon_sym_EQ_EQ = 66,
-  anon_sym_BANG_EQ = 67,
-  anon_sym_LT = 68,
-  anon_sym_LT_EQ = 69,
-  anon_sym_GT = 70,
-  anon_sym_GT_EQ = 71,
-  anon_sym_LT_EQ_GT = 72,
-  anon_sym_EQ_EQ_EQ = 73,
-  anon_sym_LBRACK_RBRACK = 74,
-  anon_sym_LBRACK_RBRACK_QMARK = 75,
-  anon_sym_LBRACK_RBRACK_EQ = 76,
-  anon_sym_BANG = 77,
-  anon_sym_TILDE = 78,
-  anon_sym_BANG_TILDE = 79,
-  anon_sym_EQ_TILDE = 80,
-  sym_program = 81,
-  sym__statement = 82,
-  sym__expression = 83,
-  sym_identifier = 84,
-  sym_bool = 85,
-  sym_float = 86,
-  sym_integer = 87,
-  sym_symbol = 88,
-  sym_char = 89,
-  sym_string = 90,
-  sym_array = 91,
-  sym_hash = 92,
-  sym_regex = 93,
-  sym_tuple = 94,
-  sym_namedTupleLiteral = 95,
-  sym_commandLiteral = 96,
-  sym_local_variable = 97,
-  sym_instance_variable = 98,
-  sym_class_variable = 99,
-  sym_constant = 100,
-  sym_assignment = 101,
-  sym__operator = 102,
-  aux_sym_program_repeat1 = 103,
-  aux_sym_symbol_repeat1 = 104,
-  aux_sym_array_repeat1 = 105,
-  aux_sym_hash_repeat1 = 106,
-  aux_sym_namedTupleLiteral_repeat1 = 107,
+  anon_sym_LBRACK2 = 38,
+  anon_sym_RBRACK2 = 39,
+  anon_sym_SLASH = 40,
+  aux_sym_regex_token1 = 41,
+  anon_sym_Tuple_DOTnew = 42,
+  anon_sym_BQUOTE = 43,
+  aux_sym_commandLiteral_token1 = 44,
+  anon_sym_PERCENTx_LPAREN = 45,
+  aux_sym_commandLiteral_token2 = 46,
+  anon_sym_RPAREN = 47,
+  sym_comment = 48,
+  aux_sym_local_variable_token1 = 49,
+  anon_sym_AT = 50,
+  anon_sym_AT_AT = 51,
+  anon_sym___LINE__ = 52,
+  anon_sym___END_LINE__ = 53,
+  anon_sym___FILE__ = 54,
+  anon_sym___DIR__ = 55,
+  aux_sym_constant_token1 = 56,
+  anon_sym_EQ = 57,
+  anon_sym_PLUS = 58,
+  anon_sym_DASH = 59,
+  anon_sym_STAR = 60,
+  anon_sym_PERCENT = 61,
+  anon_sym_AMP = 62,
+  anon_sym_PIPE = 63,
+  anon_sym_CARET = 64,
+  anon_sym_STAR_STAR = 65,
+  anon_sym_GT_GT = 66,
+  anon_sym_LT_LT = 67,
+  anon_sym_EQ_EQ = 68,
+  anon_sym_BANG_EQ = 69,
+  anon_sym_LT = 70,
+  anon_sym_LT_EQ = 71,
+  anon_sym_GT = 72,
+  anon_sym_GT_EQ = 73,
+  anon_sym_LT_EQ_GT = 74,
+  anon_sym_EQ_EQ_EQ = 75,
+  anon_sym_LBRACK_RBRACK = 76,
+  anon_sym_LBRACK_RBRACK_QMARK = 77,
+  anon_sym_LBRACK_RBRACK_EQ = 78,
+  anon_sym_BANG = 79,
+  anon_sym_TILDE = 80,
+  anon_sym_BANG_TILDE = 81,
+  anon_sym_EQ_TILDE = 82,
+  sym_program = 83,
+  sym__statement = 84,
+  sym__expression = 85,
+  sym_identifier = 86,
+  sym_bool = 87,
+  sym_float = 88,
+  sym_integer = 89,
+  sym_symbol = 90,
+  sym_char = 91,
+  sym_string = 92,
+  sym_array = 93,
+  sym_hash = 94,
+  sym_index_expression = 95,
+  sym_regex = 96,
+  sym_tuple = 97,
+  sym_namedTupleLiteral = 98,
+  sym_commandLiteral = 99,
+  sym_local_variable = 100,
+  sym_instance_variable = 101,
+  sym_class_variable = 102,
+  sym_constant = 103,
+  sym__variable = 104,
+  sym_assignment = 105,
+  sym__operator = 106,
+  aux_sym_program_repeat1 = 107,
+  aux_sym_symbol_repeat1 = 108,
+  aux_sym_array_repeat1 = 109,
+  aux_sym_hash_repeat1 = 110,
+  aux_sym_namedTupleLiteral_repeat1 = 111,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -165,6 +169,8 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_RBRACE] = "}",
   [anon_sym_of] = "of",
   [aux_sym_hash_token1] = "hash_token1",
+  [anon_sym_LBRACK2] = "[",
+  [anon_sym_RBRACK2] = "]",
   [anon_sym_SLASH] = "/",
   [aux_sym_regex_token1] = "regex_token1",
   [anon_sym_Tuple_DOTnew] = "Tuple.new",
@@ -220,6 +226,7 @@ static const char * const ts_symbol_names[] = {
   [sym_string] = "string",
   [sym_array] = "array",
   [sym_hash] = "hash",
+  [sym_index_expression] = "index_expression",
   [sym_regex] = "regex",
   [sym_tuple] = "tuple",
   [sym_namedTupleLiteral] = "namedTupleLiteral",
@@ -228,6 +235,7 @@ static const char * const ts_symbol_names[] = {
   [sym_instance_variable] = "instance_variable",
   [sym_class_variable] = "class_variable",
   [sym_constant] = "constant",
+  [sym__variable] = "_variable",
   [sym_assignment] = "assignment",
   [sym__operator] = "_operator",
   [aux_sym_program_repeat1] = "program_repeat1",
@@ -276,6 +284,8 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_RBRACE] = anon_sym_RBRACE,
   [anon_sym_of] = anon_sym_of,
   [aux_sym_hash_token1] = aux_sym_hash_token1,
+  [anon_sym_LBRACK2] = anon_sym_LBRACK,
+  [anon_sym_RBRACK2] = anon_sym_RBRACK,
   [anon_sym_SLASH] = anon_sym_SLASH,
   [aux_sym_regex_token1] = aux_sym_regex_token1,
   [anon_sym_Tuple_DOTnew] = anon_sym_Tuple_DOTnew,
@@ -331,6 +341,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_string] = sym_string,
   [sym_array] = sym_array,
   [sym_hash] = sym_hash,
+  [sym_index_expression] = sym_index_expression,
   [sym_regex] = sym_regex,
   [sym_tuple] = sym_tuple,
   [sym_namedTupleLiteral] = sym_namedTupleLiteral,
@@ -339,6 +350,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_instance_variable] = sym_instance_variable,
   [sym_class_variable] = sym_class_variable,
   [sym_constant] = sym_constant,
+  [sym__variable] = sym__variable,
   [sym_assignment] = sym_assignment,
   [sym__operator] = sym__operator,
   [aux_sym_program_repeat1] = aux_sym_program_repeat1,
@@ -499,6 +511,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [aux_sym_hash_token1] = {
     .visible = false,
+    .named = false,
+  },
+  [anon_sym_LBRACK2] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RBRACK2] = {
+    .visible = true,
     .named = false,
   },
   [anon_sym_SLASH] = {
@@ -721,6 +741,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_index_expression] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_regex] = {
     .visible = true,
     .named = true,
@@ -751,6 +775,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [sym_constant] = {
     .visible = true,
+    .named = true,
+  },
+  [sym__variable] = {
+    .visible = false,
     .named = true,
   },
   [sym_assignment] = {
@@ -787,7 +815,8 @@ enum {
   field_key = 1,
   field_lhs = 2,
   field_rhs = 3,
-  field_value = 4,
+  field_target = 4,
+  field_value = 5,
 };
 
 static const char * const ts_field_names[] = {
@@ -795,14 +824,16 @@ static const char * const ts_field_names[] = {
   [field_key] = "key",
   [field_lhs] = "lhs",
   [field_rhs] = "rhs",
+  [field_target] = "target",
   [field_value] = "value",
 };
 
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [1] = {.index = 0, .length = 2},
   [2] = {.index = 2, .length = 2},
-  [3] = {.index = 4, .length = 4},
-  [4] = {.index = 8, .length = 4},
+  [3] = {.index = 4, .length = 2},
+  [4] = {.index = 6, .length = 4},
+  [5] = {.index = 10, .length = 4},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -810,14 +841,17 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
     {field_lhs, 0},
     {field_rhs, 2},
   [2] =
+    {field_key, 2},
+    {field_target, 0},
+  [4] =
     {field_key, 1},
     {field_value, 3},
-  [4] =
+  [6] =
     {field_key, 1},
     {field_key, 4, .inherited = true},
     {field_value, 3},
     {field_value, 4, .inherited = true},
-  [8] =
+  [10] =
     {field_key, 0, .inherited = true},
     {field_key, 1, .inherited = true},
     {field_value, 0, .inherited = true},
@@ -837,84 +871,85 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(113);
-      if (lookahead == '!') ADVANCE(275);
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(111);
-      if (lookahead == '%') ADVANCE(257);
-      if (lookahead == '&') ADVANCE(258);
-      if (lookahead == '\'') ADVANCE(16);
-      if (lookahead == ')') ADVANCE(230);
-      if (lookahead == '*') ADVANCE(255);
-      if (lookahead == '+') ADVANCE(252);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == '-') ADVANCE(254);
-      if (lookahead == '/') ADVANCE(215);
-      if (lookahead == '0') ADVANCE(31);
-      if (lookahead == ':') ADVANCE(178);
-      if (lookahead == ';') ADVANCE(114);
-      if (lookahead == '<') ADVANCE(266);
-      if (lookahead == '=') ADVANCE(250);
-      if (lookahead == '>') ADVANCE(268);
-      if (lookahead == '@') ADVANCE(237);
-      if (lookahead == 'T') ADVANCE(155);
-      if (lookahead == '[') ADVANCE(206);
-      if (lookahead == ']') ADVANCE(208);
-      if (lookahead == '^') ADVANCE(260);
-      if (lookahead == '_') ADVANCE(134);
-      if (lookahead == '`') ADVANCE(222);
-      if (lookahead == 'f') ADVANCE(144);
-      if (lookahead == 'n') ADVANCE(148);
-      if (lookahead == 't') ADVANCE(153);
-      if (lookahead == '{') ADVANCE(209);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '}') ADVANCE(211);
-      if (lookahead == '~') ADVANCE(276);
+      if (eof) ADVANCE(116);
+      if (lookahead == '!') ADVANCE(282);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == '%') ADVANCE(264);
+      if (lookahead == '&') ADVANCE(265);
+      if (lookahead == '\'') ADVANCE(19);
+      if (lookahead == ')') ADVANCE(236);
+      if (lookahead == '*') ADVANCE(262);
+      if (lookahead == '+') ADVANCE(259);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == '-') ADVANCE(261);
+      if (lookahead == '/') ADVANCE(221);
+      if (lookahead == '0') ADVANCE(34);
+      if (lookahead == ':') ADVANCE(181);
+      if (lookahead == ';') ADVANCE(117);
+      if (lookahead == '<') ADVANCE(273);
+      if (lookahead == '=') ADVANCE(256);
+      if (lookahead == '>') ADVANCE(275);
+      if (lookahead == '@') ADVANCE(243);
+      if (lookahead == 'T') ADVANCE(158);
+      if (lookahead == '[') ADVANCE(219);
+      if (lookahead == ']') ADVANCE(220);
+      if (lookahead == '^') ADVANCE(267);
+      if (lookahead == '_') ADVANCE(137);
+      if (lookahead == '`') ADVANCE(228);
+      if (lookahead == 'f') ADVANCE(147);
+      if (lookahead == 'n') ADVANCE(151);
+      if (lookahead == 't') ADVANCE(156);
+      if (lookahead == '{') ADVANCE(212);
+      if (lookahead == '|') ADVANCE(266);
+      if (lookahead == '}') ADVANCE(214);
+      if (lookahead == '~') ADVANCE(283);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(0)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(157);
+          lookahead == ' ') SKIP(114)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(180);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(160);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(160);
       if (lookahead != 0 &&
-          lookahead > 159) ADVANCE(157);
+          lookahead > 159) ADVANCE(160);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(115);
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ';') ADVANCE(114);
+      if (lookahead == '\n') ADVANCE(118);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ';') ADVANCE(117);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(181);
-      if (lookahead != 0) ADVANCE(180);
+          lookahead == ' ') ADVANCE(184);
+      if (lookahead != 0) ADVANCE(183);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(116);
-      if (lookahead == '#') ADVANCE(111);
-      if (lookahead == ';') ADVANCE(114);
+      if (lookahead == '\n') ADVANCE(119);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == ';') ADVANCE(117);
+      if (lookahead == '=') ADVANCE(255);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
-      if (lookahead == '!') ADVANCE(275);
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(111);
-      if (lookahead == '%') ADVANCE(256);
-      if (lookahead == '&') ADVANCE(258);
-      if (lookahead == '*') ADVANCE(255);
-      if (lookahead == '+') ADVANCE(251);
-      if (lookahead == '-') ADVANCE(253);
-      if (lookahead == '/') ADVANCE(215);
-      if (lookahead == '<') ADVANCE(266);
-      if (lookahead == '=') ADVANCE(60);
-      if (lookahead == '>') ADVANCE(268);
-      if (lookahead == '[') ADVANCE(77);
-      if (lookahead == '^') ADVANCE(260);
-      if (lookahead == '|') ADVANCE(259);
-      if (lookahead == '~') ADVANCE(276);
+      if (lookahead == '!') ADVANCE(282);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == '%') ADVANCE(263);
+      if (lookahead == '&') ADVANCE(265);
+      if (lookahead == '*') ADVANCE(262);
+      if (lookahead == '+') ADVANCE(258);
+      if (lookahead == '-') ADVANCE(260);
+      if (lookahead == '/') ADVANCE(221);
+      if (lookahead == '<') ADVANCE(273);
+      if (lookahead == '=') ADVANCE(63);
+      if (lookahead == '>') ADVANCE(275);
+      if (lookahead == '[') ADVANCE(79);
+      if (lookahead == '^') ADVANCE(267);
+      if (lookahead == '|') ADVANCE(266);
+      if (lookahead == '~') ADVANCE(283);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -924,182 +959,229 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\\' &&
           lookahead != ']' &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 4:
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(111);
-      if (lookahead == '%') ADVANCE(100);
-      if (lookahead == '\'') ADVANCE(16);
-      if (lookahead == '/') ADVANCE(215);
-      if (lookahead == '0') ADVANCE(31);
-      if (lookahead == ':') ADVANCE(178);
-      if (lookahead == '=') ADVANCE(249);
-      if (lookahead == '@') ADVANCE(237);
-      if (lookahead == 'T') ADVANCE(155);
-      if (lookahead == '[') ADVANCE(205);
-      if (lookahead == '_') ADVANCE(134);
-      if (lookahead == '`') ADVANCE(222);
-      if (lookahead == 'f') ADVANCE(144);
-      if (lookahead == 'n') ADVANCE(148);
-      if (lookahead == 't') ADVANCE(153);
-      if (lookahead == '{') ADVANCE(209);
-      if (lookahead == '}') ADVANCE(211);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == '%') ADVANCE(102);
+      if (lookahead == '\'') ADVANCE(19);
+      if (lookahead == '/') ADVANCE(221);
+      if (lookahead == '0') ADVANCE(34);
+      if (lookahead == ':') ADVANCE(181);
+      if (lookahead == '=') ADVANCE(255);
+      if (lookahead == '@') ADVANCE(243);
+      if (lookahead == 'T') ADVANCE(158);
+      if (lookahead == '[') ADVANCE(208);
+      if (lookahead == ']') ADVANCE(220);
+      if (lookahead == '_') ADVANCE(137);
+      if (lookahead == '`') ADVANCE(228);
+      if (lookahead == 'f') ADVANCE(147);
+      if (lookahead == 'n') ADVANCE(151);
+      if (lookahead == 't') ADVANCE(156);
+      if (lookahead == '{') ADVANCE(212);
+      if (lookahead == '}') ADVANCE(214);
       if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(34);
+          lookahead == '-') ADVANCE(37);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(4)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(157);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(157);
+          lookahead == ' ') SKIP(5)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(180);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(160);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(160);
       if (lookahead != 0 &&
-          lookahead > 159) ADVANCE(157);
+          lookahead > 159) ADVANCE(160);
       END_STATE();
     case 5:
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == ':') ADVANCE(178);
-      if (lookahead == '=') ADVANCE(189);
-      if (lookahead == '}') ADVANCE(211);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == '%') ADVANCE(102);
+      if (lookahead == '\'') ADVANCE(19);
+      if (lookahead == '/') ADVANCE(221);
+      if (lookahead == '0') ADVANCE(34);
+      if (lookahead == ':') ADVANCE(181);
+      if (lookahead == '=') ADVANCE(255);
+      if (lookahead == '@') ADVANCE(243);
+      if (lookahead == 'T') ADVANCE(158);
+      if (lookahead == '[') ADVANCE(208);
+      if (lookahead == '_') ADVANCE(137);
+      if (lookahead == '`') ADVANCE(228);
+      if (lookahead == 'f') ADVANCE(147);
+      if (lookahead == 'n') ADVANCE(151);
+      if (lookahead == 't') ADVANCE(156);
+      if (lookahead == '{') ADVANCE(212);
+      if (lookahead == '}') ADVANCE(214);
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(37);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(182);
-      if (lookahead != 0) ADVANCE(180);
+          lookahead == ' ') SKIP(5)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(180);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(160);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(160);
+      if (lookahead != 0 &&
+          lookahead > 159) ADVANCE(160);
       END_STATE();
     case 6:
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == '=') ADVANCE(189);
-      if (lookahead == '}') ADVANCE(211);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(183);
-      if (lookahead != 0) ADVANCE(180);
-      END_STATE();
-    case 7:
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == ']') ADVANCE(208);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(184);
-      if (lookahead != 0) ADVANCE(180);
-      END_STATE();
-    case 8:
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == '}') ADVANCE(211);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == ':') ADVANCE(181);
+      if (lookahead == '=') ADVANCE(192);
+      if (lookahead == '}') ADVANCE(214);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(185);
-      if (lookahead != 0) ADVANCE(180);
+      if (lookahead != 0) ADVANCE(183);
       END_STATE();
-    case 9:
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ':') ADVANCE(178);
+    case 7:
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == '=') ADVANCE(192);
+      if (lookahead == '}') ADVANCE(214);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(186);
-      if (lookahead != 0) ADVANCE(180);
+      if (lookahead != 0) ADVANCE(183);
       END_STATE();
-    case 10:
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == '=') ADVANCE(189);
+    case 8:
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == ']') ADVANCE(211);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(187);
-      if (lookahead != 0) ADVANCE(180);
+      if (lookahead != 0) ADVANCE(183);
       END_STATE();
-    case 11:
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(190);
+    case 9:
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == '}') ADVANCE(214);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(188);
-      if (lookahead != 0) ADVANCE(180);
+      if (lookahead != 0) ADVANCE(183);
+      END_STATE();
+    case 10:
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ':') ADVANCE(181);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(189);
+      if (lookahead != 0) ADVANCE(183);
+      END_STATE();
+    case 11:
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == '=') ADVANCE(192);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(190);
+      if (lookahead != 0) ADVANCE(183);
       END_STATE();
     case 12:
-      if (lookahead == '#') ADVANCE(111);
-      if (lookahead == '=') ADVANCE(249);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ']') ADVANCE(220);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(12)
-      if (lookahead != 0 &&
-          lookahead > '@' &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          lookahead == ' ') ADVANCE(191);
+      if (lookahead != 0) ADVANCE(183);
       END_STATE();
     case 13:
-      if (lookahead == '#') ADVANCE(111);
-      if (lookahead == 'o') ADVANCE(91);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(193);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(13)
+          lookahead == ' ') ADVANCE(191);
+      if (lookahead != 0) ADVANCE(183);
       END_STATE();
     case 14:
-      if (lookahead == '#') ADVANCE(111);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(14)
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(232);
-      END_STATE();
-    case 15:
-      if (lookahead == '#') ADVANCE(213);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == '=') ADVANCE(255);
+      if (lookahead == '[') ADVANCE(218);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(15)
-      if (lookahead != 0) ADVANCE(214);
+      if (lookahead != 0 &&
+          lookahead > '@' &&
+          (lookahead < '\\' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 15:
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == '=') ADVANCE(255);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(15)
+      if (lookahead != 0 &&
+          lookahead > '@' &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 16:
-      if (lookahead == '\'') ADVANCE(191);
-      if (lookahead == '\\') ADVANCE(17);
-      if (lookahead != 0) ADVANCE(18);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == 'o') ADVANCE(93);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(16)
       END_STATE();
     case 17:
-      if (lookahead == '\'') ADVANCE(204);
-      if (lookahead == '\\') ADVANCE(19);
-      if (lookahead == 'a') ADVANCE(20);
-      if (lookahead == 'b') ADVANCE(21);
-      if (lookahead == 'e') ADVANCE(22);
-      if (lookahead == 'f') ADVANCE(23);
-      if (lookahead == 'n') ADVANCE(24);
-      if (lookahead == 'r') ADVANCE(25);
-      if (lookahead == 't') ADVANCE(26);
-      if (lookahead == 'u') ADVANCE(101);
-      if (lookahead == 'v') ADVANCE(27);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(17)
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(238);
       END_STATE();
     case 18:
-      if (lookahead == '\'') ADVANCE(203);
+      if (lookahead == '#') ADVANCE(216);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(18)
+      if (lookahead != 0) ADVANCE(217);
       END_STATE();
     case 19:
-      if (lookahead == '\'') ADVANCE(193);
+      if (lookahead == '\'') ADVANCE(194);
+      if (lookahead == '\\') ADVANCE(20);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 20:
-      if (lookahead == '\'') ADVANCE(194);
+      if (lookahead == '\'') ADVANCE(207);
+      if (lookahead == '\\') ADVANCE(22);
+      if (lookahead == 'a') ADVANCE(23);
+      if (lookahead == 'b') ADVANCE(24);
+      if (lookahead == 'e') ADVANCE(25);
+      if (lookahead == 'f') ADVANCE(26);
+      if (lookahead == 'n') ADVANCE(27);
+      if (lookahead == 'r') ADVANCE(28);
+      if (lookahead == 't') ADVANCE(29);
+      if (lookahead == 'u') ADVANCE(103);
+      if (lookahead == 'v') ADVANCE(30);
       END_STATE();
     case 21:
-      if (lookahead == '\'') ADVANCE(195);
+      if (lookahead == '\'') ADVANCE(206);
       END_STATE();
     case 22:
       if (lookahead == '\'') ADVANCE(196);
@@ -1123,207 +1205,207 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\'') ADVANCE(202);
       END_STATE();
     case 29:
-      if (lookahead == '\'') ADVANCE(202);
-      if (lookahead == '}') ADVANCE(28);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
+      if (lookahead == '\'') ADVANCE(203);
       END_STATE();
     case 30:
-      if (lookahead == '(') ADVANCE(226);
+      if (lookahead == '\'') ADVANCE(204);
       END_STATE();
     case 31:
-      if (lookahead == '.') ADVANCE(108);
-      if (lookahead == 'b') ADVANCE(104);
-      if (lookahead == 'e') ADVANCE(102);
-      if (lookahead == 'f') ADVANCE(46);
-      if (lookahead == 'o') ADVANCE(105);
-      if (lookahead == 'x') ADVANCE(109);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(32);
+      if (lookahead == '\'') ADVANCE(205);
       END_STATE();
     case 32:
-      if (lookahead == '.') ADVANCE(108);
-      if (lookahead == 'e') ADVANCE(102);
-      if (lookahead == 'f') ADVANCE(46);
+      if (lookahead == '\'') ADVANCE(205);
+      if (lookahead == '}') ADVANCE(31);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(32);
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(32);
       END_STATE();
     case 33:
-      if (lookahead == '.') ADVANCE(95);
+      if (lookahead == '(') ADVANCE(232);
       END_STATE();
     case 34:
-      if (lookahead == '0') ADVANCE(31);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
+      if (lookahead == '.') ADVANCE(110);
+      if (lookahead == 'b') ADVANCE(106);
+      if (lookahead == 'e') ADVANCE(104);
+      if (lookahead == 'f') ADVANCE(49);
+      if (lookahead == 'o') ADVANCE(107);
+      if (lookahead == 'x') ADVANCE(111);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(35);
       END_STATE();
     case 35:
-      if (lookahead == '1') ADVANCE(56);
-      if (lookahead == '3') ADVANCE(39);
-      if (lookahead == '6') ADVANCE(49);
-      if (lookahead == '8') ADVANCE(176);
+      if (lookahead == '.') ADVANCE(110);
+      if (lookahead == 'e') ADVANCE(104);
+      if (lookahead == 'f') ADVANCE(49);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(35);
       END_STATE();
     case 36:
-      if (lookahead == '1') ADVANCE(57);
-      if (lookahead == '3') ADVANCE(41);
-      if (lookahead == '6') ADVANCE(51);
-      if (lookahead == '8') ADVANCE(170);
+      if (lookahead == '.') ADVANCE(97);
       END_STATE();
     case 37:
-      if (lookahead == '1') ADVANCE(58);
-      if (lookahead == '3') ADVANCE(42);
-      if (lookahead == '6') ADVANCE(52);
-      if (lookahead == '8') ADVANCE(172);
+      if (lookahead == '0') ADVANCE(34);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(180);
       END_STATE();
     case 38:
       if (lookahead == '1') ADVANCE(59);
-      if (lookahead == '3') ADVANCE(43);
-      if (lookahead == '6') ADVANCE(53);
-      if (lookahead == '8') ADVANCE(174);
+      if (lookahead == '3') ADVANCE(42);
+      if (lookahead == '6') ADVANCE(52);
+      if (lookahead == '8') ADVANCE(179);
       END_STATE();
     case 39:
-      if (lookahead == '2') ADVANCE(176);
-      END_STATE();
-    case 40:
-      if (lookahead == '2') ADVANCE(169);
-      END_STATE();
-    case 41:
-      if (lookahead == '2') ADVANCE(170);
-      END_STATE();
-    case 42:
-      if (lookahead == '2') ADVANCE(172);
-      END_STATE();
-    case 43:
-      if (lookahead == '2') ADVANCE(174);
-      END_STATE();
-    case 44:
-      if (lookahead == '2') ADVANCE(164);
-      END_STATE();
-    case 45:
-      if (lookahead == '2') ADVANCE(167);
-      END_STATE();
-    case 46:
-      if (lookahead == '3') ADVANCE(40);
-      if (lookahead == '6') ADVANCE(50);
-      END_STATE();
-    case 47:
+      if (lookahead == '1') ADVANCE(60);
       if (lookahead == '3') ADVANCE(44);
       if (lookahead == '6') ADVANCE(54);
+      if (lookahead == '8') ADVANCE(173);
       END_STATE();
-    case 48:
+    case 40:
+      if (lookahead == '1') ADVANCE(61);
       if (lookahead == '3') ADVANCE(45);
       if (lookahead == '6') ADVANCE(55);
+      if (lookahead == '8') ADVANCE(175);
+      END_STATE();
+    case 41:
+      if (lookahead == '1') ADVANCE(62);
+      if (lookahead == '3') ADVANCE(46);
+      if (lookahead == '6') ADVANCE(56);
+      if (lookahead == '8') ADVANCE(177);
+      END_STATE();
+    case 42:
+      if (lookahead == '2') ADVANCE(179);
+      END_STATE();
+    case 43:
+      if (lookahead == '2') ADVANCE(172);
+      END_STATE();
+    case 44:
+      if (lookahead == '2') ADVANCE(173);
+      END_STATE();
+    case 45:
+      if (lookahead == '2') ADVANCE(175);
+      END_STATE();
+    case 46:
+      if (lookahead == '2') ADVANCE(177);
+      END_STATE();
+    case 47:
+      if (lookahead == '2') ADVANCE(167);
+      END_STATE();
+    case 48:
+      if (lookahead == '2') ADVANCE(170);
       END_STATE();
     case 49:
-      if (lookahead == '4') ADVANCE(176);
+      if (lookahead == '3') ADVANCE(43);
+      if (lookahead == '6') ADVANCE(53);
       END_STATE();
     case 50:
-      if (lookahead == '4') ADVANCE(169);
+      if (lookahead == '3') ADVANCE(47);
+      if (lookahead == '6') ADVANCE(57);
       END_STATE();
     case 51:
-      if (lookahead == '4') ADVANCE(170);
+      if (lookahead == '3') ADVANCE(48);
+      if (lookahead == '6') ADVANCE(58);
       END_STATE();
     case 52:
-      if (lookahead == '4') ADVANCE(172);
+      if (lookahead == '4') ADVANCE(179);
       END_STATE();
     case 53:
-      if (lookahead == '4') ADVANCE(174);
+      if (lookahead == '4') ADVANCE(172);
       END_STATE();
     case 54:
-      if (lookahead == '4') ADVANCE(164);
+      if (lookahead == '4') ADVANCE(173);
       END_STATE();
     case 55:
-      if (lookahead == '4') ADVANCE(167);
+      if (lookahead == '4') ADVANCE(175);
       END_STATE();
     case 56:
-      if (lookahead == '6') ADVANCE(176);
+      if (lookahead == '4') ADVANCE(177);
       END_STATE();
     case 57:
-      if (lookahead == '6') ADVANCE(170);
+      if (lookahead == '4') ADVANCE(167);
       END_STATE();
     case 58:
-      if (lookahead == '6') ADVANCE(172);
+      if (lookahead == '4') ADVANCE(170);
       END_STATE();
     case 59:
-      if (lookahead == '6') ADVANCE(174);
+      if (lookahead == '6') ADVANCE(179);
       END_STATE();
     case 60:
-      if (lookahead == '=') ADVANCE(264);
-      if (lookahead == '~') ADVANCE(278);
+      if (lookahead == '6') ADVANCE(173);
       END_STATE();
     case 61:
-      if (lookahead == '>') ADVANCE(210);
+      if (lookahead == '6') ADVANCE(175);
       END_STATE();
     case 62:
-      if (lookahead == 'D') ADVANCE(67);
-      if (lookahead == 'E') ADVANCE(73);
-      if (lookahead == 'F') ADVANCE(68);
-      if (lookahead == 'L') ADVANCE(69);
+      if (lookahead == '6') ADVANCE(177);
       END_STATE();
     case 63:
-      if (lookahead == 'D') ADVANCE(82);
+      if (lookahead == '=') ADVANCE(271);
+      if (lookahead == '~') ADVANCE(285);
       END_STATE();
     case 64:
-      if (lookahead == 'E') ADVANCE(84);
+      if (lookahead == 'D') ADVANCE(69);
+      if (lookahead == 'E') ADVANCE(75);
+      if (lookahead == 'F') ADVANCE(70);
+      if (lookahead == 'L') ADVANCE(71);
       END_STATE();
     case 65:
-      if (lookahead == 'E') ADVANCE(85);
+      if (lookahead == 'D') ADVANCE(84);
       END_STATE();
     case 66:
       if (lookahead == 'E') ADVANCE(86);
       END_STATE();
     case 67:
-      if (lookahead == 'I') ADVANCE(76);
+      if (lookahead == 'E') ADVANCE(87);
       END_STATE();
     case 68:
-      if (lookahead == 'I') ADVANCE(71);
+      if (lookahead == 'E') ADVANCE(88);
       END_STATE();
     case 69:
-      if (lookahead == 'I') ADVANCE(74);
+      if (lookahead == 'I') ADVANCE(78);
       END_STATE();
     case 70:
-      if (lookahead == 'I') ADVANCE(75);
+      if (lookahead == 'I') ADVANCE(73);
       END_STATE();
     case 71:
-      if (lookahead == 'L') ADVANCE(64);
+      if (lookahead == 'I') ADVANCE(76);
       END_STATE();
     case 72:
-      if (lookahead == 'L') ADVANCE(70);
+      if (lookahead == 'I') ADVANCE(77);
       END_STATE();
     case 73:
-      if (lookahead == 'N') ADVANCE(63);
+      if (lookahead == 'L') ADVANCE(66);
       END_STATE();
     case 74:
-      if (lookahead == 'N') ADVANCE(65);
+      if (lookahead == 'L') ADVANCE(72);
       END_STATE();
     case 75:
-      if (lookahead == 'N') ADVANCE(66);
+      if (lookahead == 'N') ADVANCE(65);
       END_STATE();
     case 76:
-      if (lookahead == 'R') ADVANCE(83);
+      if (lookahead == 'N') ADVANCE(67);
       END_STATE();
     case 77:
-      if (lookahead == ']') ADVANCE(272);
+      if (lookahead == 'N') ADVANCE(68);
       END_STATE();
     case 78:
-      if (lookahead == '_') ADVANCE(245);
+      if (lookahead == 'R') ADVANCE(85);
       END_STATE();
     case 79:
-      if (lookahead == '_') ADVANCE(243);
+      if (lookahead == ']') ADVANCE(279);
       END_STATE();
     case 80:
-      if (lookahead == '_') ADVANCE(239);
+      if (lookahead == '_') ADVANCE(251);
       END_STATE();
     case 81:
-      if (lookahead == '_') ADVANCE(241);
+      if (lookahead == '_') ADVANCE(249);
       END_STATE();
     case 82:
-      if (lookahead == '_') ADVANCE(72);
+      if (lookahead == '_') ADVANCE(245);
       END_STATE();
     case 83:
-      if (lookahead == '_') ADVANCE(78);
+      if (lookahead == '_') ADVANCE(247);
       END_STATE();
     case 84:
-      if (lookahead == '_') ADVANCE(79);
+      if (lookahead == '_') ADVANCE(74);
       END_STATE();
     case 85:
       if (lookahead == '_') ADVANCE(80);
@@ -1332,1266 +1414,1330 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '_') ADVANCE(81);
       END_STATE();
     case 87:
-      if (lookahead == 'e') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(82);
       END_STATE();
     case 88:
-      if (lookahead == 'e') ADVANCE(160);
+      if (lookahead == '_') ADVANCE(83);
       END_STATE();
     case 89:
-      if (lookahead == 'e') ADVANCE(33);
+      if (lookahead == 'e') ADVANCE(101);
       END_STATE();
     case 90:
-      if (lookahead == 'e') ADVANCE(162);
+      if (lookahead == 'e') ADVANCE(163);
       END_STATE();
     case 91:
-      if (lookahead == 'f') ADVANCE(212);
+      if (lookahead == 'e') ADVANCE(36);
       END_STATE();
     case 92:
-      if (lookahead == 'l') ADVANCE(97);
+      if (lookahead == 'e') ADVANCE(165);
       END_STATE();
     case 93:
-      if (lookahead == 'l') ADVANCE(158);
+      if (lookahead == 'f') ADVANCE(215);
       END_STATE();
     case 94:
-      if (lookahead == 'l') ADVANCE(89);
+      if (lookahead == 'l') ADVANCE(99);
       END_STATE();
     case 95:
-      if (lookahead == 'n') ADVANCE(87);
+      if (lookahead == 'l') ADVANCE(161);
       END_STATE();
     case 96:
-      if (lookahead == 'p') ADVANCE(94);
+      if (lookahead == 'l') ADVANCE(91);
       END_STATE();
     case 97:
-      if (lookahead == 's') ADVANCE(90);
+      if (lookahead == 'n') ADVANCE(89);
       END_STATE();
     case 98:
-      if (lookahead == 'u') ADVANCE(88);
+      if (lookahead == 'p') ADVANCE(96);
       END_STATE();
     case 99:
-      if (lookahead == 'w') ADVANCE(221);
+      if (lookahead == 's') ADVANCE(92);
       END_STATE();
     case 100:
-      if (lookahead == 'x') ADVANCE(30);
+      if (lookahead == 'u') ADVANCE(90);
       END_STATE();
     case 101:
-      if (lookahead == '{') ADVANCE(110);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
+      if (lookahead == 'w') ADVANCE(227);
       END_STATE();
     case 102:
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(106);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(168);
+      if (lookahead == 'x') ADVANCE(33);
       END_STATE();
     case 103:
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(107);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(166);
-      END_STATE();
-    case 104:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(171);
-      END_STATE();
-    case 105:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(173);
-      END_STATE();
-    case 106:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(168);
-      END_STATE();
-    case 107:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(166);
-      END_STATE();
-    case 108:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(165);
-      END_STATE();
-    case 109:
+      if (lookahead == '{') ADVANCE(112);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(175);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(32);
+      END_STATE();
+    case 104:
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(108);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(171);
+      END_STATE();
+    case 105:
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(109);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(169);
+      END_STATE();
+    case 106:
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(174);
+      END_STATE();
+    case 107:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(176);
+      END_STATE();
+    case 108:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(171);
+      END_STATE();
+    case 109:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(169);
       END_STATE();
     case 110:
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(29);
+          lookahead == '_') ADVANCE(168);
       END_STATE();
     case 111:
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(231);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(178);
       END_STATE();
     case 112:
-      if (eof) ADVANCE(113);
-      if (lookahead == '"') ADVANCE(179);
-      if (lookahead == '#') ADVANCE(111);
-      if (lookahead == '%') ADVANCE(100);
-      if (lookahead == '\'') ADVANCE(16);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == '/') ADVANCE(215);
-      if (lookahead == '0') ADVANCE(31);
-      if (lookahead == ':') ADVANCE(178);
-      if (lookahead == '=') ADVANCE(61);
-      if (lookahead == '@') ADVANCE(237);
-      if (lookahead == 'T') ADVANCE(248);
-      if (lookahead == '[') ADVANCE(205);
-      if (lookahead == ']') ADVANCE(208);
-      if (lookahead == '_') ADVANCE(233);
-      if (lookahead == '`') ADVANCE(222);
-      if (lookahead == 'f') ADVANCE(234);
-      if (lookahead == 'n') ADVANCE(235);
-      if (lookahead == 't') ADVANCE(236);
-      if (lookahead == '{') ADVANCE(209);
-      if (lookahead == '}') ADVANCE(211);
-      if (('+' <= lookahead && lookahead <= '-')) ADVANCE(34);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(32);
+      END_STATE();
+    case 113:
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(237);
+      END_STATE();
+    case 114:
+      if (eof) ADVANCE(116);
+      if (lookahead == '!') ADVANCE(282);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == '%') ADVANCE(264);
+      if (lookahead == '&') ADVANCE(265);
+      if (lookahead == '\'') ADVANCE(19);
+      if (lookahead == ')') ADVANCE(236);
+      if (lookahead == '*') ADVANCE(262);
+      if (lookahead == '+') ADVANCE(259);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == '-') ADVANCE(261);
+      if (lookahead == '/') ADVANCE(221);
+      if (lookahead == '0') ADVANCE(34);
+      if (lookahead == ':') ADVANCE(181);
+      if (lookahead == ';') ADVANCE(117);
+      if (lookahead == '<') ADVANCE(273);
+      if (lookahead == '=') ADVANCE(256);
+      if (lookahead == '>') ADVANCE(275);
+      if (lookahead == '@') ADVANCE(243);
+      if (lookahead == 'T') ADVANCE(158);
+      if (lookahead == '[') ADVANCE(209);
+      if (lookahead == ']') ADVANCE(211);
+      if (lookahead == '^') ADVANCE(267);
+      if (lookahead == '_') ADVANCE(137);
+      if (lookahead == '`') ADVANCE(228);
+      if (lookahead == 'f') ADVANCE(147);
+      if (lookahead == 'n') ADVANCE(151);
+      if (lookahead == 't') ADVANCE(156);
+      if (lookahead == '{') ADVANCE(212);
+      if (lookahead == '|') ADVANCE(266);
+      if (lookahead == '}') ADVANCE(214);
+      if (lookahead == '~') ADVANCE(283);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(112)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(232);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(247);
-      END_STATE();
-    case 113:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 114:
-      ACCEPT_TOKEN(anon_sym_SEMI);
+          lookahead == ' ') SKIP(114)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(180);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(160);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(160);
+      if (lookahead != 0 &&
+          lookahead > 159) ADVANCE(160);
       END_STATE();
     case 115:
-      ACCEPT_TOKEN(aux_sym__statement_token1);
-      if (lookahead == '\n') ADVANCE(115);
+      if (eof) ADVANCE(116);
+      if (lookahead == '"') ADVANCE(182);
+      if (lookahead == '#') ADVANCE(113);
+      if (lookahead == '%') ADVANCE(102);
+      if (lookahead == '\'') ADVANCE(19);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == '/') ADVANCE(221);
+      if (lookahead == '0') ADVANCE(34);
+      if (lookahead == ':') ADVANCE(181);
+      if (lookahead == '=') ADVANCE(257);
+      if (lookahead == '@') ADVANCE(243);
+      if (lookahead == 'T') ADVANCE(254);
+      if (lookahead == '[') ADVANCE(208);
+      if (lookahead == ']') ADVANCE(211);
+      if (lookahead == '_') ADVANCE(239);
+      if (lookahead == '`') ADVANCE(228);
+      if (lookahead == 'f') ADVANCE(240);
+      if (lookahead == 'n') ADVANCE(241);
+      if (lookahead == 't') ADVANCE(242);
+      if (lookahead == '{') ADVANCE(212);
+      if (lookahead == '}') ADVANCE(214);
+      if (('+' <= lookahead && lookahead <= '-')) ADVANCE(37);
       if (lookahead == '\t' ||
+          lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(181);
+          lookahead == ' ') SKIP(115)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(180);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(238);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(253);
       END_STATE();
     case 116:
-      ACCEPT_TOKEN(aux_sym__statement_token1);
-      if (lookahead == '\n') ADVANCE(116);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 117:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      ACCEPT_TOKEN(anon_sym_SEMI);
       END_STATE();
     case 118:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '.') ADVANCE(95);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      ACCEPT_TOKEN(aux_sym__statement_token1);
+      if (lookahead == '\n') ADVANCE(118);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(184);
       END_STATE();
     case 119:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'D') ADVANCE(124);
-      if (lookahead == 'E') ADVANCE(130);
-      if (lookahead == 'F') ADVANCE(125);
-      if (lookahead == 'L') ADVANCE(126);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+      ACCEPT_TOKEN(aux_sym__statement_token1);
+      if (lookahead == '\n') ADVANCE(119);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'D') ADVANCE(139);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'E') ADVANCE(141);
+      if (lookahead == '.') ADVANCE(97);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'E') ADVANCE(142);
+      if (lookahead == 'D') ADVANCE(127);
+      if (lookahead == 'E') ADVANCE(133);
+      if (lookahead == 'F') ADVANCE(128);
+      if (lookahead == 'L') ADVANCE(129);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'E') ADVANCE(143);
+      if (lookahead == 'D') ADVANCE(142);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'I') ADVANCE(133);
+      if (lookahead == 'E') ADVANCE(144);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'I') ADVANCE(128);
+      if (lookahead == 'E') ADVANCE(145);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 126:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'E') ADVANCE(146);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'I') ADVANCE(136);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 128:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
       if (lookahead == 'I') ADVANCE(131);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 127:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'I') ADVANCE(132);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 128:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'L') ADVANCE(121);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'L') ADVANCE(127);
+      if (lookahead == 'I') ADVANCE(134);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'N') ADVANCE(120);
+      if (lookahead == 'I') ADVANCE(135);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'N') ADVANCE(122);
+      if (lookahead == 'L') ADVANCE(124);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 132:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'L') ADVANCE(130);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 133:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
       if (lookahead == 'N') ADVANCE(123);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 133:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'R') ADVANCE(140);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '_') ADVANCE(119);
+      if (lookahead == 'N') ADVANCE(125);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'N') ADVANCE(126);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 136:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'R') ADVANCE(143);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 137:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(122);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
-    case 135:
+    case 138:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(252);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 139:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '_') ADVANCE(250);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 140:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
       if (lookahead == '_') ADVANCE(246);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 136:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '_') ADVANCE(244);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 137:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '_') ADVANCE(240);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 138:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '_') ADVANCE(242);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 139:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '_') ADVANCE(129);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 140:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '_') ADVANCE(135);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '_') ADVANCE(136);
+      if (lookahead == '_') ADVANCE(248);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 142:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '_') ADVANCE(137);
+      if (lookahead == '_') ADVANCE(132);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 143:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
       if (lookahead == '_') ADVANCE(138);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '`' < lookahead) &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 144:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'a') ADVANCE(149);
+      if (lookahead == '_') ADVANCE(139);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(161);
+      if (lookahead == '_') ADVANCE(140);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(118);
+      if (lookahead == '_') ADVANCE(141);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '[' || '`' < lookahead) &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(163);
+      if (lookahead == 'a') ADVANCE(152);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 148:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'i') ADVANCE(150);
+      if (lookahead == 'e') ADVANCE(164);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 149:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(154);
+      if (lookahead == 'e') ADVANCE(121);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 150:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(159);
+      if (lookahead == 'e') ADVANCE(166);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 151:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(146);
+      if (lookahead == 'i') ADVANCE(153);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 152:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'p') ADVANCE(151);
+      if (lookahead == 'l') ADVANCE(157);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 153:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'r') ADVANCE(156);
+      if (lookahead == 'l') ADVANCE(162);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 's') ADVANCE(147);
+      if (lookahead == 'l') ADVANCE(149);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(152);
+      if (lookahead == 'p') ADVANCE(154);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(145);
+      if (lookahead == 'r') ADVANCE(159);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 's') ADVANCE(150);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 158:
-      ACCEPT_TOKEN(sym_nil);
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'u') ADVANCE(155);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 159:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == 'u') ADVANCE(148);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 160:
+      ACCEPT_TOKEN(aux_sym_identifier_token1);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
+      END_STATE();
+    case 161:
+      ACCEPT_TOKEN(sym_nil);
+      END_STATE();
+    case 162:
       ACCEPT_TOKEN(sym_nil);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 160:
-      ACCEPT_TOKEN(anon_sym_true);
-      END_STATE();
-    case 161:
-      ACCEPT_TOKEN(anon_sym_true);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 162:
-      ACCEPT_TOKEN(anon_sym_false);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 163:
-      ACCEPT_TOKEN(anon_sym_false);
+      ACCEPT_TOKEN(anon_sym_true);
+      END_STATE();
+    case 164:
+      ACCEPT_TOKEN(anon_sym_true);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 164:
-      ACCEPT_TOKEN(aux_sym_float_token1);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 165:
-      ACCEPT_TOKEN(aux_sym_float_token1);
-      if (lookahead == 'e') ADVANCE(103);
-      if (lookahead == 'f') ADVANCE(47);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(165);
+      ACCEPT_TOKEN(anon_sym_false);
       END_STATE();
     case 166:
-      ACCEPT_TOKEN(aux_sym_float_token1);
-      if (lookahead == 'f') ADVANCE(47);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(166);
+      ACCEPT_TOKEN(anon_sym_false);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 167:
-      ACCEPT_TOKEN(aux_sym_float_token2);
+      ACCEPT_TOKEN(aux_sym_float_token1);
       END_STATE();
     case 168:
-      ACCEPT_TOKEN(aux_sym_float_token2);
-      if (lookahead == 'f') ADVANCE(48);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(168);
+      ACCEPT_TOKEN(aux_sym_float_token1);
+      if (lookahead == 'e') ADVANCE(105);
+      if (lookahead == 'f') ADVANCE(50);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(168);
       END_STATE();
     case 169:
-      ACCEPT_TOKEN(aux_sym_float_token3);
+      ACCEPT_TOKEN(aux_sym_float_token1);
+      if (lookahead == 'f') ADVANCE(50);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(169);
       END_STATE();
     case 170:
-      ACCEPT_TOKEN(aux_sym_integer_token1);
+      ACCEPT_TOKEN(aux_sym_float_token2);
       END_STATE();
     case 171:
-      ACCEPT_TOKEN(aux_sym_integer_token1);
-      if (lookahead == 'i') ADVANCE(36);
-      if (lookahead == 'u') ADVANCE(36);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(171);
+      ACCEPT_TOKEN(aux_sym_float_token2);
+      if (lookahead == 'f') ADVANCE(51);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(171);
       END_STATE();
     case 172:
-      ACCEPT_TOKEN(aux_sym_integer_token2);
+      ACCEPT_TOKEN(aux_sym_float_token3);
       END_STATE();
     case 173:
-      ACCEPT_TOKEN(aux_sym_integer_token2);
-      if (lookahead == 'i') ADVANCE(37);
-      if (lookahead == 'u') ADVANCE(37);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(173);
+      ACCEPT_TOKEN(aux_sym_integer_token1);
       END_STATE();
     case 174:
-      ACCEPT_TOKEN(aux_sym_integer_token3);
+      ACCEPT_TOKEN(aux_sym_integer_token1);
+      if (lookahead == 'i') ADVANCE(39);
+      if (lookahead == 'u') ADVANCE(39);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(174);
       END_STATE();
     case 175:
+      ACCEPT_TOKEN(aux_sym_integer_token2);
+      END_STATE();
+    case 176:
+      ACCEPT_TOKEN(aux_sym_integer_token2);
+      if (lookahead == 'i') ADVANCE(40);
+      if (lookahead == 'u') ADVANCE(40);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(176);
+      END_STATE();
+    case 177:
       ACCEPT_TOKEN(aux_sym_integer_token3);
+      END_STATE();
+    case 178:
+      ACCEPT_TOKEN(aux_sym_integer_token3);
+      if (lookahead == 'i') ADVANCE(41);
+      if (lookahead == 'u') ADVANCE(41);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(178);
+      END_STATE();
+    case 179:
+      ACCEPT_TOKEN(aux_sym_integer_token4);
+      END_STATE();
+    case 180:
+      ACCEPT_TOKEN(aux_sym_integer_token4);
+      if (lookahead == '.') ADVANCE(110);
+      if (lookahead == 'e') ADVANCE(104);
+      if (lookahead == 'f') ADVANCE(49);
       if (lookahead == 'i') ADVANCE(38);
       if (lookahead == 'u') ADVANCE(38);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(175);
-      END_STATE();
-    case 176:
-      ACCEPT_TOKEN(aux_sym_integer_token4);
-      END_STATE();
-    case 177:
-      ACCEPT_TOKEN(aux_sym_integer_token4);
-      if (lookahead == '.') ADVANCE(108);
-      if (lookahead == 'e') ADVANCE(102);
-      if (lookahead == 'f') ADVANCE(46);
-      if (lookahead == 'i') ADVANCE(35);
-      if (lookahead == 'u') ADVANCE(35);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(177);
-      END_STATE();
-    case 178:
-      ACCEPT_TOKEN(anon_sym_COLON);
-      END_STATE();
-    case 179:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
-      END_STATE();
-    case 180:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
+          lookahead == '_') ADVANCE(180);
       END_STATE();
     case 181:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '\n') ADVANCE(115);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ';') ADVANCE(114);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(181);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(180);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 182:
-      ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == ':') ADVANCE(178);
-      if (lookahead == '=') ADVANCE(189);
-      if (lookahead == '}') ADVANCE(211);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(182);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(180);
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
     case 183:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == '=') ADVANCE(189);
-      if (lookahead == '}') ADVANCE(211);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(183);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(180);
       END_STATE();
     case 184:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == ']') ADVANCE(208);
+      if (lookahead == '\n') ADVANCE(118);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ';') ADVANCE(117);
       if (lookahead == '\t' ||
-          lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(184);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(180);
+          lookahead != '"') ADVANCE(183);
       END_STATE();
     case 185:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ',') ADVANCE(207);
-      if (lookahead == '}') ADVANCE(211);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == ':') ADVANCE(181);
+      if (lookahead == '=') ADVANCE(192);
+      if (lookahead == '}') ADVANCE(214);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(185);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(180);
+          lookahead != '"') ADVANCE(183);
       END_STATE();
     case 186:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == ':') ADVANCE(178);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == '=') ADVANCE(192);
+      if (lookahead == '}') ADVANCE(214);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(186);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(180);
+          lookahead != '"') ADVANCE(183);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(190);
-      if (lookahead == '=') ADVANCE(189);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == ']') ADVANCE(211);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(187);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(180);
+          lookahead != '"') ADVANCE(183);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '#') ADVANCE(190);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ',') ADVANCE(210);
+      if (lookahead == '}') ADVANCE(214);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(188);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(180);
+          lookahead != '"') ADVANCE(183);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
-      if (lookahead == '>') ADVANCE(210);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == ':') ADVANCE(181);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(189);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(183);
       END_STATE();
     case 190:
       ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == '=') ADVANCE(192);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(190);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(231);
+          lookahead != '"') ADVANCE(183);
       END_STATE();
     case 191:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_SQUOTE);
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '#') ADVANCE(193);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(191);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(183);
       END_STATE();
     case 192:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE);
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead == '>') ADVANCE(213);
       END_STATE();
     case 193:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE);
+      ACCEPT_TOKEN(aux_sym_symbol_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(237);
       END_STATE();
     case 194:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHa_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_SQUOTE);
       END_STATE();
     case 195:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHb_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE);
       END_STATE();
     case 196:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHe_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE);
       END_STATE();
     case 197:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHf_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHa_SQUOTE);
       END_STATE();
     case 198:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHn_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHb_SQUOTE);
       END_STATE();
     case 199:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHr_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHe_SQUOTE);
       END_STATE();
     case 200:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHt_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHf_SQUOTE);
       END_STATE();
     case 201:
-      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHv_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHn_SQUOTE);
       END_STATE();
     case 202:
-      ACCEPT_TOKEN(aux_sym_char_token1);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHr_SQUOTE);
       END_STATE();
     case 203:
-      ACCEPT_TOKEN(aux_sym_char_token2);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHt_SQUOTE);
       END_STATE();
     case 204:
-      ACCEPT_TOKEN(aux_sym_char_token2);
-      if (lookahead == '\'') ADVANCE(192);
+      ACCEPT_TOKEN(anon_sym_SQUOTE_BSLASHv_SQUOTE);
       END_STATE();
     case 205:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(aux_sym_char_token1);
       END_STATE();
     case 206:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      if (lookahead == ']') ADVANCE(272);
+      ACCEPT_TOKEN(aux_sym_char_token2);
       END_STATE();
     case 207:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      ACCEPT_TOKEN(aux_sym_char_token2);
+      if (lookahead == '\'') ADVANCE(195);
       END_STATE();
     case 208:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 209:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == ']') ADVANCE(279);
       END_STATE();
     case 210:
-      ACCEPT_TOKEN(anon_sym_EQ_GT);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 211:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 212:
-      ACCEPT_TOKEN(anon_sym_of);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 213:
+      ACCEPT_TOKEN(anon_sym_EQ_GT);
+      END_STATE();
+    case 214:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 215:
+      ACCEPT_TOKEN(anon_sym_of);
+      END_STATE();
+    case 216:
       ACCEPT_TOKEN(aux_sym_hash_token1);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(231);
+          lookahead == ' ') ADVANCE(237);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(213);
+          lookahead != '\n') ADVANCE(216);
       END_STATE();
-    case 214:
+    case 217:
       ACCEPT_TOKEN(aux_sym_hash_token1);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(214);
-      END_STATE();
-    case 215:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      END_STATE();
-    case 216:
-      ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\n') ADVANCE(219);
-      if (lookahead == '/') ADVANCE(231);
-      if (lookahead == '\\') ADVANCE(217);
-      if (lookahead != 0) ADVANCE(216);
-      END_STATE();
-    case 217:
-      ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\n') ADVANCE(219);
-      if (lookahead != 0 &&
-          lookahead != '\\') ADVANCE(216);
-      if (lookahead == '\\') ADVANCE(217);
+          lookahead != ' ') ADVANCE(217);
       END_STATE();
     case 218:
-      ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '#') ADVANCE(216);
-      if (lookahead == '\\') ADVANCE(220);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(218);
-      if (lookahead != 0 &&
-          lookahead != '/') ADVANCE(219);
+      ACCEPT_TOKEN(anon_sym_LBRACK2);
       END_STATE();
     case 219:
-      ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead == '\\') ADVANCE(220);
-      if (lookahead != 0 &&
-          lookahead != '/') ADVANCE(219);
+      ACCEPT_TOKEN(anon_sym_LBRACK2);
+      if (lookahead == ']') ADVANCE(279);
       END_STATE();
     case 220:
-      ACCEPT_TOKEN(aux_sym_regex_token1);
-      if (lookahead != 0 &&
-          lookahead != '\\') ADVANCE(219);
-      if (lookahead == '\\') ADVANCE(220);
+      ACCEPT_TOKEN(anon_sym_RBRACK2);
       END_STATE();
     case 221:
-      ACCEPT_TOKEN(anon_sym_Tuple_DOTnew);
+      ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
     case 222:
-      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead == '\n') ADVANCE(225);
+      if (lookahead == '/') ADVANCE(237);
+      if (lookahead == '\\') ADVANCE(223);
+      if (lookahead != 0) ADVANCE(222);
       END_STATE();
     case 223:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
       if (lookahead == '\n') ADVANCE(225);
-      if (lookahead == '`') ADVANCE(231);
-      if (lookahead != 0) ADVANCE(223);
+      if (lookahead != 0 &&
+          lookahead != '\\') ADVANCE(222);
+      if (lookahead == '\\') ADVANCE(223);
       END_STATE();
     case 224:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
-      if (lookahead == '#') ADVANCE(223);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead == '#') ADVANCE(222);
+      if (lookahead == '\\') ADVANCE(226);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(224);
       if (lookahead != 0 &&
-          lookahead != '`') ADVANCE(225);
+          lookahead != '/') ADVANCE(225);
       END_STATE();
     case 225:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead == '\\') ADVANCE(226);
       if (lookahead != 0 &&
-          lookahead != '`') ADVANCE(225);
+          lookahead != '/') ADVANCE(225);
       END_STATE();
     case 226:
-      ACCEPT_TOKEN(anon_sym_PERCENTx_LPAREN);
+      ACCEPT_TOKEN(aux_sym_regex_token1);
+      if (lookahead != 0 &&
+          lookahead != '\\') ADVANCE(225);
+      if (lookahead == '\\') ADVANCE(226);
       END_STATE();
     case 227:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
-      if (lookahead == '\n') ADVANCE(229);
-      if (lookahead == ')') ADVANCE(231);
-      if (lookahead != 0) ADVANCE(227);
+      ACCEPT_TOKEN(anon_sym_Tuple_DOTnew);
       END_STATE();
     case 228:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
-      if (lookahead == '#') ADVANCE(227);
+      ACCEPT_TOKEN(anon_sym_BQUOTE);
+      END_STATE();
+    case 229:
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      if (lookahead == '\n') ADVANCE(231);
+      if (lookahead == '`') ADVANCE(237);
+      if (lookahead != 0) ADVANCE(229);
+      END_STATE();
+    case 230:
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
+      if (lookahead == '#') ADVANCE(229);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(228);
+          lookahead == ' ') ADVANCE(230);
       if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(229);
-      END_STATE();
-    case 229:
-      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
-      if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(229);
-      END_STATE();
-    case 230:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+          lookahead != '`') ADVANCE(231);
       END_STATE();
     case 231:
-      ACCEPT_TOKEN(sym_comment);
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token1);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(231);
+          lookahead != '`') ADVANCE(231);
       END_STATE();
     case 232:
-      ACCEPT_TOKEN(aux_sym_local_variable_token1);
+      ACCEPT_TOKEN(anon_sym_PERCENTx_LPAREN);
       END_STATE();
     case 233:
-      ACCEPT_TOKEN(aux_sym_local_variable_token1);
-      if (lookahead == '_') ADVANCE(62);
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
+      if (lookahead == '\n') ADVANCE(235);
+      if (lookahead == ')') ADVANCE(237);
+      if (lookahead != 0) ADVANCE(233);
       END_STATE();
     case 234:
-      ACCEPT_TOKEN(aux_sym_local_variable_token1);
-      if (lookahead == 'a') ADVANCE(92);
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
+      if (lookahead == '#') ADVANCE(233);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(234);
+      if (lookahead != 0 &&
+          lookahead != ')') ADVANCE(235);
       END_STATE();
     case 235:
-      ACCEPT_TOKEN(aux_sym_local_variable_token1);
-      if (lookahead == 'i') ADVANCE(93);
+      ACCEPT_TOKEN(aux_sym_commandLiteral_token2);
+      if (lookahead != 0 &&
+          lookahead != ')') ADVANCE(235);
       END_STATE();
     case 236:
-      ACCEPT_TOKEN(aux_sym_local_variable_token1);
-      if (lookahead == 'r') ADVANCE(98);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 237:
-      ACCEPT_TOKEN(anon_sym_AT);
-      if (lookahead == '@') ADVANCE(238);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(237);
       END_STATE();
     case 238:
-      ACCEPT_TOKEN(anon_sym_AT_AT);
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
       END_STATE();
     case 239:
-      ACCEPT_TOKEN(anon_sym___LINE__);
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
+      if (lookahead == '_') ADVANCE(64);
       END_STATE();
     case 240:
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
+      if (lookahead == 'a') ADVANCE(94);
+      END_STATE();
+    case 241:
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
+      if (lookahead == 'i') ADVANCE(95);
+      END_STATE();
+    case 242:
+      ACCEPT_TOKEN(aux_sym_local_variable_token1);
+      if (lookahead == 'r') ADVANCE(100);
+      END_STATE();
+    case 243:
+      ACCEPT_TOKEN(anon_sym_AT);
+      if (lookahead == '@') ADVANCE(244);
+      END_STATE();
+    case 244:
+      ACCEPT_TOKEN(anon_sym_AT_AT);
+      END_STATE();
+    case 245:
+      ACCEPT_TOKEN(anon_sym___LINE__);
+      END_STATE();
+    case 246:
       ACCEPT_TOKEN(anon_sym___LINE__);
       if (lookahead == '!' ||
           lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
+          lookahead == '?') ADVANCE(120);
       if (lookahead != 0 &&
           lookahead > '/' &&
           (lookahead < ':' || '@' < lookahead) &&
           (lookahead < '[' || '^' < lookahead) &&
           lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 241:
-      ACCEPT_TOKEN(anon_sym___END_LINE__);
-      END_STATE();
-    case 242:
-      ACCEPT_TOKEN(anon_sym___END_LINE__);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 243:
-      ACCEPT_TOKEN(anon_sym___FILE__);
-      END_STATE();
-    case 244:
-      ACCEPT_TOKEN(anon_sym___FILE__);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
-      END_STATE();
-    case 245:
-      ACCEPT_TOKEN(anon_sym___DIR__);
-      END_STATE();
-    case 246:
-      ACCEPT_TOKEN(anon_sym___DIR__);
-      if (lookahead == '!' ||
-          lookahead == '=' ||
-          lookahead == '?') ADVANCE(117);
-      if (lookahead != 0 &&
-          lookahead > '/' &&
-          (lookahead < ':' || '@' < lookahead) &&
-          (lookahead < '[' || '^' < lookahead) &&
-          lookahead != '`' &&
-          (lookahead < '{' || 159 < lookahead)) ADVANCE(157);
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 247:
-      ACCEPT_TOKEN(aux_sym_constant_token1);
+      ACCEPT_TOKEN(anon_sym___END_LINE__);
       END_STATE();
     case 248:
-      ACCEPT_TOKEN(aux_sym_constant_token1);
-      if (lookahead == 'u') ADVANCE(96);
+      ACCEPT_TOKEN(anon_sym___END_LINE__);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 249:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(anon_sym___FILE__);
       END_STATE();
     case 250:
-      ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead == '=') ADVANCE(264);
-      if (lookahead == '>') ADVANCE(210);
-      if (lookahead == '~') ADVANCE(278);
+      ACCEPT_TOKEN(anon_sym___FILE__);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 251:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(anon_sym___DIR__);
       END_STATE();
     case 252:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      if (lookahead == '0') ADVANCE(31);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
+      ACCEPT_TOKEN(anon_sym___DIR__);
+      if (lookahead == '!' ||
+          lookahead == '=' ||
+          lookahead == '?') ADVANCE(120);
+      if (lookahead != 0 &&
+          lookahead > '/' &&
+          (lookahead < ':' || '@' < lookahead) &&
+          (lookahead < '[' || '^' < lookahead) &&
+          lookahead != '`' &&
+          (lookahead < '{' || 159 < lookahead)) ADVANCE(160);
       END_STATE();
     case 253:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(aux_sym_constant_token1);
       END_STATE();
     case 254:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '0') ADVANCE(31);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(177);
+      ACCEPT_TOKEN(aux_sym_constant_token1);
+      if (lookahead == 'u') ADVANCE(98);
       END_STATE();
     case 255:
-      ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '*') ADVANCE(261);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 256:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
+      ACCEPT_TOKEN(anon_sym_EQ);
+      if (lookahead == '=') ADVANCE(271);
+      if (lookahead == '>') ADVANCE(213);
+      if (lookahead == '~') ADVANCE(285);
       END_STATE();
     case 257:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
-      if (lookahead == 'x') ADVANCE(30);
+      ACCEPT_TOKEN(anon_sym_EQ);
+      if (lookahead == '>') ADVANCE(213);
       END_STATE();
     case 258:
-      ACCEPT_TOKEN(anon_sym_AMP);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 259:
-      ACCEPT_TOKEN(anon_sym_PIPE);
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      if (lookahead == '0') ADVANCE(34);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(180);
       END_STATE();
     case 260:
-      ACCEPT_TOKEN(anon_sym_CARET);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 261:
-      ACCEPT_TOKEN(anon_sym_STAR_STAR);
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '0') ADVANCE(34);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(180);
       END_STATE();
     case 262:
-      ACCEPT_TOKEN(anon_sym_GT_GT);
+      ACCEPT_TOKEN(anon_sym_STAR);
+      if (lookahead == '*') ADVANCE(268);
       END_STATE();
     case 263:
-      ACCEPT_TOKEN(anon_sym_LT_LT);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
     case 264:
-      ACCEPT_TOKEN(anon_sym_EQ_EQ);
-      if (lookahead == '=') ADVANCE(271);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
+      if (lookahead == 'x') ADVANCE(33);
       END_STATE();
     case 265:
-      ACCEPT_TOKEN(anon_sym_BANG_EQ);
+      ACCEPT_TOKEN(anon_sym_AMP);
       END_STATE();
     case 266:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '<') ADVANCE(263);
-      if (lookahead == '=') ADVANCE(267);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 267:
-      ACCEPT_TOKEN(anon_sym_LT_EQ);
-      if (lookahead == '>') ADVANCE(270);
+      ACCEPT_TOKEN(anon_sym_CARET);
       END_STATE();
     case 268:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '=') ADVANCE(269);
-      if (lookahead == '>') ADVANCE(262);
+      ACCEPT_TOKEN(anon_sym_STAR_STAR);
       END_STATE();
     case 269:
-      ACCEPT_TOKEN(anon_sym_GT_EQ);
+      ACCEPT_TOKEN(anon_sym_GT_GT);
       END_STATE();
     case 270:
-      ACCEPT_TOKEN(anon_sym_LT_EQ_GT);
+      ACCEPT_TOKEN(anon_sym_LT_LT);
       END_STATE();
     case 271:
-      ACCEPT_TOKEN(anon_sym_EQ_EQ_EQ);
+      ACCEPT_TOKEN(anon_sym_EQ_EQ);
+      if (lookahead == '=') ADVANCE(278);
       END_STATE();
     case 272:
-      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK);
-      if (lookahead == '=') ADVANCE(274);
-      if (lookahead == '?') ADVANCE(273);
+      ACCEPT_TOKEN(anon_sym_BANG_EQ);
       END_STATE();
     case 273:
-      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_QMARK);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '<') ADVANCE(270);
+      if (lookahead == '=') ADVANCE(274);
       END_STATE();
     case 274:
-      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_EQ);
+      ACCEPT_TOKEN(anon_sym_LT_EQ);
+      if (lookahead == '>') ADVANCE(277);
       END_STATE();
     case 275:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead == '=') ADVANCE(265);
-      if (lookahead == '~') ADVANCE(277);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '=') ADVANCE(276);
+      if (lookahead == '>') ADVANCE(269);
       END_STATE();
     case 276:
-      ACCEPT_TOKEN(anon_sym_TILDE);
+      ACCEPT_TOKEN(anon_sym_GT_EQ);
       END_STATE();
     case 277:
-      ACCEPT_TOKEN(anon_sym_BANG_TILDE);
+      ACCEPT_TOKEN(anon_sym_LT_EQ_GT);
       END_STATE();
     case 278:
+      ACCEPT_TOKEN(anon_sym_EQ_EQ_EQ);
+      END_STATE();
+    case 279:
+      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK);
+      if (lookahead == '=') ADVANCE(281);
+      if (lookahead == '?') ADVANCE(280);
+      END_STATE();
+    case 280:
+      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_QMARK);
+      END_STATE();
+    case 281:
+      ACCEPT_TOKEN(anon_sym_LBRACK_RBRACK_EQ);
+      END_STATE();
+    case 282:
+      ACCEPT_TOKEN(anon_sym_BANG);
+      if (lookahead == '=') ADVANCE(272);
+      if (lookahead == '~') ADVANCE(284);
+      END_STATE();
+    case 283:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      END_STATE();
+    case 284:
+      ACCEPT_TOKEN(anon_sym_BANG_TILDE);
+      END_STATE();
+    case 285:
       ACCEPT_TOKEN(anon_sym_EQ_TILDE);
       END_STATE();
     default:
@@ -2601,187 +2747,255 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 112},
+  [1] = {.lex_state = 115},
   [2] = {.lex_state = 4},
-  [3] = {.lex_state = 112},
-  [4] = {.lex_state = 112},
+  [3] = {.lex_state = 4},
+  [4] = {.lex_state = 115},
   [5] = {.lex_state = 4},
-  [6] = {.lex_state = 112},
-  [7] = {.lex_state = 112},
-  [8] = {.lex_state = 112},
-  [9] = {.lex_state = 112},
-  [10] = {.lex_state = 112},
-  [11] = {.lex_state = 112},
-  [12] = {.lex_state = 112},
-  [13] = {.lex_state = 112},
-  [14] = {.lex_state = 112},
-  [15] = {.lex_state = 112},
-  [16] = {.lex_state = 112},
-  [17] = {.lex_state = 112},
-  [18] = {.lex_state = 112},
-  [19] = {.lex_state = 112},
-  [20] = {.lex_state = 112},
-  [21] = {.lex_state = 112},
-  [22] = {.lex_state = 112},
-  [23] = {.lex_state = 3},
-  [24] = {.lex_state = 3},
-  [25] = {.lex_state = 3},
-  [26] = {.lex_state = 3},
-  [27] = {.lex_state = 3},
-  [28] = {.lex_state = 5},
-  [29] = {.lex_state = 5},
-  [30] = {.lex_state = 6},
-  [31] = {.lex_state = 6},
-  [32] = {.lex_state = 6},
-  [33] = {.lex_state = 6},
-  [34] = {.lex_state = 112},
-  [35] = {.lex_state = 112},
-  [36] = {.lex_state = 112},
-  [37] = {.lex_state = 112},
-  [38] = {.lex_state = 112},
-  [39] = {.lex_state = 112},
-  [40] = {.lex_state = 112},
-  [41] = {.lex_state = 112},
-  [42] = {.lex_state = 112},
-  [43] = {.lex_state = 1},
-  [44] = {.lex_state = 112},
-  [45] = {.lex_state = 1},
-  [46] = {.lex_state = 7},
-  [47] = {.lex_state = 8},
-  [48] = {.lex_state = 112},
-  [49] = {.lex_state = 112},
-  [50] = {.lex_state = 112},
-  [51] = {.lex_state = 1},
-  [52] = {.lex_state = 112},
-  [53] = {.lex_state = 112},
-  [54] = {.lex_state = 8},
-  [55] = {.lex_state = 7},
-  [56] = {.lex_state = 7},
-  [57] = {.lex_state = 8},
-  [58] = {.lex_state = 7},
-  [59] = {.lex_state = 112},
-  [60] = {.lex_state = 1},
-  [61] = {.lex_state = 112},
-  [62] = {.lex_state = 112},
-  [63] = {.lex_state = 3},
-  [64] = {.lex_state = 112},
-  [65] = {.lex_state = 112},
-  [66] = {.lex_state = 8},
-  [67] = {.lex_state = 112},
-  [68] = {.lex_state = 112},
-  [69] = {.lex_state = 11},
-  [70] = {.lex_state = 10},
-  [71] = {.lex_state = 11},
-  [72] = {.lex_state = 0},
-  [73] = {.lex_state = 0},
-  [74] = {.lex_state = 0},
-  [75] = {.lex_state = 11},
-  [76] = {.lex_state = 0},
-  [77] = {.lex_state = 11},
-  [78] = {.lex_state = 11},
-  [79] = {.lex_state = 0},
-  [80] = {.lex_state = 11},
-  [81] = {.lex_state = 0},
-  [82] = {.lex_state = 11},
-  [83] = {.lex_state = 11},
-  [84] = {.lex_state = 11},
-  [85] = {.lex_state = 0},
-  [86] = {.lex_state = 11},
-  [87] = {.lex_state = 11},
-  [88] = {.lex_state = 0},
-  [89] = {.lex_state = 11},
-  [90] = {.lex_state = 11},
-  [91] = {.lex_state = 11},
-  [92] = {.lex_state = 11},
-  [93] = {.lex_state = 11},
-  [94] = {.lex_state = 11},
-  [95] = {.lex_state = 11},
-  [96] = {.lex_state = 0},
+  [6] = {.lex_state = 115},
+  [7] = {.lex_state = 115},
+  [8] = {.lex_state = 115},
+  [9] = {.lex_state = 115},
+  [10] = {.lex_state = 115},
+  [11] = {.lex_state = 115},
+  [12] = {.lex_state = 115},
+  [13] = {.lex_state = 115},
+  [14] = {.lex_state = 115},
+  [15] = {.lex_state = 115},
+  [16] = {.lex_state = 115},
+  [17] = {.lex_state = 115},
+  [18] = {.lex_state = 115},
+  [19] = {.lex_state = 115},
+  [20] = {.lex_state = 115},
+  [21] = {.lex_state = 115},
+  [22] = {.lex_state = 115},
+  [23] = {.lex_state = 115},
+  [24] = {.lex_state = 115},
+  [25] = {.lex_state = 115},
+  [26] = {.lex_state = 115},
+  [27] = {.lex_state = 115},
+  [28] = {.lex_state = 115},
+  [29] = {.lex_state = 115},
+  [30] = {.lex_state = 115},
+  [31] = {.lex_state = 3},
+  [32] = {.lex_state = 3},
+  [33] = {.lex_state = 3},
+  [34] = {.lex_state = 3},
+  [35] = {.lex_state = 3},
+  [36] = {.lex_state = 3},
+  [37] = {.lex_state = 6},
+  [38] = {.lex_state = 6},
+  [39] = {.lex_state = 7},
+  [40] = {.lex_state = 7},
+  [41] = {.lex_state = 115},
+  [42] = {.lex_state = 7},
+  [43] = {.lex_state = 7},
+  [44] = {.lex_state = 115},
+  [45] = {.lex_state = 8},
+  [46] = {.lex_state = 0},
+  [47] = {.lex_state = 9},
+  [48] = {.lex_state = 1},
+  [49] = {.lex_state = 9},
+  [50] = {.lex_state = 1},
+  [51] = {.lex_state = 115},
+  [52] = {.lex_state = 115},
+  [53] = {.lex_state = 0},
+  [54] = {.lex_state = 115},
+  [55] = {.lex_state = 0},
+  [56] = {.lex_state = 0},
+  [57] = {.lex_state = 0},
+  [58] = {.lex_state = 115},
+  [59] = {.lex_state = 115},
+  [60] = {.lex_state = 9},
+  [61] = {.lex_state = 115},
+  [62] = {.lex_state = 115},
+  [63] = {.lex_state = 9},
+  [64] = {.lex_state = 115},
+  [65] = {.lex_state = 115},
+  [66] = {.lex_state = 1},
+  [67] = {.lex_state = 115},
+  [68] = {.lex_state = 8},
+  [69] = {.lex_state = 0},
+  [70] = {.lex_state = 8},
+  [71] = {.lex_state = 1},
+  [72] = {.lex_state = 115},
+  [73] = {.lex_state = 115},
+  [74] = {.lex_state = 115},
+  [75] = {.lex_state = 115},
+  [76] = {.lex_state = 3},
+  [77] = {.lex_state = 115},
+  [78] = {.lex_state = 115},
+  [79] = {.lex_state = 8},
+  [80] = {.lex_state = 115},
+  [81] = {.lex_state = 115},
+  [82] = {.lex_state = 115},
+  [83] = {.lex_state = 10},
+  [84] = {.lex_state = 115},
+  [85] = {.lex_state = 13},
+  [86] = {.lex_state = 0},
+  [87] = {.lex_state = 14},
+  [88] = {.lex_state = 14},
+  [89] = {.lex_state = 0},
+  [90] = {.lex_state = 2},
+  [91] = {.lex_state = 13},
+  [92] = {.lex_state = 13},
+  [93] = {.lex_state = 115},
+  [94] = {.lex_state = 13},
+  [95] = {.lex_state = 115},
+  [96] = {.lex_state = 13},
   [97] = {.lex_state = 0},
-  [98] = {.lex_state = 0},
+  [98] = {.lex_state = 13},
   [99] = {.lex_state = 0},
-  [100] = {.lex_state = 0},
-  [101] = {.lex_state = 0},
-  [102] = {.lex_state = 11},
+  [100] = {.lex_state = 2},
+  [101] = {.lex_state = 13},
+  [102] = {.lex_state = 13},
   [103] = {.lex_state = 0},
-  [104] = {.lex_state = 0},
+  [104] = {.lex_state = 13},
   [105] = {.lex_state = 0},
-  [106] = {.lex_state = 11},
-  [107] = {.lex_state = 0},
-  [108] = {.lex_state = 11},
-  [109] = {.lex_state = 11},
-  [110] = {.lex_state = 11},
-  [111] = {.lex_state = 9},
-  [112] = {.lex_state = 9},
-  [113] = {.lex_state = 0},
-  [114] = {.lex_state = 11},
-  [115] = {.lex_state = 11},
-  [116] = {.lex_state = 10},
-  [117] = {.lex_state = 10},
-  [118] = {.lex_state = 10},
-  [119] = {.lex_state = 2},
-  [120] = {.lex_state = 2},
-  [121] = {.lex_state = 2},
-  [122] = {.lex_state = 2},
-  [123] = {.lex_state = 2},
-  [124] = {.lex_state = 2},
-  [125] = {.lex_state = 2},
-  [126] = {.lex_state = 2},
-  [127] = {.lex_state = 2},
-  [128] = {.lex_state = 12},
-  [129] = {.lex_state = 2},
-  [130] = {.lex_state = 2},
-  [131] = {.lex_state = 12},
-  [132] = {.lex_state = 2},
-  [133] = {.lex_state = 2},
-  [134] = {.lex_state = 2},
-  [135] = {.lex_state = 2},
+  [106] = {.lex_state = 13},
+  [107] = {.lex_state = 13},
+  [108] = {.lex_state = 13},
+  [109] = {.lex_state = 0},
+  [110] = {.lex_state = 13},
+  [111] = {.lex_state = 13},
+  [112] = {.lex_state = 0},
+  [113] = {.lex_state = 13},
+  [114] = {.lex_state = 13},
+  [115] = {.lex_state = 115},
+  [116] = {.lex_state = 13},
+  [117] = {.lex_state = 13},
+  [118] = {.lex_state = 13},
+  [119] = {.lex_state = 0},
+  [120] = {.lex_state = 0},
+  [121] = {.lex_state = 0},
+  [122] = {.lex_state = 0},
+  [123] = {.lex_state = 115},
+  [124] = {.lex_state = 0},
+  [125] = {.lex_state = 13},
+  [126] = {.lex_state = 115},
+  [127] = {.lex_state = 13},
+  [128] = {.lex_state = 115},
+  [129] = {.lex_state = 13},
+  [130] = {.lex_state = 13},
+  [131] = {.lex_state = 13},
+  [132] = {.lex_state = 13},
+  [133] = {.lex_state = 0},
+  [134] = {.lex_state = 0},
+  [135] = {.lex_state = 0},
   [136] = {.lex_state = 0},
-  [137] = {.lex_state = 12},
-  [138] = {.lex_state = 12},
-  [139] = {.lex_state = 2},
-  [140] = {.lex_state = 0},
-  [141] = {.lex_state = 2},
-  [142] = {.lex_state = 2},
-  [143] = {.lex_state = 2},
-  [144] = {.lex_state = 0},
-  [145] = {.lex_state = 228},
-  [146] = {.lex_state = 15},
-  [147] = {.lex_state = 15},
-  [148] = {.lex_state = 4},
-  [149] = {.lex_state = 4},
-  [150] = {.lex_state = 4},
-  [151] = {.lex_state = 4},
-  [152] = {.lex_state = 0},
-  [153] = {.lex_state = 0},
-  [154] = {.lex_state = 112},
-  [155] = {.lex_state = 0},
-  [156] = {.lex_state = 0},
-  [157] = {.lex_state = 0},
-  [158] = {.lex_state = 15},
-  [159] = {.lex_state = 4},
-  [160] = {.lex_state = 14},
-  [161] = {.lex_state = 218},
-  [162] = {.lex_state = 224},
-  [163] = {.lex_state = 4},
+  [137] = {.lex_state = 0},
+  [138] = {.lex_state = 115},
+  [139] = {.lex_state = 13},
+  [140] = {.lex_state = 12},
+  [141] = {.lex_state = 12},
+  [142] = {.lex_state = 12},
+  [143] = {.lex_state = 12},
+  [144] = {.lex_state = 13},
+  [145] = {.lex_state = 14},
+  [146] = {.lex_state = 14},
+  [147] = {.lex_state = 13},
+  [148] = {.lex_state = 115},
+  [149] = {.lex_state = 11},
+  [150] = {.lex_state = 13},
+  [151] = {.lex_state = 11},
+  [152] = {.lex_state = 11},
+  [153] = {.lex_state = 11},
+  [154] = {.lex_state = 10},
+  [155] = {.lex_state = 2},
+  [156] = {.lex_state = 14},
+  [157] = {.lex_state = 14},
+  [158] = {.lex_state = 115},
+  [159] = {.lex_state = 2},
+  [160] = {.lex_state = 2},
+  [161] = {.lex_state = 14},
+  [162] = {.lex_state = 2},
+  [163] = {.lex_state = 2},
   [164] = {.lex_state = 14},
-  [165] = {.lex_state = 0},
-  [166] = {.lex_state = 228},
-  [167] = {.lex_state = 0},
-  [168] = {.lex_state = 112},
-  [169] = {.lex_state = 224},
-  [170] = {.lex_state = 4},
-  [171] = {.lex_state = 4},
-  [172] = {.lex_state = 218},
-  [173] = {.lex_state = 13},
+  [165] = {.lex_state = 2},
+  [166] = {.lex_state = 14},
+  [167] = {.lex_state = 2},
+  [168] = {.lex_state = 2},
+  [169] = {.lex_state = 14},
+  [170] = {.lex_state = 14},
+  [171] = {.lex_state = 14},
+  [172] = {.lex_state = 14},
+  [173] = {.lex_state = 2},
   [174] = {.lex_state = 4},
-  [175] = {.lex_state = 112},
-  [176] = {.lex_state = 0},
-  [177] = {.lex_state = 4},
-  [178] = {.lex_state = 0},
-  [179] = {.lex_state = 0},
-  [180] = {.lex_state = 15},
-  [181] = {.lex_state = 13},
+  [175] = {.lex_state = 2},
+  [176] = {.lex_state = 14},
+  [177] = {.lex_state = 14},
+  [178] = {.lex_state = 2},
+  [179] = {.lex_state = 2},
+  [180] = {.lex_state = 2},
+  [181] = {.lex_state = 2},
+  [182] = {.lex_state = 2},
+  [183] = {.lex_state = 2},
+  [184] = {.lex_state = 2},
+  [185] = {.lex_state = 4},
+  [186] = {.lex_state = 0},
+  [187] = {.lex_state = 0},
+  [188] = {.lex_state = 2},
+  [189] = {.lex_state = 2},
+  [190] = {.lex_state = 0},
+  [191] = {.lex_state = 4},
+  [192] = {.lex_state = 4},
+  [193] = {.lex_state = 4},
+  [194] = {.lex_state = 4},
+  [195] = {.lex_state = 4},
+  [196] = {.lex_state = 4},
+  [197] = {.lex_state = 18},
+  [198] = {.lex_state = 4},
+  [199] = {.lex_state = 4},
+  [200] = {.lex_state = 4},
+  [201] = {.lex_state = 4},
+  [202] = {.lex_state = 4},
+  [203] = {.lex_state = 0},
+  [204] = {.lex_state = 0},
+  [205] = {.lex_state = 0},
+  [206] = {.lex_state = 0},
+  [207] = {.lex_state = 18},
+  [208] = {.lex_state = 0},
+  [209] = {.lex_state = 0},
+  [210] = {.lex_state = 4},
+  [211] = {.lex_state = 4},
+  [212] = {.lex_state = 224},
+  [213] = {.lex_state = 230},
+  [214] = {.lex_state = 234},
+  [215] = {.lex_state = 4},
+  [216] = {.lex_state = 4},
+  [217] = {.lex_state = 4},
+  [218] = {.lex_state = 16},
+  [219] = {.lex_state = 0},
+  [220] = {.lex_state = 0},
+  [221] = {.lex_state = 0},
+  [222] = {.lex_state = 18},
+  [223] = {.lex_state = 4},
+  [224] = {.lex_state = 4},
+  [225] = {.lex_state = 17},
+  [226] = {.lex_state = 224},
+  [227] = {.lex_state = 230},
+  [228] = {.lex_state = 234},
+  [229] = {.lex_state = 17},
+  [230] = {.lex_state = 4},
+  [231] = {.lex_state = 234},
+  [232] = {.lex_state = 0},
+  [233] = {.lex_state = 230},
+  [234] = {.lex_state = 4},
+  [235] = {.lex_state = 4},
+  [236] = {.lex_state = 224},
+  [237] = {.lex_state = 18},
+  [238] = {.lex_state = 0},
+  [239] = {.lex_state = 0},
+  [240] = {.lex_state = 0},
+  [241] = {.lex_state = 18},
+  [242] = {.lex_state = 0},
+  [243] = {.lex_state = 0},
+  [244] = {.lex_state = 0},
+  [245] = {.lex_state = 18},
+  [246] = {.lex_state = 0},
+  [247] = {.lex_state = 0},
+  [248] = {.lex_state = 16},
+  [249] = {.lex_state = 16},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -2820,6 +3034,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE] = ACTIONS(1),
     [anon_sym_EQ_GT] = ACTIONS(1),
     [anon_sym_RBRACE] = ACTIONS(1),
+    [anon_sym_LBRACK2] = ACTIONS(1),
+    [anon_sym_RBRACK2] = ACTIONS(1),
     [anon_sym_SLASH] = ACTIONS(1),
     [anon_sym_Tuple_DOTnew] = ACTIONS(1),
     [anon_sym_BQUOTE] = ACTIONS(1),
@@ -2862,27 +3078,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_EQ_TILDE] = ACTIONS(1),
   },
   [1] = {
-    [sym_program] = STATE(176),
-    [sym__statement] = STATE(4),
-    [sym__expression] = STATE(122),
-    [sym_bool] = STATE(122),
-    [sym_float] = STATE(122),
-    [sym_integer] = STATE(122),
-    [sym_symbol] = STATE(122),
-    [sym_char] = STATE(122),
-    [sym_string] = STATE(122),
-    [sym_array] = STATE(122),
-    [sym_hash] = STATE(122),
-    [sym_regex] = STATE(122),
-    [sym_tuple] = STATE(122),
-    [sym_namedTupleLiteral] = STATE(122),
-    [sym_commandLiteral] = STATE(122),
-    [sym_local_variable] = STATE(150),
-    [sym_instance_variable] = STATE(150),
-    [sym_class_variable] = STATE(150),
-    [sym_constant] = STATE(150),
-    [sym_assignment] = STATE(122),
-    [aux_sym_program_repeat1] = STATE(4),
+    [sym_program] = STATE(221),
+    [sym__statement] = STATE(6),
+    [sym__expression] = STATE(173),
+    [sym_bool] = STATE(173),
+    [sym_float] = STATE(173),
+    [sym_integer] = STATE(173),
+    [sym_symbol] = STATE(173),
+    [sym_char] = STATE(173),
+    [sym_string] = STATE(173),
+    [sym_array] = STATE(173),
+    [sym_hash] = STATE(173),
+    [sym_index_expression] = STATE(90),
+    [sym_regex] = STATE(173),
+    [sym_tuple] = STATE(173),
+    [sym_namedTupleLiteral] = STATE(173),
+    [sym_commandLiteral] = STATE(173),
+    [sym_local_variable] = STATE(176),
+    [sym_instance_variable] = STATE(176),
+    [sym_class_variable] = STATE(176),
+    [sym_constant] = STATE(176),
+    [sym__variable] = STATE(176),
+    [sym_assignment] = STATE(173),
+    [aux_sym_program_repeat1] = STATE(6),
     [ts_builtin_sym_end] = ACTIONS(5),
     [sym_nil] = ACTIONS(7),
     [anon_sym_true] = ACTIONS(9),
@@ -2926,25 +3144,27 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [2] = {
-    [sym__expression] = STATE(67),
-    [sym_identifier] = STATE(178),
-    [sym_bool] = STATE(67),
-    [sym_float] = STATE(67),
-    [sym_integer] = STATE(67),
-    [sym_symbol] = STATE(67),
-    [sym_char] = STATE(67),
-    [sym_string] = STATE(40),
-    [sym_array] = STATE(67),
-    [sym_hash] = STATE(67),
-    [sym_regex] = STATE(67),
-    [sym_tuple] = STATE(67),
-    [sym_namedTupleLiteral] = STATE(67),
-    [sym_commandLiteral] = STATE(67),
-    [sym_local_variable] = STATE(171),
-    [sym_instance_variable] = STATE(171),
-    [sym_class_variable] = STATE(171),
-    [sym_constant] = STATE(171),
-    [sym_assignment] = STATE(67),
+    [sym__expression] = STATE(55),
+    [sym_identifier] = STATE(244),
+    [sym_bool] = STATE(55),
+    [sym_float] = STATE(55),
+    [sym_integer] = STATE(55),
+    [sym_symbol] = STATE(55),
+    [sym_char] = STATE(55),
+    [sym_string] = STATE(53),
+    [sym_array] = STATE(55),
+    [sym_hash] = STATE(55),
+    [sym_index_expression] = STATE(73),
+    [sym_regex] = STATE(55),
+    [sym_tuple] = STATE(55),
+    [sym_namedTupleLiteral] = STATE(55),
+    [sym_commandLiteral] = STATE(55),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym__variable] = STATE(170),
+    [sym_assignment] = STATE(55),
     [aux_sym_identifier_token1] = ACTIONS(49),
     [sym_nil] = ACTIONS(51),
     [anon_sym_true] = ACTIONS(53),
@@ -2989,90 +3209,224 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [3] = {
-    [sym__statement] = STATE(3),
-    [sym__expression] = STATE(122),
-    [sym_bool] = STATE(122),
-    [sym_float] = STATE(122),
-    [sym_integer] = STATE(122),
-    [sym_symbol] = STATE(122),
-    [sym_char] = STATE(122),
-    [sym_string] = STATE(122),
-    [sym_array] = STATE(122),
-    [sym_hash] = STATE(122),
-    [sym_regex] = STATE(122),
-    [sym_tuple] = STATE(122),
-    [sym_namedTupleLiteral] = STATE(122),
-    [sym_commandLiteral] = STATE(122),
-    [sym_local_variable] = STATE(150),
-    [sym_instance_variable] = STATE(150),
-    [sym_class_variable] = STATE(150),
-    [sym_constant] = STATE(150),
-    [sym_assignment] = STATE(122),
-    [aux_sym_program_repeat1] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(87),
-    [sym_nil] = ACTIONS(89),
-    [anon_sym_true] = ACTIONS(92),
-    [anon_sym_false] = ACTIONS(92),
-    [aux_sym_float_token1] = ACTIONS(95),
-    [aux_sym_float_token2] = ACTIONS(98),
-    [aux_sym_float_token3] = ACTIONS(98),
-    [aux_sym_integer_token1] = ACTIONS(101),
-    [aux_sym_integer_token2] = ACTIONS(101),
-    [aux_sym_integer_token3] = ACTIONS(101),
-    [aux_sym_integer_token4] = ACTIONS(104),
-    [anon_sym_COLON] = ACTIONS(107),
-    [anon_sym_DQUOTE] = ACTIONS(110),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(113),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(113),
-    [aux_sym_char_token1] = ACTIONS(113),
-    [aux_sym_char_token2] = ACTIONS(116),
-    [anon_sym_LBRACK] = ACTIONS(119),
-    [anon_sym_LBRACE] = ACTIONS(122),
-    [anon_sym_SLASH] = ACTIONS(125),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(128),
-    [anon_sym_BQUOTE] = ACTIONS(131),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(134),
+    [sym__expression] = STATE(57),
+    [sym_identifier] = STATE(243),
+    [sym_bool] = STATE(57),
+    [sym_float] = STATE(57),
+    [sym_integer] = STATE(57),
+    [sym_symbol] = STATE(57),
+    [sym_char] = STATE(57),
+    [sym_string] = STATE(46),
+    [sym_array] = STATE(57),
+    [sym_hash] = STATE(57),
+    [sym_index_expression] = STATE(73),
+    [sym_regex] = STATE(57),
+    [sym_tuple] = STATE(57),
+    [sym_namedTupleLiteral] = STATE(57),
+    [sym_commandLiteral] = STATE(57),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym__variable] = STATE(170),
+    [sym_assignment] = STATE(57),
+    [aux_sym_identifier_token1] = ACTIONS(49),
+    [sym_nil] = ACTIONS(87),
+    [anon_sym_true] = ACTIONS(53),
+    [anon_sym_false] = ACTIONS(53),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(63),
+    [anon_sym_DQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_RBRACE] = ACTIONS(89),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
     [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(137),
-    [anon_sym_AT] = ACTIONS(140),
-    [anon_sym_AT_AT] = ACTIONS(143),
-    [anon_sym___LINE__] = ACTIONS(146),
-    [anon_sym___END_LINE__] = ACTIONS(146),
-    [anon_sym___FILE__] = ACTIONS(146),
-    [anon_sym___DIR__] = ACTIONS(146),
-    [aux_sym_constant_token1] = ACTIONS(149),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(85),
+    [anon_sym___END_LINE__] = ACTIONS(85),
+    [anon_sym___FILE__] = ACTIONS(85),
+    [anon_sym___DIR__] = ACTIONS(85),
+    [aux_sym_constant_token1] = ACTIONS(47),
   },
   [4] = {
-    [sym__statement] = STATE(3),
-    [sym__expression] = STATE(122),
-    [sym_bool] = STATE(122),
-    [sym_float] = STATE(122),
-    [sym_integer] = STATE(122),
-    [sym_symbol] = STATE(122),
-    [sym_char] = STATE(122),
-    [sym_string] = STATE(122),
-    [sym_array] = STATE(122),
-    [sym_hash] = STATE(122),
-    [sym_regex] = STATE(122),
-    [sym_tuple] = STATE(122),
-    [sym_namedTupleLiteral] = STATE(122),
-    [sym_commandLiteral] = STATE(122),
-    [sym_local_variable] = STATE(150),
-    [sym_instance_variable] = STATE(150),
-    [sym_class_variable] = STATE(150),
-    [sym_constant] = STATE(150),
-    [sym_assignment] = STATE(122),
-    [aux_sym_program_repeat1] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(152),
+    [sym__statement] = STATE(4),
+    [sym__expression] = STATE(173),
+    [sym_bool] = STATE(173),
+    [sym_float] = STATE(173),
+    [sym_integer] = STATE(173),
+    [sym_symbol] = STATE(173),
+    [sym_char] = STATE(173),
+    [sym_string] = STATE(173),
+    [sym_array] = STATE(173),
+    [sym_hash] = STATE(173),
+    [sym_index_expression] = STATE(90),
+    [sym_regex] = STATE(173),
+    [sym_tuple] = STATE(173),
+    [sym_namedTupleLiteral] = STATE(173),
+    [sym_commandLiteral] = STATE(173),
+    [sym_local_variable] = STATE(176),
+    [sym_instance_variable] = STATE(176),
+    [sym_class_variable] = STATE(176),
+    [sym_constant] = STATE(176),
+    [sym__variable] = STATE(176),
+    [sym_assignment] = STATE(173),
+    [aux_sym_program_repeat1] = STATE(4),
+    [ts_builtin_sym_end] = ACTIONS(91),
+    [sym_nil] = ACTIONS(93),
+    [anon_sym_true] = ACTIONS(96),
+    [anon_sym_false] = ACTIONS(96),
+    [aux_sym_float_token1] = ACTIONS(99),
+    [aux_sym_float_token2] = ACTIONS(102),
+    [aux_sym_float_token3] = ACTIONS(102),
+    [aux_sym_integer_token1] = ACTIONS(105),
+    [aux_sym_integer_token2] = ACTIONS(105),
+    [aux_sym_integer_token3] = ACTIONS(105),
+    [aux_sym_integer_token4] = ACTIONS(108),
+    [anon_sym_COLON] = ACTIONS(111),
+    [anon_sym_DQUOTE] = ACTIONS(114),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(117),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(117),
+    [aux_sym_char_token1] = ACTIONS(117),
+    [aux_sym_char_token2] = ACTIONS(120),
+    [anon_sym_LBRACK] = ACTIONS(123),
+    [anon_sym_LBRACE] = ACTIONS(126),
+    [anon_sym_SLASH] = ACTIONS(129),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(132),
+    [anon_sym_BQUOTE] = ACTIONS(135),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(138),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(141),
+    [anon_sym_AT] = ACTIONS(144),
+    [anon_sym_AT_AT] = ACTIONS(147),
+    [anon_sym___LINE__] = ACTIONS(150),
+    [anon_sym___END_LINE__] = ACTIONS(150),
+    [anon_sym___FILE__] = ACTIONS(150),
+    [anon_sym___DIR__] = ACTIONS(150),
+    [aux_sym_constant_token1] = ACTIONS(153),
+  },
+  [5] = {
+    [sym__expression] = STATE(56),
+    [sym_identifier] = STATE(239),
+    [sym_bool] = STATE(56),
+    [sym_float] = STATE(56),
+    [sym_integer] = STATE(56),
+    [sym_symbol] = STATE(56),
+    [sym_char] = STATE(56),
+    [sym_string] = STATE(69),
+    [sym_array] = STATE(56),
+    [sym_hash] = STATE(56),
+    [sym_index_expression] = STATE(73),
+    [sym_regex] = STATE(56),
+    [sym_tuple] = STATE(56),
+    [sym_namedTupleLiteral] = STATE(56),
+    [sym_commandLiteral] = STATE(56),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym__variable] = STATE(170),
+    [sym_assignment] = STATE(56),
+    [aux_sym_identifier_token1] = ACTIONS(49),
+    [sym_nil] = ACTIONS(156),
+    [anon_sym_true] = ACTIONS(53),
+    [anon_sym_false] = ACTIONS(53),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(63),
+    [anon_sym_DQUOTE] = ACTIONS(65),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_RBRACE] = ACTIONS(158),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(85),
+    [anon_sym___END_LINE__] = ACTIONS(85),
+    [anon_sym___FILE__] = ACTIONS(85),
+    [anon_sym___DIR__] = ACTIONS(85),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [6] = {
+    [sym__statement] = STATE(4),
+    [sym__expression] = STATE(173),
+    [sym_bool] = STATE(173),
+    [sym_float] = STATE(173),
+    [sym_integer] = STATE(173),
+    [sym_symbol] = STATE(173),
+    [sym_char] = STATE(173),
+    [sym_string] = STATE(173),
+    [sym_array] = STATE(173),
+    [sym_hash] = STATE(173),
+    [sym_index_expression] = STATE(90),
+    [sym_regex] = STATE(173),
+    [sym_tuple] = STATE(173),
+    [sym_namedTupleLiteral] = STATE(173),
+    [sym_commandLiteral] = STATE(173),
+    [sym_local_variable] = STATE(176),
+    [sym_instance_variable] = STATE(176),
+    [sym_class_variable] = STATE(176),
+    [sym_constant] = STATE(176),
+    [sym__variable] = STATE(176),
+    [sym_assignment] = STATE(173),
+    [aux_sym_program_repeat1] = STATE(4),
+    [ts_builtin_sym_end] = ACTIONS(160),
     [sym_nil] = ACTIONS(7),
     [anon_sym_true] = ACTIONS(9),
     [anon_sym_false] = ACTIONS(9),
@@ -3114,151 +3468,30 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym___DIR__] = ACTIONS(45),
     [aux_sym_constant_token1] = ACTIONS(47),
   },
-  [5] = {
-    [sym__expression] = STATE(44),
-    [sym_identifier] = STATE(167),
-    [sym_bool] = STATE(44),
-    [sym_float] = STATE(44),
-    [sym_integer] = STATE(44),
-    [sym_symbol] = STATE(44),
-    [sym_char] = STATE(44),
-    [sym_string] = STATE(42),
-    [sym_array] = STATE(44),
-    [sym_hash] = STATE(44),
-    [sym_regex] = STATE(44),
-    [sym_tuple] = STATE(44),
-    [sym_namedTupleLiteral] = STATE(44),
-    [sym_commandLiteral] = STATE(44),
-    [sym_local_variable] = STATE(171),
-    [sym_instance_variable] = STATE(171),
-    [sym_class_variable] = STATE(171),
-    [sym_constant] = STATE(171),
-    [sym_assignment] = STATE(44),
-    [aux_sym_identifier_token1] = ACTIONS(49),
-    [sym_nil] = ACTIONS(154),
-    [anon_sym_true] = ACTIONS(53),
-    [anon_sym_false] = ACTIONS(53),
-    [aux_sym_float_token1] = ACTIONS(55),
-    [aux_sym_float_token2] = ACTIONS(57),
-    [aux_sym_float_token3] = ACTIONS(57),
-    [aux_sym_integer_token1] = ACTIONS(59),
-    [aux_sym_integer_token2] = ACTIONS(59),
-    [aux_sym_integer_token3] = ACTIONS(59),
-    [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(63),
-    [anon_sym_DQUOTE] = ACTIONS(65),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
-    [aux_sym_char_token1] = ACTIONS(67),
-    [aux_sym_char_token2] = ACTIONS(69),
-    [anon_sym_LBRACK] = ACTIONS(71),
-    [anon_sym_LBRACE] = ACTIONS(73),
-    [anon_sym_RBRACE] = ACTIONS(156),
-    [anon_sym_SLASH] = ACTIONS(77),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
-    [anon_sym_BQUOTE] = ACTIONS(81),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [anon_sym___LINE__] = ACTIONS(85),
-    [anon_sym___END_LINE__] = ACTIONS(85),
-    [anon_sym___FILE__] = ACTIONS(85),
-    [anon_sym___DIR__] = ACTIONS(85),
-    [aux_sym_constant_token1] = ACTIONS(47),
-  },
-  [6] = {
-    [sym__expression] = STATE(107),
-    [sym_bool] = STATE(107),
-    [sym_float] = STATE(107),
-    [sym_integer] = STATE(107),
-    [sym_symbol] = STATE(107),
-    [sym_char] = STATE(107),
-    [sym_string] = STATE(107),
-    [sym_array] = STATE(107),
-    [sym_hash] = STATE(107),
-    [sym_regex] = STATE(107),
-    [sym_tuple] = STATE(107),
-    [sym_namedTupleLiteral] = STATE(107),
-    [sym_commandLiteral] = STATE(107),
-    [sym_local_variable] = STATE(170),
-    [sym_instance_variable] = STATE(170),
-    [sym_class_variable] = STATE(170),
-    [sym_constant] = STATE(170),
-    [sym_assignment] = STATE(107),
-    [sym_nil] = ACTIONS(158),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
-    [aux_sym_float_token1] = ACTIONS(55),
-    [aux_sym_float_token2] = ACTIONS(57),
-    [aux_sym_float_token3] = ACTIONS(57),
-    [aux_sym_integer_token1] = ACTIONS(59),
-    [aux_sym_integer_token2] = ACTIONS(59),
-    [aux_sym_integer_token3] = ACTIONS(59),
-    [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(162),
-    [anon_sym_DQUOTE] = ACTIONS(164),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
-    [aux_sym_char_token1] = ACTIONS(67),
-    [aux_sym_char_token2] = ACTIONS(69),
-    [anon_sym_LBRACK] = ACTIONS(71),
-    [anon_sym_LBRACE] = ACTIONS(73),
-    [anon_sym_SLASH] = ACTIONS(77),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
-    [anon_sym_BQUOTE] = ACTIONS(81),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [anon_sym___LINE__] = ACTIONS(45),
-    [anon_sym___END_LINE__] = ACTIONS(45),
-    [anon_sym___FILE__] = ACTIONS(45),
-    [anon_sym___DIR__] = ACTIONS(45),
-    [aux_sym_constant_token1] = ACTIONS(47),
-  },
   [7] = {
-    [sym__expression] = STATE(98),
-    [sym_bool] = STATE(98),
-    [sym_float] = STATE(98),
-    [sym_integer] = STATE(98),
-    [sym_symbol] = STATE(98),
-    [sym_char] = STATE(98),
-    [sym_string] = STATE(98),
-    [sym_array] = STATE(98),
-    [sym_hash] = STATE(98),
-    [sym_regex] = STATE(98),
-    [sym_tuple] = STATE(98),
-    [sym_namedTupleLiteral] = STATE(98),
-    [sym_commandLiteral] = STATE(98),
-    [sym_local_variable] = STATE(170),
-    [sym_instance_variable] = STATE(170),
-    [sym_class_variable] = STATE(170),
-    [sym_constant] = STATE(170),
-    [sym_assignment] = STATE(98),
-    [sym_nil] = ACTIONS(166),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(121),
+    [sym_bool] = STATE(121),
+    [sym_float] = STATE(121),
+    [sym_integer] = STATE(121),
+    [sym_symbol] = STATE(121),
+    [sym_char] = STATE(121),
+    [sym_string] = STATE(121),
+    [sym_array] = STATE(121),
+    [sym_hash] = STATE(121),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(121),
+    [sym_tuple] = STATE(121),
+    [sym_namedTupleLiteral] = STATE(121),
+    [sym_commandLiteral] = STATE(121),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(121),
+    [sym_nil] = ACTIONS(162),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3266,8 +3499,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(162),
-    [anon_sym_DQUOTE] = ACTIONS(164),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -3298,25 +3531,89 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [8] = {
-    [sym__expression] = STATE(142),
-    [sym_bool] = STATE(142),
-    [sym_float] = STATE(142),
-    [sym_integer] = STATE(142),
-    [sym_symbol] = STATE(142),
-    [sym_char] = STATE(142),
-    [sym_string] = STATE(142),
-    [sym_array] = STATE(142),
-    [sym_hash] = STATE(142),
-    [sym_regex] = STATE(142),
-    [sym_tuple] = STATE(142),
-    [sym_namedTupleLiteral] = STATE(142),
-    [sym_commandLiteral] = STATE(142),
-    [sym_local_variable] = STATE(150),
-    [sym_instance_variable] = STATE(150),
-    [sym_class_variable] = STATE(150),
-    [sym_constant] = STATE(150),
-    [sym_assignment] = STATE(142),
-    [sym_nil] = ACTIONS(168),
+    [sym__expression] = STATE(230),
+    [sym_bool] = STATE(230),
+    [sym_float] = STATE(230),
+    [sym_integer] = STATE(230),
+    [sym_symbol] = STATE(230),
+    [sym_char] = STATE(230),
+    [sym_string] = STATE(230),
+    [sym_array] = STATE(230),
+    [sym_hash] = STATE(230),
+    [sym_index_expression] = STATE(185),
+    [sym_regex] = STATE(230),
+    [sym_tuple] = STATE(230),
+    [sym_namedTupleLiteral] = STATE(230),
+    [sym_commandLiteral] = STATE(230),
+    [sym_local_variable] = STATE(177),
+    [sym_instance_variable] = STATE(177),
+    [sym_class_variable] = STATE(177),
+    [sym_constant] = STATE(177),
+    [sym__variable] = STATE(177),
+    [sym_assignment] = STATE(230),
+    [sym_nil] = ACTIONS(170),
+    [anon_sym_true] = ACTIONS(172),
+    [anon_sym_false] = ACTIONS(172),
+    [aux_sym_float_token1] = ACTIONS(174),
+    [aux_sym_float_token2] = ACTIONS(176),
+    [aux_sym_float_token3] = ACTIONS(176),
+    [aux_sym_integer_token1] = ACTIONS(178),
+    [aux_sym_integer_token2] = ACTIONS(178),
+    [aux_sym_integer_token3] = ACTIONS(178),
+    [aux_sym_integer_token4] = ACTIONS(180),
+    [anon_sym_COLON] = ACTIONS(182),
+    [anon_sym_DQUOTE] = ACTIONS(184),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(186),
+    [aux_sym_char_token1] = ACTIONS(186),
+    [aux_sym_char_token2] = ACTIONS(188),
+    [anon_sym_LBRACK] = ACTIONS(190),
+    [anon_sym_LBRACE] = ACTIONS(192),
+    [anon_sym_SLASH] = ACTIONS(194),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(196),
+    [anon_sym_BQUOTE] = ACTIONS(198),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(200),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [9] = {
+    [sym__expression] = STATE(175),
+    [sym_bool] = STATE(175),
+    [sym_float] = STATE(175),
+    [sym_integer] = STATE(175),
+    [sym_symbol] = STATE(175),
+    [sym_char] = STATE(175),
+    [sym_string] = STATE(175),
+    [sym_array] = STATE(175),
+    [sym_hash] = STATE(175),
+    [sym_index_expression] = STATE(90),
+    [sym_regex] = STATE(175),
+    [sym_tuple] = STATE(175),
+    [sym_namedTupleLiteral] = STATE(175),
+    [sym_commandLiteral] = STATE(175),
+    [sym_local_variable] = STATE(176),
+    [sym_instance_variable] = STATE(176),
+    [sym_class_variable] = STATE(176),
+    [sym_constant] = STATE(176),
+    [sym__variable] = STATE(176),
+    [sym_assignment] = STATE(175),
+    [sym_nil] = ACTIONS(202),
     [anon_sym_true] = ACTIONS(9),
     [anon_sym_false] = ACTIONS(9),
     [aux_sym_float_token1] = ACTIONS(11),
@@ -3357,88 +3654,30 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym___DIR__] = ACTIONS(45),
     [aux_sym_constant_token1] = ACTIONS(47),
   },
-  [9] = {
-    [sym__expression] = STATE(48),
-    [sym_bool] = STATE(48),
-    [sym_float] = STATE(48),
-    [sym_integer] = STATE(48),
-    [sym_symbol] = STATE(48),
-    [sym_char] = STATE(48),
-    [sym_string] = STATE(48),
-    [sym_array] = STATE(48),
-    [sym_hash] = STATE(48),
-    [sym_regex] = STATE(48),
-    [sym_tuple] = STATE(48),
-    [sym_namedTupleLiteral] = STATE(48),
-    [sym_commandLiteral] = STATE(48),
-    [sym_local_variable] = STATE(174),
-    [sym_instance_variable] = STATE(174),
-    [sym_class_variable] = STATE(174),
-    [sym_constant] = STATE(174),
-    [sym_assignment] = STATE(48),
-    [sym_nil] = ACTIONS(170),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
-    [aux_sym_float_token1] = ACTIONS(55),
-    [aux_sym_float_token2] = ACTIONS(57),
-    [aux_sym_float_token3] = ACTIONS(57),
-    [aux_sym_integer_token1] = ACTIONS(59),
-    [aux_sym_integer_token2] = ACTIONS(59),
-    [aux_sym_integer_token3] = ACTIONS(59),
-    [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(172),
-    [anon_sym_DQUOTE] = ACTIONS(174),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
-    [aux_sym_char_token1] = ACTIONS(67),
-    [aux_sym_char_token2] = ACTIONS(69),
-    [anon_sym_LBRACK] = ACTIONS(71),
-    [anon_sym_LBRACE] = ACTIONS(73),
-    [anon_sym_SLASH] = ACTIONS(77),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
-    [anon_sym_BQUOTE] = ACTIONS(81),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
-    [sym_comment] = ACTIONS(3),
-    [aux_sym_local_variable_token1] = ACTIONS(39),
-    [anon_sym_AT] = ACTIONS(41),
-    [anon_sym_AT_AT] = ACTIONS(43),
-    [anon_sym___LINE__] = ACTIONS(45),
-    [anon_sym___END_LINE__] = ACTIONS(45),
-    [anon_sym___FILE__] = ACTIONS(45),
-    [anon_sym___DIR__] = ACTIONS(45),
-    [aux_sym_constant_token1] = ACTIONS(47),
-  },
   [10] = {
-    [sym__expression] = STATE(113),
-    [sym_bool] = STATE(113),
-    [sym_float] = STATE(113),
-    [sym_integer] = STATE(113),
-    [sym_symbol] = STATE(113),
-    [sym_char] = STATE(113),
-    [sym_string] = STATE(113),
-    [sym_array] = STATE(113),
-    [sym_hash] = STATE(113),
-    [sym_regex] = STATE(113),
-    [sym_tuple] = STATE(113),
-    [sym_namedTupleLiteral] = STATE(113),
-    [sym_commandLiteral] = STATE(113),
-    [sym_local_variable] = STATE(170),
-    [sym_instance_variable] = STATE(170),
-    [sym_class_variable] = STATE(170),
-    [sym_constant] = STATE(170),
-    [sym_assignment] = STATE(113),
-    [sym_nil] = ACTIONS(176),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(136),
+    [sym_bool] = STATE(136),
+    [sym_float] = STATE(136),
+    [sym_integer] = STATE(136),
+    [sym_symbol] = STATE(136),
+    [sym_char] = STATE(136),
+    [sym_string] = STATE(136),
+    [sym_array] = STATE(136),
+    [sym_hash] = STATE(136),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(136),
+    [sym_tuple] = STATE(136),
+    [sym_namedTupleLiteral] = STATE(136),
+    [sym_commandLiteral] = STATE(136),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(136),
+    [sym_nil] = ACTIONS(204),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3446,8 +3685,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(162),
-    [anon_sym_DQUOTE] = ACTIONS(164),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -3478,27 +3717,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [11] = {
-    [sym__expression] = STATE(48),
-    [sym_bool] = STATE(48),
-    [sym_float] = STATE(48),
-    [sym_integer] = STATE(48),
-    [sym_symbol] = STATE(48),
-    [sym_char] = STATE(48),
-    [sym_string] = STATE(48),
-    [sym_array] = STATE(48),
-    [sym_hash] = STATE(48),
-    [sym_regex] = STATE(48),
-    [sym_tuple] = STATE(48),
-    [sym_namedTupleLiteral] = STATE(48),
-    [sym_commandLiteral] = STATE(48),
-    [sym_local_variable] = STATE(177),
-    [sym_instance_variable] = STATE(177),
-    [sym_class_variable] = STATE(177),
-    [sym_constant] = STATE(177),
-    [sym_assignment] = STATE(48),
-    [sym_nil] = ACTIONS(170),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(78),
+    [sym_bool] = STATE(78),
+    [sym_float] = STATE(78),
+    [sym_integer] = STATE(78),
+    [sym_symbol] = STATE(78),
+    [sym_char] = STATE(78),
+    [sym_string] = STATE(78),
+    [sym_array] = STATE(78),
+    [sym_hash] = STATE(78),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(78),
+    [sym_tuple] = STATE(78),
+    [sym_namedTupleLiteral] = STATE(78),
+    [sym_commandLiteral] = STATE(78),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(78),
+    [sym_nil] = ACTIONS(206),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3506,8 +3747,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(178),
-    [anon_sym_DQUOTE] = ACTIONS(180),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -3538,27 +3779,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [12] = {
-    [sym__expression] = STATE(48),
-    [sym_bool] = STATE(48),
-    [sym_float] = STATE(48),
-    [sym_integer] = STATE(48),
-    [sym_symbol] = STATE(48),
-    [sym_char] = STATE(48),
-    [sym_string] = STATE(48),
-    [sym_array] = STATE(48),
-    [sym_hash] = STATE(48),
-    [sym_regex] = STATE(48),
-    [sym_tuple] = STATE(48),
-    [sym_namedTupleLiteral] = STATE(48),
-    [sym_commandLiteral] = STATE(48),
-    [sym_local_variable] = STATE(171),
-    [sym_instance_variable] = STATE(171),
-    [sym_class_variable] = STATE(171),
-    [sym_constant] = STATE(171),
-    [sym_assignment] = STATE(48),
-    [sym_nil] = ACTIONS(170),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(78),
+    [sym_bool] = STATE(78),
+    [sym_float] = STATE(78),
+    [sym_integer] = STATE(78),
+    [sym_symbol] = STATE(78),
+    [sym_char] = STATE(78),
+    [sym_string] = STATE(78),
+    [sym_array] = STATE(78),
+    [sym_hash] = STATE(78),
+    [sym_index_expression] = STATE(115),
+    [sym_regex] = STATE(78),
+    [sym_tuple] = STATE(78),
+    [sym_namedTupleLiteral] = STATE(78),
+    [sym_commandLiteral] = STATE(78),
+    [sym_local_variable] = STATE(161),
+    [sym_instance_variable] = STATE(161),
+    [sym_class_variable] = STATE(161),
+    [sym_constant] = STATE(161),
+    [sym__variable] = STATE(161),
+    [sym_assignment] = STATE(78),
+    [sym_nil] = ACTIONS(206),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3566,8 +3809,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(63),
-    [anon_sym_DQUOTE] = ACTIONS(182),
+    [anon_sym_COLON] = ACTIONS(208),
+    [anon_sym_DQUOTE] = ACTIONS(210),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -3598,27 +3841,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [13] = {
-    [sym__expression] = STATE(101),
-    [sym_bool] = STATE(101),
-    [sym_float] = STATE(101),
-    [sym_integer] = STATE(101),
-    [sym_symbol] = STATE(101),
-    [sym_char] = STATE(101),
-    [sym_string] = STATE(101),
-    [sym_array] = STATE(101),
-    [sym_hash] = STATE(101),
-    [sym_regex] = STATE(101),
-    [sym_tuple] = STATE(101),
-    [sym_namedTupleLiteral] = STATE(101),
-    [sym_commandLiteral] = STATE(101),
-    [sym_local_variable] = STATE(174),
-    [sym_instance_variable] = STATE(174),
-    [sym_class_variable] = STATE(174),
-    [sym_constant] = STATE(174),
-    [sym_assignment] = STATE(101),
-    [sym_nil] = ACTIONS(184),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(122),
+    [sym_bool] = STATE(122),
+    [sym_float] = STATE(122),
+    [sym_integer] = STATE(122),
+    [sym_symbol] = STATE(122),
+    [sym_char] = STATE(122),
+    [sym_string] = STATE(122),
+    [sym_array] = STATE(122),
+    [sym_hash] = STATE(122),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(122),
+    [sym_tuple] = STATE(122),
+    [sym_namedTupleLiteral] = STATE(122),
+    [sym_commandLiteral] = STATE(122),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(122),
+    [sym_nil] = ACTIONS(212),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3626,8 +3871,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(172),
-    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -3658,55 +3903,57 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [14] = {
-    [sym__expression] = STATE(103),
-    [sym_bool] = STATE(103),
-    [sym_float] = STATE(103),
-    [sym_integer] = STATE(103),
-    [sym_symbol] = STATE(103),
-    [sym_char] = STATE(103),
-    [sym_string] = STATE(103),
-    [sym_array] = STATE(103),
-    [sym_hash] = STATE(103),
-    [sym_regex] = STATE(103),
-    [sym_tuple] = STATE(103),
-    [sym_namedTupleLiteral] = STATE(103),
-    [sym_commandLiteral] = STATE(103),
-    [sym_local_variable] = STATE(174),
-    [sym_instance_variable] = STATE(174),
-    [sym_class_variable] = STATE(174),
-    [sym_constant] = STATE(174),
-    [sym_assignment] = STATE(103),
-    [sym_nil] = ACTIONS(186),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
-    [aux_sym_float_token1] = ACTIONS(55),
-    [aux_sym_float_token2] = ACTIONS(57),
-    [aux_sym_float_token3] = ACTIONS(57),
-    [aux_sym_integer_token1] = ACTIONS(59),
-    [aux_sym_integer_token2] = ACTIONS(59),
-    [aux_sym_integer_token3] = ACTIONS(59),
-    [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(172),
-    [anon_sym_DQUOTE] = ACTIONS(174),
-    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
-    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
-    [aux_sym_char_token1] = ACTIONS(67),
-    [aux_sym_char_token2] = ACTIONS(69),
-    [anon_sym_LBRACK] = ACTIONS(71),
-    [anon_sym_LBRACE] = ACTIONS(73),
-    [anon_sym_SLASH] = ACTIONS(77),
-    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
-    [anon_sym_BQUOTE] = ACTIONS(81),
-    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym__expression] = STATE(195),
+    [sym_bool] = STATE(195),
+    [sym_float] = STATE(195),
+    [sym_integer] = STATE(195),
+    [sym_symbol] = STATE(195),
+    [sym_char] = STATE(195),
+    [sym_string] = STATE(195),
+    [sym_array] = STATE(195),
+    [sym_hash] = STATE(195),
+    [sym_index_expression] = STATE(185),
+    [sym_regex] = STATE(195),
+    [sym_tuple] = STATE(195),
+    [sym_namedTupleLiteral] = STATE(195),
+    [sym_commandLiteral] = STATE(195),
+    [sym_local_variable] = STATE(177),
+    [sym_instance_variable] = STATE(177),
+    [sym_class_variable] = STATE(177),
+    [sym_constant] = STATE(177),
+    [sym__variable] = STATE(177),
+    [sym_assignment] = STATE(195),
+    [sym_nil] = ACTIONS(214),
+    [anon_sym_true] = ACTIONS(172),
+    [anon_sym_false] = ACTIONS(172),
+    [aux_sym_float_token1] = ACTIONS(174),
+    [aux_sym_float_token2] = ACTIONS(176),
+    [aux_sym_float_token3] = ACTIONS(176),
+    [aux_sym_integer_token1] = ACTIONS(178),
+    [aux_sym_integer_token2] = ACTIONS(178),
+    [aux_sym_integer_token3] = ACTIONS(178),
+    [aux_sym_integer_token4] = ACTIONS(180),
+    [anon_sym_COLON] = ACTIONS(182),
+    [anon_sym_DQUOTE] = ACTIONS(184),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(186),
+    [aux_sym_char_token1] = ACTIONS(186),
+    [aux_sym_char_token2] = ACTIONS(188),
+    [anon_sym_LBRACK] = ACTIONS(190),
+    [anon_sym_LBRACE] = ACTIONS(192),
+    [anon_sym_SLASH] = ACTIONS(194),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(196),
+    [anon_sym_BQUOTE] = ACTIONS(198),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(200),
     [sym_comment] = ACTIONS(3),
     [aux_sym_local_variable_token1] = ACTIONS(39),
     [anon_sym_AT] = ACTIONS(41),
@@ -3718,27 +3965,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [15] = {
-    [sym__expression] = STATE(98),
-    [sym_bool] = STATE(98),
-    [sym_float] = STATE(98),
-    [sym_integer] = STATE(98),
-    [sym_symbol] = STATE(98),
-    [sym_char] = STATE(98),
-    [sym_string] = STATE(98),
-    [sym_array] = STATE(98),
-    [sym_hash] = STATE(98),
-    [sym_regex] = STATE(98),
-    [sym_tuple] = STATE(98),
-    [sym_namedTupleLiteral] = STATE(98),
-    [sym_commandLiteral] = STATE(98),
-    [sym_local_variable] = STATE(174),
-    [sym_instance_variable] = STATE(174),
-    [sym_class_variable] = STATE(174),
-    [sym_constant] = STATE(174),
-    [sym_assignment] = STATE(98),
-    [sym_nil] = ACTIONS(166),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(93),
+    [sym_bool] = STATE(93),
+    [sym_float] = STATE(93),
+    [sym_integer] = STATE(93),
+    [sym_symbol] = STATE(93),
+    [sym_char] = STATE(93),
+    [sym_string] = STATE(93),
+    [sym_array] = STATE(93),
+    [sym_hash] = STATE(93),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(93),
+    [sym_tuple] = STATE(93),
+    [sym_namedTupleLiteral] = STATE(93),
+    [sym_commandLiteral] = STATE(93),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(93),
+    [sym_nil] = ACTIONS(216),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3746,8 +3995,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(172),
-    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -3778,27 +4027,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [16] = {
-    [sym__expression] = STATE(154),
-    [sym_bool] = STATE(154),
-    [sym_float] = STATE(154),
-    [sym_integer] = STATE(154),
-    [sym_symbol] = STATE(154),
-    [sym_char] = STATE(154),
-    [sym_string] = STATE(154),
-    [sym_array] = STATE(154),
-    [sym_hash] = STATE(154),
-    [sym_regex] = STATE(154),
-    [sym_tuple] = STATE(154),
-    [sym_namedTupleLiteral] = STATE(154),
-    [sym_commandLiteral] = STATE(154),
-    [sym_local_variable] = STATE(177),
-    [sym_instance_variable] = STATE(177),
-    [sym_class_variable] = STATE(177),
-    [sym_constant] = STATE(177),
-    [sym_assignment] = STATE(154),
-    [sym_nil] = ACTIONS(188),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(128),
+    [sym_bool] = STATE(128),
+    [sym_float] = STATE(128),
+    [sym_integer] = STATE(128),
+    [sym_symbol] = STATE(128),
+    [sym_char] = STATE(128),
+    [sym_string] = STATE(128),
+    [sym_array] = STATE(128),
+    [sym_hash] = STATE(128),
+    [sym_index_expression] = STATE(115),
+    [sym_regex] = STATE(128),
+    [sym_tuple] = STATE(128),
+    [sym_namedTupleLiteral] = STATE(128),
+    [sym_commandLiteral] = STATE(128),
+    [sym_local_variable] = STATE(161),
+    [sym_instance_variable] = STATE(161),
+    [sym_class_variable] = STATE(161),
+    [sym_constant] = STATE(161),
+    [sym__variable] = STATE(161),
+    [sym_assignment] = STATE(128),
+    [sym_nil] = ACTIONS(218),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3806,8 +4057,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(178),
-    [anon_sym_DQUOTE] = ACTIONS(180),
+    [anon_sym_COLON] = ACTIONS(208),
+    [anon_sym_DQUOTE] = ACTIONS(210),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -3838,27 +4089,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [17] = {
-    [sym__expression] = STATE(136),
-    [sym_bool] = STATE(136),
-    [sym_float] = STATE(136),
-    [sym_integer] = STATE(136),
-    [sym_symbol] = STATE(136),
-    [sym_char] = STATE(136),
-    [sym_string] = STATE(136),
-    [sym_array] = STATE(136),
-    [sym_hash] = STATE(136),
-    [sym_regex] = STATE(136),
-    [sym_tuple] = STATE(136),
-    [sym_namedTupleLiteral] = STATE(136),
-    [sym_commandLiteral] = STATE(136),
-    [sym_local_variable] = STATE(174),
-    [sym_instance_variable] = STATE(174),
-    [sym_class_variable] = STATE(174),
-    [sym_constant] = STATE(174),
-    [sym_assignment] = STATE(136),
-    [sym_nil] = ACTIONS(190),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(93),
+    [sym_bool] = STATE(93),
+    [sym_float] = STATE(93),
+    [sym_integer] = STATE(93),
+    [sym_symbol] = STATE(93),
+    [sym_char] = STATE(93),
+    [sym_string] = STATE(93),
+    [sym_array] = STATE(93),
+    [sym_hash] = STATE(93),
+    [sym_index_expression] = STATE(115),
+    [sym_regex] = STATE(93),
+    [sym_tuple] = STATE(93),
+    [sym_namedTupleLiteral] = STATE(93),
+    [sym_commandLiteral] = STATE(93),
+    [sym_local_variable] = STATE(161),
+    [sym_instance_variable] = STATE(161),
+    [sym_class_variable] = STATE(161),
+    [sym_constant] = STATE(161),
+    [sym__variable] = STATE(161),
+    [sym_assignment] = STATE(93),
+    [sym_nil] = ACTIONS(216),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3866,8 +4119,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(172),
-    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_COLON] = ACTIONS(208),
+    [anon_sym_DQUOTE] = ACTIONS(210),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -3898,27 +4151,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [18] = {
-    [sym__expression] = STATE(74),
-    [sym_bool] = STATE(74),
-    [sym_float] = STATE(74),
-    [sym_integer] = STATE(74),
-    [sym_symbol] = STATE(74),
-    [sym_char] = STATE(74),
-    [sym_string] = STATE(74),
-    [sym_array] = STATE(74),
-    [sym_hash] = STATE(74),
-    [sym_regex] = STATE(74),
-    [sym_tuple] = STATE(74),
-    [sym_namedTupleLiteral] = STATE(74),
-    [sym_commandLiteral] = STATE(74),
-    [sym_local_variable] = STATE(174),
-    [sym_instance_variable] = STATE(174),
-    [sym_class_variable] = STATE(174),
-    [sym_constant] = STATE(174),
-    [sym_assignment] = STATE(74),
-    [sym_nil] = ACTIONS(192),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(78),
+    [sym_bool] = STATE(78),
+    [sym_float] = STATE(78),
+    [sym_integer] = STATE(78),
+    [sym_symbol] = STATE(78),
+    [sym_char] = STATE(78),
+    [sym_string] = STATE(78),
+    [sym_array] = STATE(78),
+    [sym_hash] = STATE(78),
+    [sym_index_expression] = STATE(73),
+    [sym_regex] = STATE(78),
+    [sym_tuple] = STATE(78),
+    [sym_namedTupleLiteral] = STATE(78),
+    [sym_commandLiteral] = STATE(78),
+    [sym_local_variable] = STATE(170),
+    [sym_instance_variable] = STATE(170),
+    [sym_class_variable] = STATE(170),
+    [sym_constant] = STATE(170),
+    [sym__variable] = STATE(170),
+    [sym_assignment] = STATE(78),
+    [sym_nil] = ACTIONS(206),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3926,8 +4181,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(172),
-    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_COLON] = ACTIONS(63),
+    [anon_sym_DQUOTE] = ACTIONS(220),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -3958,27 +4213,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [19] = {
-    [sym__expression] = STATE(76),
-    [sym_bool] = STATE(76),
-    [sym_float] = STATE(76),
-    [sym_integer] = STATE(76),
-    [sym_symbol] = STATE(76),
-    [sym_char] = STATE(76),
-    [sym_string] = STATE(76),
-    [sym_array] = STATE(76),
-    [sym_hash] = STATE(76),
-    [sym_regex] = STATE(76),
-    [sym_tuple] = STATE(76),
-    [sym_namedTupleLiteral] = STATE(76),
-    [sym_commandLiteral] = STATE(76),
-    [sym_local_variable] = STATE(174),
-    [sym_instance_variable] = STATE(174),
-    [sym_class_variable] = STATE(174),
-    [sym_constant] = STATE(174),
-    [sym_assignment] = STATE(76),
-    [sym_nil] = ACTIONS(194),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(135),
+    [sym_bool] = STATE(135),
+    [sym_float] = STATE(135),
+    [sym_integer] = STATE(135),
+    [sym_symbol] = STATE(135),
+    [sym_char] = STATE(135),
+    [sym_string] = STATE(135),
+    [sym_array] = STATE(135),
+    [sym_hash] = STATE(135),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(135),
+    [sym_tuple] = STATE(135),
+    [sym_namedTupleLiteral] = STATE(135),
+    [sym_commandLiteral] = STATE(135),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(135),
+    [sym_nil] = ACTIONS(222),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -3986,8 +4243,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(172),
-    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -4018,27 +4275,153 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_constant_token1] = ACTIONS(47),
   },
   [20] = {
-    [sym__expression] = STATE(140),
-    [sym_bool] = STATE(140),
-    [sym_float] = STATE(140),
-    [sym_integer] = STATE(140),
-    [sym_symbol] = STATE(140),
-    [sym_char] = STATE(140),
-    [sym_string] = STATE(140),
-    [sym_array] = STATE(140),
-    [sym_hash] = STATE(140),
-    [sym_regex] = STATE(140),
-    [sym_tuple] = STATE(140),
-    [sym_namedTupleLiteral] = STATE(140),
-    [sym_commandLiteral] = STATE(140),
-    [sym_local_variable] = STATE(174),
-    [sym_instance_variable] = STATE(174),
-    [sym_class_variable] = STATE(174),
-    [sym_constant] = STATE(174),
-    [sym_assignment] = STATE(140),
-    [sym_nil] = ACTIONS(196),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+    [sym__expression] = STATE(211),
+    [sym_bool] = STATE(211),
+    [sym_float] = STATE(211),
+    [sym_integer] = STATE(211),
+    [sym_symbol] = STATE(211),
+    [sym_char] = STATE(211),
+    [sym_string] = STATE(211),
+    [sym_array] = STATE(211),
+    [sym_hash] = STATE(211),
+    [sym_index_expression] = STATE(185),
+    [sym_regex] = STATE(211),
+    [sym_tuple] = STATE(211),
+    [sym_namedTupleLiteral] = STATE(211),
+    [sym_commandLiteral] = STATE(211),
+    [sym_local_variable] = STATE(177),
+    [sym_instance_variable] = STATE(177),
+    [sym_class_variable] = STATE(177),
+    [sym_constant] = STATE(177),
+    [sym__variable] = STATE(177),
+    [sym_assignment] = STATE(211),
+    [sym_nil] = ACTIONS(224),
+    [anon_sym_true] = ACTIONS(172),
+    [anon_sym_false] = ACTIONS(172),
+    [aux_sym_float_token1] = ACTIONS(174),
+    [aux_sym_float_token2] = ACTIONS(176),
+    [aux_sym_float_token3] = ACTIONS(176),
+    [aux_sym_integer_token1] = ACTIONS(178),
+    [aux_sym_integer_token2] = ACTIONS(178),
+    [aux_sym_integer_token3] = ACTIONS(178),
+    [aux_sym_integer_token4] = ACTIONS(180),
+    [anon_sym_COLON] = ACTIONS(182),
+    [anon_sym_DQUOTE] = ACTIONS(184),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(186),
+    [aux_sym_char_token1] = ACTIONS(186),
+    [aux_sym_char_token2] = ACTIONS(188),
+    [anon_sym_LBRACK] = ACTIONS(190),
+    [anon_sym_LBRACE] = ACTIONS(192),
+    [anon_sym_SLASH] = ACTIONS(194),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(196),
+    [anon_sym_BQUOTE] = ACTIONS(198),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(200),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [21] = {
+    [sym__expression] = STATE(215),
+    [sym_bool] = STATE(215),
+    [sym_float] = STATE(215),
+    [sym_integer] = STATE(215),
+    [sym_symbol] = STATE(215),
+    [sym_char] = STATE(215),
+    [sym_string] = STATE(215),
+    [sym_array] = STATE(215),
+    [sym_hash] = STATE(215),
+    [sym_index_expression] = STATE(185),
+    [sym_regex] = STATE(215),
+    [sym_tuple] = STATE(215),
+    [sym_namedTupleLiteral] = STATE(215),
+    [sym_commandLiteral] = STATE(215),
+    [sym_local_variable] = STATE(177),
+    [sym_instance_variable] = STATE(177),
+    [sym_class_variable] = STATE(177),
+    [sym_constant] = STATE(177),
+    [sym__variable] = STATE(177),
+    [sym_assignment] = STATE(215),
+    [sym_nil] = ACTIONS(226),
+    [anon_sym_true] = ACTIONS(172),
+    [anon_sym_false] = ACTIONS(172),
+    [aux_sym_float_token1] = ACTIONS(174),
+    [aux_sym_float_token2] = ACTIONS(176),
+    [aux_sym_float_token3] = ACTIONS(176),
+    [aux_sym_integer_token1] = ACTIONS(178),
+    [aux_sym_integer_token2] = ACTIONS(178),
+    [aux_sym_integer_token3] = ACTIONS(178),
+    [aux_sym_integer_token4] = ACTIONS(180),
+    [anon_sym_COLON] = ACTIONS(182),
+    [anon_sym_DQUOTE] = ACTIONS(184),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(186),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(186),
+    [aux_sym_char_token1] = ACTIONS(186),
+    [aux_sym_char_token2] = ACTIONS(188),
+    [anon_sym_LBRACK] = ACTIONS(190),
+    [anon_sym_LBRACE] = ACTIONS(192),
+    [anon_sym_SLASH] = ACTIONS(194),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(196),
+    [anon_sym_BQUOTE] = ACTIONS(198),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(200),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [22] = {
+    [sym__expression] = STATE(97),
+    [sym_bool] = STATE(97),
+    [sym_float] = STATE(97),
+    [sym_integer] = STATE(97),
+    [sym_symbol] = STATE(97),
+    [sym_char] = STATE(97),
+    [sym_string] = STATE(97),
+    [sym_array] = STATE(97),
+    [sym_hash] = STATE(97),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(97),
+    [sym_tuple] = STATE(97),
+    [sym_namedTupleLiteral] = STATE(97),
+    [sym_commandLiteral] = STATE(97),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(97),
+    [sym_nil] = ACTIONS(228),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -4046,8 +4429,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(172),
-    [anon_sym_DQUOTE] = ACTIONS(174),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -4077,28 +4460,30 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym___DIR__] = ACTIONS(45),
     [aux_sym_constant_token1] = ACTIONS(47),
   },
-  [21] = {
-    [sym__expression] = STATE(48),
-    [sym_bool] = STATE(48),
-    [sym_float] = STATE(48),
-    [sym_integer] = STATE(48),
-    [sym_symbol] = STATE(48),
-    [sym_char] = STATE(48),
-    [sym_string] = STATE(48),
-    [sym_array] = STATE(48),
-    [sym_hash] = STATE(48),
-    [sym_regex] = STATE(48),
-    [sym_tuple] = STATE(48),
-    [sym_namedTupleLiteral] = STATE(48),
-    [sym_commandLiteral] = STATE(48),
-    [sym_local_variable] = STATE(170),
-    [sym_instance_variable] = STATE(170),
-    [sym_class_variable] = STATE(170),
-    [sym_constant] = STATE(170),
-    [sym_assignment] = STATE(48),
-    [sym_nil] = ACTIONS(170),
-    [anon_sym_true] = ACTIONS(160),
-    [anon_sym_false] = ACTIONS(160),
+  [23] = {
+    [sym__expression] = STATE(78),
+    [sym_bool] = STATE(78),
+    [sym_float] = STATE(78),
+    [sym_integer] = STATE(78),
+    [sym_symbol] = STATE(78),
+    [sym_char] = STATE(78),
+    [sym_string] = STATE(78),
+    [sym_array] = STATE(78),
+    [sym_hash] = STATE(78),
+    [sym_index_expression] = STATE(158),
+    [sym_regex] = STATE(78),
+    [sym_tuple] = STATE(78),
+    [sym_namedTupleLiteral] = STATE(78),
+    [sym_commandLiteral] = STATE(78),
+    [sym_local_variable] = STATE(164),
+    [sym_instance_variable] = STATE(164),
+    [sym_class_variable] = STATE(164),
+    [sym_constant] = STATE(164),
+    [sym__variable] = STATE(164),
+    [sym_assignment] = STATE(78),
+    [sym_nil] = ACTIONS(206),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
     [aux_sym_float_token1] = ACTIONS(55),
     [aux_sym_float_token2] = ACTIONS(57),
     [aux_sym_float_token3] = ACTIONS(57),
@@ -4106,8 +4491,380 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_integer_token2] = ACTIONS(59),
     [aux_sym_integer_token3] = ACTIONS(59),
     [aux_sym_integer_token4] = ACTIONS(61),
-    [anon_sym_COLON] = ACTIONS(162),
-    [anon_sym_DQUOTE] = ACTIONS(164),
+    [anon_sym_COLON] = ACTIONS(230),
+    [anon_sym_DQUOTE] = ACTIONS(232),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [24] = {
+    [sym__expression] = STATE(187),
+    [sym_bool] = STATE(187),
+    [sym_float] = STATE(187),
+    [sym_integer] = STATE(187),
+    [sym_symbol] = STATE(187),
+    [sym_char] = STATE(187),
+    [sym_string] = STATE(187),
+    [sym_array] = STATE(187),
+    [sym_hash] = STATE(187),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(187),
+    [sym_tuple] = STATE(187),
+    [sym_namedTupleLiteral] = STATE(187),
+    [sym_commandLiteral] = STATE(187),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(187),
+    [sym_nil] = ACTIONS(234),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [25] = {
+    [sym__expression] = STATE(148),
+    [sym_bool] = STATE(148),
+    [sym_float] = STATE(148),
+    [sym_integer] = STATE(148),
+    [sym_symbol] = STATE(148),
+    [sym_char] = STATE(148),
+    [sym_string] = STATE(148),
+    [sym_array] = STATE(148),
+    [sym_hash] = STATE(148),
+    [sym_index_expression] = STATE(115),
+    [sym_regex] = STATE(148),
+    [sym_tuple] = STATE(148),
+    [sym_namedTupleLiteral] = STATE(148),
+    [sym_commandLiteral] = STATE(148),
+    [sym_local_variable] = STATE(161),
+    [sym_instance_variable] = STATE(161),
+    [sym_class_variable] = STATE(161),
+    [sym_constant] = STATE(161),
+    [sym__variable] = STATE(161),
+    [sym_assignment] = STATE(148),
+    [sym_nil] = ACTIONS(236),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(208),
+    [anon_sym_DQUOTE] = ACTIONS(210),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [26] = {
+    [sym__expression] = STATE(186),
+    [sym_bool] = STATE(186),
+    [sym_float] = STATE(186),
+    [sym_integer] = STATE(186),
+    [sym_symbol] = STATE(186),
+    [sym_char] = STATE(186),
+    [sym_string] = STATE(186),
+    [sym_array] = STATE(186),
+    [sym_hash] = STATE(186),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(186),
+    [sym_tuple] = STATE(186),
+    [sym_namedTupleLiteral] = STATE(186),
+    [sym_commandLiteral] = STATE(186),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(186),
+    [sym_nil] = ACTIONS(238),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [27] = {
+    [sym__expression] = STATE(203),
+    [sym_bool] = STATE(203),
+    [sym_float] = STATE(203),
+    [sym_integer] = STATE(203),
+    [sym_symbol] = STATE(203),
+    [sym_char] = STATE(203),
+    [sym_string] = STATE(203),
+    [sym_array] = STATE(203),
+    [sym_hash] = STATE(203),
+    [sym_index_expression] = STATE(158),
+    [sym_regex] = STATE(203),
+    [sym_tuple] = STATE(203),
+    [sym_namedTupleLiteral] = STATE(203),
+    [sym_commandLiteral] = STATE(203),
+    [sym_local_variable] = STATE(164),
+    [sym_instance_variable] = STATE(164),
+    [sym_class_variable] = STATE(164),
+    [sym_constant] = STATE(164),
+    [sym__variable] = STATE(164),
+    [sym_assignment] = STATE(203),
+    [sym_nil] = ACTIONS(240),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(230),
+    [anon_sym_DQUOTE] = ACTIONS(232),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [28] = {
+    [sym__expression] = STATE(99),
+    [sym_bool] = STATE(99),
+    [sym_float] = STATE(99),
+    [sym_integer] = STATE(99),
+    [sym_symbol] = STATE(99),
+    [sym_char] = STATE(99),
+    [sym_string] = STATE(99),
+    [sym_array] = STATE(99),
+    [sym_hash] = STATE(99),
+    [sym_index_expression] = STATE(84),
+    [sym_regex] = STATE(99),
+    [sym_tuple] = STATE(99),
+    [sym_namedTupleLiteral] = STATE(99),
+    [sym_commandLiteral] = STATE(99),
+    [sym_local_variable] = STATE(166),
+    [sym_instance_variable] = STATE(166),
+    [sym_class_variable] = STATE(166),
+    [sym_constant] = STATE(166),
+    [sym__variable] = STATE(166),
+    [sym_assignment] = STATE(99),
+    [sym_nil] = ACTIONS(242),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(166),
+    [anon_sym_DQUOTE] = ACTIONS(168),
+    [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHa_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHb_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHe_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHf_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHn_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHr_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHt_SQUOTE] = ACTIONS(67),
+    [anon_sym_SQUOTE_BSLASHv_SQUOTE] = ACTIONS(67),
+    [aux_sym_char_token1] = ACTIONS(67),
+    [aux_sym_char_token2] = ACTIONS(69),
+    [anon_sym_LBRACK] = ACTIONS(71),
+    [anon_sym_LBRACE] = ACTIONS(73),
+    [anon_sym_SLASH] = ACTIONS(77),
+    [anon_sym_Tuple_DOTnew] = ACTIONS(79),
+    [anon_sym_BQUOTE] = ACTIONS(81),
+    [anon_sym_PERCENTx_LPAREN] = ACTIONS(83),
+    [sym_comment] = ACTIONS(3),
+    [aux_sym_local_variable_token1] = ACTIONS(39),
+    [anon_sym_AT] = ACTIONS(41),
+    [anon_sym_AT_AT] = ACTIONS(43),
+    [anon_sym___LINE__] = ACTIONS(45),
+    [anon_sym___END_LINE__] = ACTIONS(45),
+    [anon_sym___FILE__] = ACTIONS(45),
+    [anon_sym___DIR__] = ACTIONS(45),
+    [aux_sym_constant_token1] = ACTIONS(47),
+  },
+  [29] = {
+    [sym__expression] = STATE(126),
+    [sym_bool] = STATE(126),
+    [sym_float] = STATE(126),
+    [sym_integer] = STATE(126),
+    [sym_symbol] = STATE(126),
+    [sym_char] = STATE(126),
+    [sym_string] = STATE(126),
+    [sym_array] = STATE(126),
+    [sym_hash] = STATE(126),
+    [sym_index_expression] = STATE(115),
+    [sym_regex] = STATE(126),
+    [sym_tuple] = STATE(126),
+    [sym_namedTupleLiteral] = STATE(126),
+    [sym_commandLiteral] = STATE(126),
+    [sym_local_variable] = STATE(161),
+    [sym_instance_variable] = STATE(161),
+    [sym_class_variable] = STATE(161),
+    [sym_constant] = STATE(161),
+    [sym__variable] = STATE(161),
+    [sym_assignment] = STATE(126),
+    [sym_nil] = ACTIONS(244),
+    [anon_sym_true] = ACTIONS(164),
+    [anon_sym_false] = ACTIONS(164),
+    [aux_sym_float_token1] = ACTIONS(55),
+    [aux_sym_float_token2] = ACTIONS(57),
+    [aux_sym_float_token3] = ACTIONS(57),
+    [aux_sym_integer_token1] = ACTIONS(59),
+    [aux_sym_integer_token2] = ACTIONS(59),
+    [aux_sym_integer_token3] = ACTIONS(59),
+    [aux_sym_integer_token4] = ACTIONS(61),
+    [anon_sym_COLON] = ACTIONS(208),
+    [anon_sym_DQUOTE] = ACTIONS(210),
     [anon_sym_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_SQUOTE_SQUOTE] = ACTIONS(67),
     [anon_sym_SQUOTE_BSLASH_BSLASH_SQUOTE] = ACTIONS(67),
@@ -4143,7 +4900,7 @@ static const uint16_t ts_small_parse_table[] = {
   [0] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(200), 7,
+    ACTIONS(248), 7,
       aux_sym_float_token2,
       aux_sym_float_token3,
       aux_sym_integer_token4,
@@ -4151,7 +4908,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_local_variable_token1,
       anon_sym_AT,
       aux_sym_constant_token1,
-    ACTIONS(198), 33,
+    ACTIONS(246), 33,
       ts_builtin_sym_end,
       sym_nil,
       anon_sym_true,
@@ -4188,11 +4945,11 @@ static const uint16_t ts_small_parse_table[] = {
   [48] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(204), 1,
+    ACTIONS(252), 1,
       anon_sym_DQUOTE,
-    STATE(59), 1,
+    STATE(67), 1,
       sym__operator,
-    ACTIONS(206), 7,
+    ACTIONS(254), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -4200,7 +4957,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(202), 20,
+    ACTIONS(250), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -4224,11 +4981,11 @@ static const uint16_t ts_small_parse_table[] = {
   [89] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(210), 1,
+    ACTIONS(258), 1,
       anon_sym_DQUOTE,
-    STATE(135), 1,
+    STATE(196), 1,
       sym__operator,
-    ACTIONS(212), 7,
+    ACTIONS(260), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -4236,7 +4993,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(208), 20,
+    ACTIONS(256), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -4260,11 +5017,11 @@ static const uint16_t ts_small_parse_table[] = {
   [130] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(214), 1,
+    ACTIONS(262), 1,
       anon_sym_DQUOTE,
-    STATE(59), 1,
+    STATE(67), 1,
       sym__operator,
-    ACTIONS(206), 7,
+    ACTIONS(254), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -4272,7 +5029,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(202), 20,
+    ACTIONS(250), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -4296,11 +5053,11 @@ static const uint16_t ts_small_parse_table[] = {
   [171] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(216), 1,
+    ACTIONS(264), 1,
       anon_sym_DQUOTE,
-    STATE(59), 1,
+    STATE(67), 1,
       sym__operator,
-    ACTIONS(206), 7,
+    ACTIONS(254), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -4308,7 +5065,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(202), 20,
+    ACTIONS(250), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -4332,11 +5089,11 @@ static const uint16_t ts_small_parse_table[] = {
   [212] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(218), 1,
+    ACTIONS(268), 1,
       anon_sym_DQUOTE,
-    STATE(59), 1,
+    STATE(178), 1,
       sym__operator,
-    ACTIONS(206), 7,
+    ACTIONS(270), 7,
       anon_sym_STAR,
       anon_sym_EQ_EQ,
       anon_sym_LT,
@@ -4344,7 +5101,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_LBRACK_RBRACK,
       anon_sym_BANG,
-    ACTIONS(202), 20,
+    ACTIONS(266), 20,
       aux_sym_identifier_token1,
       anon_sym_SLASH,
       anon_sym_PLUS,
@@ -4365,1337 +5122,1842 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_BANG_TILDE,
       anon_sym_EQ_TILDE,
-  [253] = 3,
-    ACTIONS(224), 1,
+  [253] = 5,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(222), 2,
+    ACTIONS(272), 1,
       anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(220), 4,
-      anon_sym_COLON,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [267] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(226), 4,
-      anon_sym_COLON,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [281] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(226), 3,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
+    STATE(67), 1,
+      sym__operator,
+    ACTIONS(254), 7,
+      anon_sym_STAR,
+      anon_sym_EQ_EQ,
+      anon_sym_LT,
+      anon_sym_LT_EQ,
+      anon_sym_GT,
+      anon_sym_LBRACK_RBRACK,
+      anon_sym_BANG,
+    ACTIONS(250), 20,
+      aux_sym_identifier_token1,
+      anon_sym_SLASH,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_PERCENT,
+      anon_sym_AMP,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_STAR_STAR,
+      anon_sym_GT_GT,
+      anon_sym_LT_LT,
+      anon_sym_BANG_EQ,
+      anon_sym_GT_EQ,
+      anon_sym_LT_EQ_GT,
+      anon_sym_EQ_EQ_EQ,
+      anon_sym_LBRACK_RBRACK_QMARK,
+      anon_sym_LBRACK_RBRACK_EQ,
+      anon_sym_TILDE,
+      anon_sym_BANG_TILDE,
+      anon_sym_EQ_TILDE,
   [294] = 3,
-    ACTIONS(224), 1,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(222), 2,
+    ACTIONS(276), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(220), 3,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [307] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(228), 3,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [320] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(230), 3,
-      anon_sym_COMMA,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [333] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(232), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [343] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(234), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [353] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(236), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [363] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(238), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [373] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(240), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [383] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(242), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [393] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(244), 1,
+    ACTIONS(274), 4,
       anon_sym_COLON,
-    ACTIONS(246), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [405] = 2,
+  [308] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(280), 4,
+      anon_sym_COLON,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [322] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(282), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [335] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(280), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [348] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(248), 4,
+    ACTIONS(286), 1,
+      anon_sym_EQ,
+    ACTIONS(284), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [415] = 3,
-    ACTIONS(3), 1,
+  [361] = 3,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(250), 1,
-      anon_sym_COLON,
-    ACTIONS(246), 3,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(288), 3,
       anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [427] = 3,
-    ACTIONS(224), 1,
+  [374] = 3,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(222), 2,
+    ACTIONS(276), 2,
       anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    ACTIONS(230), 2,
+    ACTIONS(274), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [387] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(290), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [397] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(280), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [409] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(292), 1,
+      anon_sym_COLON,
+    ACTIONS(294), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [421] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(280), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [433] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(288), 2,
       anon_sym_SEMI,
       aux_sym__statement_token1,
-  [439] = 5,
-    ACTIONS(3), 1,
+  [445] = 3,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(252), 1,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(282), 2,
       anon_sym_COMMA,
-    ACTIONS(254), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(256), 1,
       anon_sym_RBRACE,
-    STATE(97), 1,
-      aux_sym_array_repeat1,
-  [455] = 3,
-    ACTIONS(224), 1,
+  [457] = 3,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(220), 2,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(280), 2,
       anon_sym_SEMI,
       aux_sym__statement_token1,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [467] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(228), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [479] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(226), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [491] = 2,
+  [469] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(258), 4,
+    ACTIONS(296), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [479] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(298), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [489] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(300), 1,
+      anon_sym_COLON,
+    ACTIONS(294), 3,
+      anon_sym_COMMA,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
   [501] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(260), 4,
+    ACTIONS(302), 4,
       anon_sym_COMMA,
       anon_sym_RBRACK,
       anon_sym_EQ_GT,
       anon_sym_RBRACE,
-  [511] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(262), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [521] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(226), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-  [533] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(264), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [543] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(266), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [553] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(230), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [565] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(220), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [577] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(230), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [589] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(220), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [601] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(226), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [613] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(268), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [623] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(228), 2,
-      anon_sym_SEMI,
-      aux_sym__statement_token1,
-  [635] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(270), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [645] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(272), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [655] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(274), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(276), 1,
-      anon_sym_DQUOTE,
-    STATE(152), 2,
-      sym_identifier,
-      sym_string,
-  [669] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(278), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [679] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(280), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [689] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-    ACTIONS(228), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [701] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(252), 1,
-      anon_sym_COMMA,
-    ACTIONS(282), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(284), 1,
-      anon_sym_RBRACE,
-    STATE(104), 1,
-      aux_sym_array_repeat1,
-  [717] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(286), 4,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_EQ_GT,
-      anon_sym_RBRACE,
-  [727] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(288), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [740] = 3,
-    ACTIONS(220), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [751] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(292), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(294), 1,
-      aux_sym_symbol_token1,
-    STATE(114), 1,
-      aux_sym_symbol_repeat1,
-  [764] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(296), 1,
-      anon_sym_COMMA,
-    ACTIONS(299), 1,
-      anon_sym_RBRACK,
-    STATE(72), 1,
-      aux_sym_array_repeat1,
-  [777] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(299), 1,
-      anon_sym_RBRACE,
-    ACTIONS(301), 1,
-      anon_sym_COMMA,
-    STATE(73), 1,
-      aux_sym_array_repeat1,
-  [790] = 4,
+  [511] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(304), 1,
       anon_sym_COMMA,
     ACTIONS(306), 1,
-      anon_sym_RBRACE,
-    STATE(79), 1,
-      aux_sym_hash_repeat1,
-  [803] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
+      anon_sym_EQ_GT,
     ACTIONS(308), 1,
-      anon_sym_DQUOTE,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [816] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(310), 1,
-      anon_sym_COMMA,
-    ACTIONS(312), 1,
       anon_sym_RBRACE,
-    STATE(81), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [829] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(314), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(316), 1,
-      aux_sym_symbol_token1,
-    STATE(75), 1,
-      aux_sym_symbol_repeat1,
-  [842] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(318), 1,
-      anon_sym_DQUOTE,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [855] = 4,
+    STATE(86), 1,
+      aux_sym_array_repeat1,
+  [527] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(304), 1,
       anon_sym_COMMA,
-    ACTIONS(320), 1,
+    ACTIONS(310), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(312), 1,
       anon_sym_RBRACE,
-    STATE(85), 1,
-      aux_sym_hash_repeat1,
-  [868] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(322), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(324), 1,
-      aux_sym_symbol_token1,
-    STATE(78), 1,
-      aux_sym_symbol_repeat1,
-  [881] = 4,
+    STATE(137), 1,
+      aux_sym_array_repeat1,
+  [543] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(310), 1,
+    ACTIONS(304), 1,
       anon_sym_COMMA,
-    ACTIONS(326), 1,
+    ACTIONS(314), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(316), 1,
       anon_sym_RBRACE,
-    STATE(88), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [894] = 4,
-    ACTIONS(224), 1,
+    STATE(124), 1,
+      aux_sym_array_repeat1,
+  [559] = 2,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(328), 1,
-      anon_sym_DQUOTE,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [907] = 4,
-    ACTIONS(224), 1,
+    ACTIONS(318), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [569] = 2,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(330), 1,
+    ACTIONS(320), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [579] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
       anon_sym_DQUOTE,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [920] = 4,
-    ACTIONS(224), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(288), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [591] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(322), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [601] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(324), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [611] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(274), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [623] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(326), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [633] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(328), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [643] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(274), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [655] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(330), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [665] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(274), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [677] = 3,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(332), 1,
+      anon_sym_COLON,
+    ACTIONS(294), 3,
+      anon_sym_COMMA,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [689] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
       anon_sym_DQUOTE,
-    ACTIONS(334), 1,
       aux_sym_symbol_token1,
-    STATE(82), 1,
-      aux_sym_symbol_repeat1,
-  [933] = 4,
+    ACTIONS(288), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [701] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(282), 2,
+      anon_sym_SEMI,
+      aux_sym__statement_token1,
+  [713] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(334), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [723] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(336), 1,
+      anon_sym_EQ,
+    ACTIONS(294), 3,
       anon_sym_COMMA,
-    ACTIONS(339), 1,
+      anon_sym_EQ_GT,
       anon_sym_RBRACE,
-    STATE(85), 1,
-      aux_sym_hash_repeat1,
-  [946] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(341), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(343), 1,
-      aux_sym_symbol_token1,
-    STATE(83), 1,
-      aux_sym_symbol_repeat1,
-  [959] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(345), 1,
-      anon_sym_DQUOTE,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [972] = 4,
+  [735] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(347), 1,
+    ACTIONS(338), 4,
       anon_sym_COMMA,
-    ACTIONS(350), 1,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
       anon_sym_RBRACE,
-    STATE(88), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [985] = 4,
-    ACTIONS(224), 1,
+  [745] = 2,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(352), 1,
+    ACTIONS(340), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [755] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(342), 1,
+      aux_sym_identifier_token1,
+    ACTIONS(344), 1,
       anon_sym_DQUOTE,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [998] = 4,
-    ACTIONS(224), 1,
+    STATE(190), 2,
+      sym_identifier,
+      sym_string,
+  [769] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(346), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [779] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(348), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [789] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+    ACTIONS(282), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [801] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(350), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [811] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(352), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_EQ_GT,
+      anon_sym_RBRACE,
+  [821] = 4,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(354), 1,
-      anon_sym_DQUOTE,
+      anon_sym_COMMA,
     ACTIONS(356), 1,
+      anon_sym_RBRACK,
+    STATE(95), 1,
+      aux_sym_array_repeat1,
+  [834] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(280), 1,
+      anon_sym_COLON,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
       aux_sym_symbol_token1,
-    STATE(87), 1,
-      aux_sym_symbol_repeat1,
-  [1011] = 4,
-    ACTIONS(224), 1,
+  [845] = 3,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(358), 1,
-      anon_sym_DQUOTE,
+      anon_sym_EQ,
+    ACTIONS(294), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [856] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
     ACTIONS(360), 1,
-      aux_sym_symbol_token1,
-    STATE(89), 1,
-      aux_sym_symbol_repeat1,
-  [1024] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
+      anon_sym_DQUOTE,
     ACTIONS(362), 1,
-      anon_sym_DQUOTE,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [1037] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(364), 1,
-      anon_sym_DQUOTE,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [1050] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(366), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(368), 1,
       aux_sym_symbol_token1,
     STATE(92), 1,
       aux_sym_symbol_repeat1,
-  [1063] = 4,
-    ACTIONS(224), 1,
+  [869] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(304), 1,
+      anon_sym_COMMA,
+    ACTIONS(364), 1,
+      anon_sym_RBRACE,
+    STATE(89), 1,
+      aux_sym_array_repeat1,
+  [882] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(366), 1,
+      aux_sym_identifier_token1,
+    ACTIONS(368), 2,
+      anon_sym_LBRACK2,
+      anon_sym_EQ,
+  [893] = 3,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(370), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(372), 1,
-      aux_sym_symbol_token1,
-    STATE(93), 1,
-      aux_sym_symbol_repeat1,
-  [1076] = 4,
+      aux_sym_identifier_token1,
+    ACTIONS(372), 2,
+      anon_sym_LBRACK2,
+      anon_sym_EQ,
+  [904] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(310), 1,
-      anon_sym_COMMA,
     ACTIONS(374), 1,
-      anon_sym_RBRACE,
-    STATE(88), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1089] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(252), 1,
       anon_sym_COMMA,
-    ACTIONS(376), 1,
+    ACTIONS(377), 1,
       anon_sym_RBRACE,
-    STATE(73), 1,
+    STATE(89), 1,
       aux_sym_array_repeat1,
-  [1102] = 2,
-    ACTIONS(3), 1,
+  [917] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(299), 3,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-      anon_sym_RBRACE,
-  [1111] = 4,
-    ACTIONS(3), 1,
+    ACTIONS(294), 1,
+      aux_sym__statement_token1,
+    ACTIONS(379), 1,
+      anon_sym_SEMI,
+    ACTIONS(381), 1,
+      anon_sym_EQ,
+  [930] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(304), 1,
-      anon_sym_COMMA,
-    ACTIONS(378), 1,
-      anon_sym_RBRACE,
-    STATE(85), 1,
-      aux_sym_hash_repeat1,
-  [1124] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(380), 1,
-      anon_sym_COMMA,
-    ACTIONS(382), 1,
-      anon_sym_RBRACK,
-    STATE(72), 1,
-      aux_sym_array_repeat1,
-  [1137] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(310), 1,
-      anon_sym_COMMA,
-    ACTIONS(384), 1,
-      anon_sym_RBRACE,
-    STATE(96), 1,
-      aux_sym_namedTupleLiteral_repeat1,
-  [1150] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-    ACTIONS(386), 2,
+    ACTIONS(383), 1,
       anon_sym_DQUOTE,
+    ACTIONS(385), 1,
       aux_sym_symbol_token1,
-  [1161] = 4,
-    ACTIONS(3), 1,
+    STATE(131), 1,
+      aux_sym_symbol_repeat1,
+  [943] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(304), 1,
-      anon_sym_COMMA,
+    ACTIONS(387), 1,
+      anon_sym_DQUOTE,
     ACTIONS(389), 1,
-      anon_sym_RBRACE,
-    STATE(99), 1,
-      aux_sym_hash_repeat1,
-  [1174] = 4,
+      aux_sym_symbol_token1,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [956] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(252), 1,
+    ACTIONS(377), 3,
       anon_sym_COMMA,
+      anon_sym_RBRACK,
+      anon_sym_RBRACE,
+  [965] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
     ACTIONS(391), 1,
-      anon_sym_RBRACE,
-    STATE(73), 1,
-      aux_sym_array_repeat1,
-  [1187] = 4,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [978] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(380), 1,
-      anon_sym_COMMA,
+    ACTIONS(377), 1,
+      anon_sym_RBRACK,
     ACTIONS(393), 1,
-      anon_sym_RBRACK,
-    STATE(72), 1,
+      anon_sym_COMMA,
+    STATE(95), 1,
       aux_sym_array_repeat1,
-  [1200] = 4,
-    ACTIONS(224), 1,
+  [991] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(395), 1,
+    ACTIONS(396), 1,
       anon_sym_DQUOTE,
-    STATE(102), 1,
+    ACTIONS(398), 1,
+      aux_sym_symbol_token1,
+    STATE(94), 1,
       aux_sym_symbol_repeat1,
-  [1213] = 4,
+  [1004] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(380), 1,
+    ACTIONS(400), 1,
       anon_sym_COMMA,
-    ACTIONS(397), 1,
-      anon_sym_RBRACK,
-    STATE(105), 1,
-      aux_sym_array_repeat1,
-  [1226] = 4,
-    ACTIONS(224), 1,
+    ACTIONS(402), 1,
+      anon_sym_RBRACE,
+    STATE(103), 1,
+      aux_sym_hash_repeat1,
+  [1017] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(290), 1,
+    ACTIONS(389), 1,
       aux_sym_symbol_token1,
-    ACTIONS(399), 1,
+    ACTIONS(404), 1,
       anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1030] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(406), 1,
+      anon_sym_COMMA,
+    ACTIONS(408), 1,
+      anon_sym_RBRACE,
+    STATE(105), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1043] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(284), 1,
+      aux_sym__statement_token1,
+    ACTIONS(286), 2,
+      anon_sym_SEMI,
+      anon_sym_EQ,
+  [1054] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(410), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(412), 1,
+      aux_sym_symbol_token1,
+    STATE(98), 1,
+      aux_sym_symbol_repeat1,
+  [1067] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(414), 1,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1080] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(400), 1,
+      anon_sym_COMMA,
+    ACTIONS(416), 1,
+      anon_sym_RBRACE,
+    STATE(109), 1,
+      aux_sym_hash_repeat1,
+  [1093] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(418), 1,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1106] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(406), 1,
+      anon_sym_COMMA,
+    ACTIONS(420), 1,
+      anon_sym_RBRACE,
+    STATE(112), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1119] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(422), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(424), 1,
+      aux_sym_symbol_token1,
     STATE(102), 1,
       aux_sym_symbol_repeat1,
-  [1239] = 4,
-    ACTIONS(224), 1,
+  [1132] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(401), 1,
+    ACTIONS(426), 1,
       anon_sym_DQUOTE,
-    ACTIONS(403), 1,
+    ACTIONS(428), 1,
       aux_sym_symbol_token1,
-    STATE(106), 1,
+    STATE(104), 1,
       aux_sym_symbol_repeat1,
-  [1252] = 4,
-    ACTIONS(224), 1,
+  [1145] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(405), 1,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(430), 1,
       anon_sym_DQUOTE,
-    ACTIONS(407), 1,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1158] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(432), 1,
+      anon_sym_COMMA,
+    ACTIONS(435), 1,
+      anon_sym_RBRACE,
+    STATE(109), 1,
+      aux_sym_hash_repeat1,
+  [1171] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(437), 1,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1184] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(439), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(441), 1,
       aux_sym_symbol_token1,
     STATE(108), 1,
       aux_sym_symbol_repeat1,
-  [1265] = 3,
-    ACTIONS(220), 1,
-      anon_sym_COLON,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1276] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(226), 1,
-      anon_sym_COLON,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1287] = 4,
+  [1197] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(380), 1,
-      anon_sym_COMMA,
-    ACTIONS(409), 1,
-      anon_sym_RBRACK,
-    STATE(100), 1,
-      aux_sym_array_repeat1,
-  [1300] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(290), 1,
-      aux_sym_symbol_token1,
-    ACTIONS(411), 1,
-      anon_sym_DQUOTE,
-    STATE(102), 1,
-      aux_sym_symbol_repeat1,
-  [1313] = 4,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(413), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(415), 1,
-      aux_sym_symbol_token1,
-    STATE(69), 1,
-      aux_sym_symbol_repeat1,
-  [1326] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(228), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1337] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(226), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1348] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(230), 1,
-      anon_sym_EQ_GT,
-    ACTIONS(222), 2,
-      anon_sym_DQUOTE,
-      aux_sym_symbol_token1,
-  [1359] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(264), 1,
-      aux_sym__statement_token1,
-    ACTIONS(417), 1,
-      anon_sym_SEMI,
-  [1369] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(260), 1,
-      aux_sym__statement_token1,
-    ACTIONS(419), 1,
-      anon_sym_SEMI,
-  [1379] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(278), 1,
-      aux_sym__statement_token1,
-    ACTIONS(421), 1,
-      anon_sym_SEMI,
-  [1389] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(423), 1,
-      anon_sym_SEMI,
-    ACTIONS(425), 1,
-      aux_sym__statement_token1,
-  [1399] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(242), 1,
-      aux_sym__statement_token1,
-    ACTIONS(427), 1,
-      anon_sym_SEMI,
-  [1409] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(280), 1,
-      aux_sym__statement_token1,
-    ACTIONS(429), 1,
-      anon_sym_SEMI,
-  [1419] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(286), 1,
-      aux_sym__statement_token1,
-    ACTIONS(431), 1,
-      anon_sym_SEMI,
-  [1429] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(270), 1,
-      aux_sym__statement_token1,
-    ACTIONS(433), 1,
-      anon_sym_SEMI,
-  [1439] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(240), 1,
-      aux_sym__statement_token1,
-    ACTIONS(435), 1,
-      anon_sym_SEMI,
-  [1449] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(437), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(439), 1,
-      anon_sym_EQ,
-  [1459] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(238), 1,
-      aux_sym__statement_token1,
-    ACTIONS(441), 1,
-      anon_sym_SEMI,
-  [1469] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(236), 1,
-      aux_sym__statement_token1,
     ACTIONS(443), 1,
-      anon_sym_SEMI,
-  [1479] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(445), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(447), 1,
-      anon_sym_EQ,
-  [1489] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(234), 1,
-      aux_sym__statement_token1,
-    ACTIONS(449), 1,
-      anon_sym_SEMI,
-  [1499] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(232), 1,
-      aux_sym__statement_token1,
-    ACTIONS(451), 1,
-      anon_sym_SEMI,
-  [1509] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(248), 1,
-      aux_sym__statement_token1,
-    ACTIONS(453), 1,
-      anon_sym_SEMI,
-  [1519] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(268), 1,
-      aux_sym__statement_token1,
-    ACTIONS(455), 1,
-      anon_sym_SEMI,
-  [1529] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(457), 2,
       anon_sym_COMMA,
+    ACTIONS(446), 1,
       anon_sym_RBRACE,
-  [1537] = 3,
+    STATE(112), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1210] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(448), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(450), 1,
+      aux_sym_symbol_token1,
+    STATE(110), 1,
+      aux_sym_symbol_repeat1,
+  [1223] = 4,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(452), 1,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1236] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(459), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(461), 1,
+    ACTIONS(454), 1,
       anon_sym_EQ,
-  [1547] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(463), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(465), 1,
-      anon_sym_EQ,
-  [1557] = 3,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(272), 1,
-      aux_sym__statement_token1,
-    ACTIONS(467), 1,
-      anon_sym_SEMI,
-  [1567] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(469), 2,
+    ACTIONS(294), 2,
       anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [1575] = 3,
-    ACTIONS(224), 1,
+      anon_sym_RBRACK,
+  [1247] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(266), 1,
-      aux_sym__statement_token1,
-    ACTIONS(471), 1,
-      anon_sym_SEMI,
-  [1585] = 3,
-    ACTIONS(224), 1,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
+    ACTIONS(456), 1,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1260] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(258), 1,
-      aux_sym__statement_token1,
-    ACTIONS(473), 1,
-      anon_sym_SEMI,
-  [1595] = 3,
-    ACTIONS(224), 1,
+    ACTIONS(458), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(460), 1,
+      aux_sym_symbol_token1,
+    STATE(114), 1,
+      aux_sym_symbol_repeat1,
+  [1273] = 4,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(262), 1,
-      aux_sym__statement_token1,
-    ACTIONS(475), 1,
-      anon_sym_SEMI,
-  [1605] = 2,
+    ACTIONS(462), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(464), 1,
+      aux_sym_symbol_token1,
+    STATE(116), 1,
+      aux_sym_symbol_repeat1,
+  [1286] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(477), 1,
-      anon_sym_RPAREN,
-  [1612] = 2,
-    ACTIONS(224), 1,
+    ACTIONS(406), 1,
+      anon_sym_COMMA,
+    ACTIONS(466), 1,
+      anon_sym_RBRACE,
+    STATE(112), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1299] = 4,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(479), 1,
-      aux_sym_commandLiteral_token2,
-  [1619] = 2,
-    ACTIONS(224), 1,
+    ACTIONS(400), 1,
+      anon_sym_COMMA,
+    ACTIONS(468), 1,
+      anon_sym_RBRACE,
+    STATE(109), 1,
+      aux_sym_hash_repeat1,
+  [1312] = 4,
+    ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(406), 1,
+      anon_sym_COMMA,
+    ACTIONS(470), 1,
+      anon_sym_RBRACE,
+    STATE(119), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1325] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(400), 1,
+      anon_sym_COMMA,
+    ACTIONS(472), 1,
+      anon_sym_RBRACE,
+    STATE(120), 1,
+      aux_sym_hash_repeat1,
+  [1338] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(354), 1,
+      anon_sym_COMMA,
+    ACTIONS(474), 1,
+      anon_sym_RBRACK,
+    STATE(95), 1,
+      aux_sym_array_repeat1,
+  [1351] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(304), 1,
+      anon_sym_COMMA,
+    ACTIONS(476), 1,
+      anon_sym_RBRACE,
+    STATE(89), 1,
+      aux_sym_array_repeat1,
+  [1364] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+    ACTIONS(478), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1375] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(354), 1,
+      anon_sym_COMMA,
     ACTIONS(481), 1,
-      aux_sym_hash_token1,
-  [1626] = 2,
-    ACTIONS(224), 1,
+      anon_sym_RBRACK,
+    STATE(123), 1,
+      aux_sym_array_repeat1,
+  [1388] = 4,
+    ACTIONS(278), 1,
       sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
     ACTIONS(483), 1,
-      aux_sym_hash_token1,
-  [1633] = 2,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1401] = 4,
     ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(354), 1,
+      anon_sym_COMMA,
     ACTIONS(485), 1,
-      anon_sym_EQ,
-  [1640] = 2,
-    ACTIONS(3), 1,
+      anon_sym_RBRACK,
+    STATE(82), 1,
+      aux_sym_array_repeat1,
+  [1414] = 4,
+    ACTIONS(278), 1,
       sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
     ACTIONS(487), 1,
-      anon_sym_EQ,
-  [1647] = 2,
-    ACTIONS(3), 1,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1427] = 4,
+    ACTIONS(278), 1,
       sym_comment,
     ACTIONS(489), 1,
-      anon_sym_EQ,
-  [1654] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
+      anon_sym_DQUOTE,
     ACTIONS(491), 1,
-      anon_sym_EQ,
-  [1661] = 2,
-    ACTIONS(3), 1,
+      aux_sym_symbol_token1,
+    STATE(127), 1,
+      aux_sym_symbol_repeat1,
+  [1440] = 4,
+    ACTIONS(278), 1,
       sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
     ACTIONS(493), 1,
-      anon_sym_COLON,
-  [1668] = 2,
-    ACTIONS(3), 1,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1453] = 4,
+    ACTIONS(278), 1,
       sym_comment,
     ACTIONS(495), 1,
-      anon_sym_RPAREN,
-  [1675] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
+      anon_sym_DQUOTE,
     ACTIONS(497), 1,
-      anon_sym_EQ_GT,
-  [1682] = 2,
+      aux_sym_symbol_token1,
+    STATE(129), 1,
+      aux_sym_symbol_repeat1,
+  [1466] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(495), 1,
-      anon_sym_BQUOTE,
-  [1689] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
+    ACTIONS(406), 1,
+      anon_sym_COMMA,
     ACTIONS(499), 1,
-      anon_sym_SLASH,
-  [1696] = 2,
+      anon_sym_RBRACE,
+    STATE(112), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1479] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(477), 1,
-      anon_sym_BQUOTE,
-  [1703] = 2,
-    ACTIONS(224), 1,
-      sym_comment,
+    ACTIONS(400), 1,
+      anon_sym_COMMA,
     ACTIONS(501), 1,
-      aux_sym_hash_token1,
-  [1710] = 2,
+      anon_sym_RBRACE,
+    STATE(109), 1,
+      aux_sym_hash_repeat1,
+  [1492] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(447), 1,
-      anon_sym_EQ,
-  [1717] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
+    ACTIONS(406), 1,
+      anon_sym_COMMA,
     ACTIONS(503), 1,
-      aux_sym_local_variable_token1,
-  [1724] = 2,
-    ACTIONS(224), 1,
+      anon_sym_RBRACE,
+    STATE(133), 1,
+      aux_sym_namedTupleLiteral_repeat1,
+  [1505] = 4,
+    ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(400), 1,
+      anon_sym_COMMA,
     ACTIONS(505), 1,
-      aux_sym_regex_token1,
-  [1731] = 2,
-    ACTIONS(224), 1,
+      anon_sym_RBRACE,
+    STATE(134), 1,
+      aux_sym_hash_repeat1,
+  [1518] = 4,
+    ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(304), 1,
+      anon_sym_COMMA,
     ACTIONS(507), 1,
-      aux_sym_commandLiteral_token1,
-  [1738] = 2,
+      anon_sym_RBRACE,
+    STATE(89), 1,
+      aux_sym_array_repeat1,
+  [1531] = 4,
     ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(354), 1,
+      anon_sym_COMMA,
     ACTIONS(509), 1,
-      anon_sym_EQ,
-  [1745] = 2,
-    ACTIONS(3), 1,
+      anon_sym_RBRACK,
+    STATE(95), 1,
+      aux_sym_array_repeat1,
+  [1544] = 4,
+    ACTIONS(278), 1,
       sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
     ACTIONS(511), 1,
-      aux_sym_local_variable_token1,
-  [1752] = 2,
-    ACTIONS(3), 1,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1557] = 3,
+    ACTIONS(278), 1,
       sym_comment,
     ACTIONS(513), 1,
-      anon_sym_SLASH,
-  [1759] = 2,
-    ACTIONS(224), 1,
+      anon_sym_RBRACK2,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1568] = 3,
+    ACTIONS(278), 1,
       sym_comment,
     ACTIONS(515), 1,
-      aux_sym_commandLiteral_token2,
-  [1766] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(250), 1,
-      anon_sym_COLON,
-  [1773] = 2,
-    ACTIONS(3), 1,
+      anon_sym_RBRACK2,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1579] = 3,
+    ACTIONS(278), 1,
       sym_comment,
     ACTIONS(517), 1,
-      anon_sym_EQ_GT,
-  [1780] = 2,
-    ACTIONS(224), 1,
+      anon_sym_RBRACK2,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1590] = 3,
+    ACTIONS(278), 1,
       sym_comment,
     ACTIONS(519), 1,
-      aux_sym_commandLiteral_token1,
-  [1787] = 2,
-    ACTIONS(3), 1,
+      anon_sym_RBRACK2,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1601] = 4,
+    ACTIONS(278), 1,
       sym_comment,
+    ACTIONS(389), 1,
+      aux_sym_symbol_token1,
     ACTIONS(521), 1,
-      anon_sym_EQ,
-  [1794] = 2,
+      anon_sym_DQUOTE,
+    STATE(125), 1,
+      aux_sym_symbol_repeat1,
+  [1614] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(523), 1,
+      aux_sym_identifier_token1,
+    ACTIONS(525), 2,
+      anon_sym_LBRACK2,
       anon_sym_EQ,
-  [1801] = 2,
-    ACTIONS(224), 1,
-      sym_comment,
-    ACTIONS(525), 1,
-      aux_sym_regex_token1,
-  [1808] = 2,
+  [1625] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(527), 1,
-      anon_sym_of,
-  [1815] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(529), 1,
+      aux_sym_identifier_token1,
+    ACTIONS(529), 2,
+      anon_sym_LBRACK2,
       anon_sym_EQ,
-  [1822] = 2,
-    ACTIONS(3), 1,
+  [1636] = 4,
+    ACTIONS(278), 1,
       sym_comment,
     ACTIONS(531), 1,
-      anon_sym_EQ_GT,
-  [1829] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
+      anon_sym_DQUOTE,
     ACTIONS(533), 1,
-      ts_builtin_sym_end,
-  [1836] = 2,
+      aux_sym_symbol_token1,
+    STATE(144), 1,
+      aux_sym_symbol_repeat1,
+  [1649] = 4,
     ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(354), 1,
+      anon_sym_COMMA,
     ACTIONS(535), 1,
-      anon_sym_EQ,
-  [1843] = 2,
-    ACTIONS(3), 1,
+      anon_sym_RBRACK,
+    STATE(138), 1,
+      aux_sym_array_repeat1,
+  [1662] = 3,
+    ACTIONS(278), 1,
       sym_comment,
-    ACTIONS(244), 1,
-      anon_sym_COLON,
-  [1850] = 2,
-    ACTIONS(3), 1,
+    ACTIONS(288), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1673] = 4,
+    ACTIONS(278), 1,
       sym_comment,
     ACTIONS(537), 1,
-      anon_sym_COLON,
-  [1857] = 2,
-    ACTIONS(224), 1,
-      sym_comment,
+      anon_sym_DQUOTE,
     ACTIONS(539), 1,
-      aux_sym_hash_token1,
-  [1864] = 2,
+      aux_sym_symbol_token1,
+    STATE(139), 1,
+      aux_sym_symbol_repeat1,
+  [1686] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(282), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1697] = 3,
+    ACTIONS(274), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1708] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(280), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1719] = 3,
+    ACTIONS(274), 1,
+      anon_sym_COLON,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(276), 2,
+      anon_sym_DQUOTE,
+      aux_sym_symbol_token1,
+  [1730] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(290), 1,
+      aux_sym__statement_token1,
+    ACTIONS(541), 1,
+      anon_sym_SEMI,
+  [1740] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(541), 1,
+    ACTIONS(543), 2,
+      anon_sym_LBRACK2,
+      anon_sym_EQ,
+  [1748] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(545), 2,
+      anon_sym_LBRACK2,
+      anon_sym_EQ,
+  [1756] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(294), 1,
+      anon_sym_EQ_GT,
+    ACTIONS(547), 1,
+      anon_sym_EQ,
+  [1766] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(338), 1,
+      aux_sym__statement_token1,
+    ACTIONS(549), 1,
+      anon_sym_SEMI,
+  [1776] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(322), 1,
+      aux_sym__statement_token1,
+    ACTIONS(551), 1,
+      anon_sym_SEMI,
+  [1786] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(454), 1,
+      anon_sym_EQ,
+    ACTIONS(553), 1,
+      anon_sym_LBRACK2,
+  [1796] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(350), 1,
+      aux_sym__statement_token1,
+    ACTIONS(555), 1,
+      anon_sym_SEMI,
+  [1806] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(340), 1,
+      aux_sym__statement_token1,
+    ACTIONS(557), 1,
+      anon_sym_SEMI,
+  [1816] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(553), 1,
+      anon_sym_LBRACK2,
+    ACTIONS(559), 1,
+      anon_sym_EQ,
+  [1826] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(302), 1,
+      aux_sym__statement_token1,
+    ACTIONS(561), 1,
+      anon_sym_SEMI,
+  [1836] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(358), 1,
+      anon_sym_EQ,
+    ACTIONS(553), 1,
+      anon_sym_LBRACK2,
+  [1846] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(328), 1,
+      aux_sym__statement_token1,
+    ACTIONS(563), 1,
+      anon_sym_SEMI,
+  [1856] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(346), 1,
+      aux_sym__statement_token1,
+    ACTIONS(565), 1,
+      anon_sym_SEMI,
+  [1866] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(372), 2,
+      anon_sym_LBRACK2,
+      anon_sym_EQ,
+  [1874] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(553), 1,
+      anon_sym_LBRACK2,
+    ACTIONS(567), 1,
+      anon_sym_EQ,
+  [1884] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(569), 2,
+      anon_sym_LBRACK2,
+      anon_sym_EQ,
+  [1892] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(571), 2,
+      anon_sym_LBRACK2,
+      anon_sym_EQ,
+  [1900] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(573), 1,
+      anon_sym_SEMI,
+    ACTIONS(575), 1,
+      aux_sym__statement_token1,
+  [1910] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(284), 2,
+      anon_sym_RBRACK2,
+      anon_sym_EQ,
+  [1918] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(348), 1,
+      aux_sym__statement_token1,
+    ACTIONS(577), 1,
+      anon_sym_SEMI,
+  [1928] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(579), 1,
+      anon_sym_LBRACK2,
+    ACTIONS(581), 1,
+      anon_sym_EQ,
+  [1938] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(583), 1,
+      anon_sym_LBRACK2,
+    ACTIONS(585), 1,
+      anon_sym_EQ,
+  [1948] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(330), 1,
+      aux_sym__statement_token1,
+    ACTIONS(587), 1,
+      anon_sym_SEMI,
+  [1958] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(324), 1,
+      aux_sym__statement_token1,
+    ACTIONS(589), 1,
+      anon_sym_SEMI,
+  [1968] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(352), 1,
+      aux_sym__statement_token1,
+    ACTIONS(591), 1,
+      anon_sym_SEMI,
+  [1978] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(296), 1,
+      aux_sym__statement_token1,
+    ACTIONS(593), 1,
+      anon_sym_SEMI,
+  [1988] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(298), 1,
+      aux_sym__statement_token1,
+    ACTIONS(595), 1,
+      anon_sym_SEMI,
+  [1998] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(326), 1,
+      aux_sym__statement_token1,
+    ACTIONS(597), 1,
+      anon_sym_SEMI,
+  [2008] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(318), 1,
+      aux_sym__statement_token1,
+    ACTIONS(599), 1,
+      anon_sym_SEMI,
+  [2018] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(294), 1,
+      anon_sym_RBRACK2,
+    ACTIONS(585), 1,
+      anon_sym_EQ,
+  [2028] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(601), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [2036] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(603), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+  [2044] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(320), 1,
+      aux_sym__statement_token1,
+    ACTIONS(605), 1,
+      anon_sym_SEMI,
+  [2054] = 3,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(334), 1,
+      aux_sym__statement_token1,
+    ACTIONS(607), 1,
+      anon_sym_SEMI,
+  [2064] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(609), 1,
+      anon_sym_COLON,
+  [2071] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(296), 1,
+      anon_sym_RBRACK2,
+  [2078] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(340), 1,
+      anon_sym_RBRACK2,
+  [2085] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(338), 1,
+      anon_sym_RBRACK2,
+  [2092] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(334), 1,
+      anon_sym_RBRACK2,
+  [2099] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(611), 1,
+      anon_sym_RBRACK2,
+  [2106] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(330), 1,
+      anon_sym_RBRACK2,
+  [2113] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(613), 1,
+      aux_sym_hash_token1,
+  [2120] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(328), 1,
+      anon_sym_RBRACK2,
+  [2127] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(302), 1,
+      anon_sym_RBRACK2,
+  [2134] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(350), 1,
+      anon_sym_RBRACK2,
+  [2141] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(322), 1,
+      anon_sym_RBRACK2,
+  [2148] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(290), 1,
+      anon_sym_RBRACK2,
+  [2155] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(615), 1,
+      anon_sym_EQ_GT,
+  [2162] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(617), 1,
+      anon_sym_RPAREN,
+  [2169] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(619), 1,
+      anon_sym_BQUOTE,
+  [2176] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(621), 1,
+      anon_sym_SLASH,
+  [2183] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(623), 1,
+      aux_sym_hash_token1,
+  [2190] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(625), 1,
+      anon_sym_COLON,
+  [2197] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(627), 1,
+      anon_sym_EQ_GT,
+  [2204] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(346), 1,
+      anon_sym_RBRACK2,
+  [2211] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(629), 1,
+      anon_sym_RBRACK2,
+  [2218] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(631), 1,
+      aux_sym_regex_token1,
+  [2225] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(633), 1,
+      aux_sym_commandLiteral_token1,
+  [2232] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(635), 1,
+      aux_sym_commandLiteral_token2,
+  [2239] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(348), 1,
+      anon_sym_RBRACK2,
+  [2246] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(324), 1,
+      anon_sym_RBRACK2,
+  [2253] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(352), 1,
+      anon_sym_RBRACK2,
+  [2260] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(637), 1,
+      anon_sym_of,
+  [2267] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(619), 1,
+      anon_sym_RPAREN,
+  [2274] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(639), 1,
+      anon_sym_EQ_GT,
+  [2281] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(641), 1,
+      ts_builtin_sym_end,
+  [2288] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(643), 1,
+      aux_sym_hash_token1,
+  [2295] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(298), 1,
+      anon_sym_RBRACK2,
+  [2302] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(326), 1,
+      anon_sym_RBRACK2,
+  [2309] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(645), 1,
+      aux_sym_local_variable_token1,
+  [2316] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(647), 1,
+      aux_sym_regex_token1,
+  [2323] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(649), 1,
+      aux_sym_commandLiteral_token1,
+  [2330] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(651), 1,
+      aux_sym_commandLiteral_token2,
+  [2337] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(653), 1,
+      aux_sym_local_variable_token1,
+  [2344] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(655), 1,
+      anon_sym_RBRACK2,
+  [2351] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(657), 1,
+      aux_sym_commandLiteral_token2,
+  [2358] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(659), 1,
+      anon_sym_EQ_GT,
+  [2365] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(661), 1,
+      aux_sym_commandLiteral_token1,
+  [2372] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(318), 1,
+      anon_sym_RBRACK2,
+  [2379] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(320), 1,
+      anon_sym_RBRACK2,
+  [2386] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(663), 1,
+      aux_sym_regex_token1,
+  [2393] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(665), 1,
+      aux_sym_hash_token1,
+  [2400] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(667), 1,
+      anon_sym_RPAREN,
+  [2407] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(332), 1,
+      anon_sym_COLON,
+  [2414] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(667), 1,
+      anon_sym_BQUOTE,
+  [2421] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(669), 1,
+      aux_sym_hash_token1,
+  [2428] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(671), 1,
+      anon_sym_SLASH,
+  [2435] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(292), 1,
+      anon_sym_COLON,
+  [2442] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(300), 1,
+      anon_sym_COLON,
+  [2449] = 2,
+    ACTIONS(278), 1,
+      sym_comment,
+    ACTIONS(673), 1,
+      aux_sym_hash_token1,
+  [2456] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(675), 1,
+      anon_sym_SLASH,
+  [2463] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(617), 1,
+      anon_sym_BQUOTE,
+  [2470] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(677), 1,
+      anon_sym_of,
+  [2477] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(679), 1,
       anon_sym_of,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(22)] = 0,
-  [SMALL_STATE(23)] = 48,
-  [SMALL_STATE(24)] = 89,
-  [SMALL_STATE(25)] = 130,
-  [SMALL_STATE(26)] = 171,
-  [SMALL_STATE(27)] = 212,
-  [SMALL_STATE(28)] = 253,
-  [SMALL_STATE(29)] = 267,
-  [SMALL_STATE(30)] = 281,
-  [SMALL_STATE(31)] = 294,
-  [SMALL_STATE(32)] = 307,
-  [SMALL_STATE(33)] = 320,
-  [SMALL_STATE(34)] = 333,
-  [SMALL_STATE(35)] = 343,
-  [SMALL_STATE(36)] = 353,
-  [SMALL_STATE(37)] = 363,
-  [SMALL_STATE(38)] = 373,
-  [SMALL_STATE(39)] = 383,
-  [SMALL_STATE(40)] = 393,
-  [SMALL_STATE(41)] = 405,
-  [SMALL_STATE(42)] = 415,
-  [SMALL_STATE(43)] = 427,
-  [SMALL_STATE(44)] = 439,
-  [SMALL_STATE(45)] = 455,
-  [SMALL_STATE(46)] = 467,
-  [SMALL_STATE(47)] = 479,
-  [SMALL_STATE(48)] = 491,
-  [SMALL_STATE(49)] = 501,
-  [SMALL_STATE(50)] = 511,
-  [SMALL_STATE(51)] = 521,
-  [SMALL_STATE(52)] = 533,
-  [SMALL_STATE(53)] = 543,
-  [SMALL_STATE(54)] = 553,
-  [SMALL_STATE(55)] = 565,
-  [SMALL_STATE(56)] = 577,
-  [SMALL_STATE(57)] = 589,
-  [SMALL_STATE(58)] = 601,
-  [SMALL_STATE(59)] = 613,
-  [SMALL_STATE(60)] = 623,
-  [SMALL_STATE(61)] = 635,
-  [SMALL_STATE(62)] = 645,
-  [SMALL_STATE(63)] = 655,
-  [SMALL_STATE(64)] = 669,
-  [SMALL_STATE(65)] = 679,
-  [SMALL_STATE(66)] = 689,
-  [SMALL_STATE(67)] = 701,
-  [SMALL_STATE(68)] = 717,
-  [SMALL_STATE(69)] = 727,
-  [SMALL_STATE(70)] = 740,
-  [SMALL_STATE(71)] = 751,
-  [SMALL_STATE(72)] = 764,
-  [SMALL_STATE(73)] = 777,
-  [SMALL_STATE(74)] = 790,
-  [SMALL_STATE(75)] = 803,
-  [SMALL_STATE(76)] = 816,
-  [SMALL_STATE(77)] = 829,
-  [SMALL_STATE(78)] = 842,
-  [SMALL_STATE(79)] = 855,
-  [SMALL_STATE(80)] = 868,
-  [SMALL_STATE(81)] = 881,
-  [SMALL_STATE(82)] = 894,
-  [SMALL_STATE(83)] = 907,
-  [SMALL_STATE(84)] = 920,
-  [SMALL_STATE(85)] = 933,
-  [SMALL_STATE(86)] = 946,
-  [SMALL_STATE(87)] = 959,
-  [SMALL_STATE(88)] = 972,
-  [SMALL_STATE(89)] = 985,
-  [SMALL_STATE(90)] = 998,
-  [SMALL_STATE(91)] = 1011,
-  [SMALL_STATE(92)] = 1024,
-  [SMALL_STATE(93)] = 1037,
-  [SMALL_STATE(94)] = 1050,
-  [SMALL_STATE(95)] = 1063,
-  [SMALL_STATE(96)] = 1076,
-  [SMALL_STATE(97)] = 1089,
-  [SMALL_STATE(98)] = 1102,
-  [SMALL_STATE(99)] = 1111,
-  [SMALL_STATE(100)] = 1124,
-  [SMALL_STATE(101)] = 1137,
-  [SMALL_STATE(102)] = 1150,
-  [SMALL_STATE(103)] = 1161,
-  [SMALL_STATE(104)] = 1174,
-  [SMALL_STATE(105)] = 1187,
-  [SMALL_STATE(106)] = 1200,
-  [SMALL_STATE(107)] = 1213,
-  [SMALL_STATE(108)] = 1226,
-  [SMALL_STATE(109)] = 1239,
-  [SMALL_STATE(110)] = 1252,
-  [SMALL_STATE(111)] = 1265,
-  [SMALL_STATE(112)] = 1276,
-  [SMALL_STATE(113)] = 1287,
-  [SMALL_STATE(114)] = 1300,
-  [SMALL_STATE(115)] = 1313,
-  [SMALL_STATE(116)] = 1326,
-  [SMALL_STATE(117)] = 1337,
-  [SMALL_STATE(118)] = 1348,
-  [SMALL_STATE(119)] = 1359,
-  [SMALL_STATE(120)] = 1369,
-  [SMALL_STATE(121)] = 1379,
-  [SMALL_STATE(122)] = 1389,
-  [SMALL_STATE(123)] = 1399,
-  [SMALL_STATE(124)] = 1409,
-  [SMALL_STATE(125)] = 1419,
-  [SMALL_STATE(126)] = 1429,
-  [SMALL_STATE(127)] = 1439,
-  [SMALL_STATE(128)] = 1449,
-  [SMALL_STATE(129)] = 1459,
-  [SMALL_STATE(130)] = 1469,
-  [SMALL_STATE(131)] = 1479,
-  [SMALL_STATE(132)] = 1489,
-  [SMALL_STATE(133)] = 1499,
-  [SMALL_STATE(134)] = 1509,
-  [SMALL_STATE(135)] = 1519,
-  [SMALL_STATE(136)] = 1529,
-  [SMALL_STATE(137)] = 1537,
-  [SMALL_STATE(138)] = 1547,
-  [SMALL_STATE(139)] = 1557,
-  [SMALL_STATE(140)] = 1567,
-  [SMALL_STATE(141)] = 1575,
-  [SMALL_STATE(142)] = 1585,
-  [SMALL_STATE(143)] = 1595,
-  [SMALL_STATE(144)] = 1605,
-  [SMALL_STATE(145)] = 1612,
-  [SMALL_STATE(146)] = 1619,
-  [SMALL_STATE(147)] = 1626,
-  [SMALL_STATE(148)] = 1633,
-  [SMALL_STATE(149)] = 1640,
-  [SMALL_STATE(150)] = 1647,
-  [SMALL_STATE(151)] = 1654,
-  [SMALL_STATE(152)] = 1661,
-  [SMALL_STATE(153)] = 1668,
-  [SMALL_STATE(154)] = 1675,
-  [SMALL_STATE(155)] = 1682,
-  [SMALL_STATE(156)] = 1689,
-  [SMALL_STATE(157)] = 1696,
-  [SMALL_STATE(158)] = 1703,
-  [SMALL_STATE(159)] = 1710,
-  [SMALL_STATE(160)] = 1717,
-  [SMALL_STATE(161)] = 1724,
-  [SMALL_STATE(162)] = 1731,
-  [SMALL_STATE(163)] = 1738,
-  [SMALL_STATE(164)] = 1745,
-  [SMALL_STATE(165)] = 1752,
-  [SMALL_STATE(166)] = 1759,
-  [SMALL_STATE(167)] = 1766,
-  [SMALL_STATE(168)] = 1773,
-  [SMALL_STATE(169)] = 1780,
-  [SMALL_STATE(170)] = 1787,
-  [SMALL_STATE(171)] = 1794,
-  [SMALL_STATE(172)] = 1801,
-  [SMALL_STATE(173)] = 1808,
-  [SMALL_STATE(174)] = 1815,
-  [SMALL_STATE(175)] = 1822,
-  [SMALL_STATE(176)] = 1829,
-  [SMALL_STATE(177)] = 1836,
-  [SMALL_STATE(178)] = 1843,
-  [SMALL_STATE(179)] = 1850,
-  [SMALL_STATE(180)] = 1857,
-  [SMALL_STATE(181)] = 1864,
+  [SMALL_STATE(30)] = 0,
+  [SMALL_STATE(31)] = 48,
+  [SMALL_STATE(32)] = 89,
+  [SMALL_STATE(33)] = 130,
+  [SMALL_STATE(34)] = 171,
+  [SMALL_STATE(35)] = 212,
+  [SMALL_STATE(36)] = 253,
+  [SMALL_STATE(37)] = 294,
+  [SMALL_STATE(38)] = 308,
+  [SMALL_STATE(39)] = 322,
+  [SMALL_STATE(40)] = 335,
+  [SMALL_STATE(41)] = 348,
+  [SMALL_STATE(42)] = 361,
+  [SMALL_STATE(43)] = 374,
+  [SMALL_STATE(44)] = 387,
+  [SMALL_STATE(45)] = 397,
+  [SMALL_STATE(46)] = 409,
+  [SMALL_STATE(47)] = 421,
+  [SMALL_STATE(48)] = 433,
+  [SMALL_STATE(49)] = 445,
+  [SMALL_STATE(50)] = 457,
+  [SMALL_STATE(51)] = 469,
+  [SMALL_STATE(52)] = 479,
+  [SMALL_STATE(53)] = 489,
+  [SMALL_STATE(54)] = 501,
+  [SMALL_STATE(55)] = 511,
+  [SMALL_STATE(56)] = 527,
+  [SMALL_STATE(57)] = 543,
+  [SMALL_STATE(58)] = 559,
+  [SMALL_STATE(59)] = 569,
+  [SMALL_STATE(60)] = 579,
+  [SMALL_STATE(61)] = 591,
+  [SMALL_STATE(62)] = 601,
+  [SMALL_STATE(63)] = 611,
+  [SMALL_STATE(64)] = 623,
+  [SMALL_STATE(65)] = 633,
+  [SMALL_STATE(66)] = 643,
+  [SMALL_STATE(67)] = 655,
+  [SMALL_STATE(68)] = 665,
+  [SMALL_STATE(69)] = 677,
+  [SMALL_STATE(70)] = 689,
+  [SMALL_STATE(71)] = 701,
+  [SMALL_STATE(72)] = 713,
+  [SMALL_STATE(73)] = 723,
+  [SMALL_STATE(74)] = 735,
+  [SMALL_STATE(75)] = 745,
+  [SMALL_STATE(76)] = 755,
+  [SMALL_STATE(77)] = 769,
+  [SMALL_STATE(78)] = 779,
+  [SMALL_STATE(79)] = 789,
+  [SMALL_STATE(80)] = 801,
+  [SMALL_STATE(81)] = 811,
+  [SMALL_STATE(82)] = 821,
+  [SMALL_STATE(83)] = 834,
+  [SMALL_STATE(84)] = 845,
+  [SMALL_STATE(85)] = 856,
+  [SMALL_STATE(86)] = 869,
+  [SMALL_STATE(87)] = 882,
+  [SMALL_STATE(88)] = 893,
+  [SMALL_STATE(89)] = 904,
+  [SMALL_STATE(90)] = 917,
+  [SMALL_STATE(91)] = 930,
+  [SMALL_STATE(92)] = 943,
+  [SMALL_STATE(93)] = 956,
+  [SMALL_STATE(94)] = 965,
+  [SMALL_STATE(95)] = 978,
+  [SMALL_STATE(96)] = 991,
+  [SMALL_STATE(97)] = 1004,
+  [SMALL_STATE(98)] = 1017,
+  [SMALL_STATE(99)] = 1030,
+  [SMALL_STATE(100)] = 1043,
+  [SMALL_STATE(101)] = 1054,
+  [SMALL_STATE(102)] = 1067,
+  [SMALL_STATE(103)] = 1080,
+  [SMALL_STATE(104)] = 1093,
+  [SMALL_STATE(105)] = 1106,
+  [SMALL_STATE(106)] = 1119,
+  [SMALL_STATE(107)] = 1132,
+  [SMALL_STATE(108)] = 1145,
+  [SMALL_STATE(109)] = 1158,
+  [SMALL_STATE(110)] = 1171,
+  [SMALL_STATE(111)] = 1184,
+  [SMALL_STATE(112)] = 1197,
+  [SMALL_STATE(113)] = 1210,
+  [SMALL_STATE(114)] = 1223,
+  [SMALL_STATE(115)] = 1236,
+  [SMALL_STATE(116)] = 1247,
+  [SMALL_STATE(117)] = 1260,
+  [SMALL_STATE(118)] = 1273,
+  [SMALL_STATE(119)] = 1286,
+  [SMALL_STATE(120)] = 1299,
+  [SMALL_STATE(121)] = 1312,
+  [SMALL_STATE(122)] = 1325,
+  [SMALL_STATE(123)] = 1338,
+  [SMALL_STATE(124)] = 1351,
+  [SMALL_STATE(125)] = 1364,
+  [SMALL_STATE(126)] = 1375,
+  [SMALL_STATE(127)] = 1388,
+  [SMALL_STATE(128)] = 1401,
+  [SMALL_STATE(129)] = 1414,
+  [SMALL_STATE(130)] = 1427,
+  [SMALL_STATE(131)] = 1440,
+  [SMALL_STATE(132)] = 1453,
+  [SMALL_STATE(133)] = 1466,
+  [SMALL_STATE(134)] = 1479,
+  [SMALL_STATE(135)] = 1492,
+  [SMALL_STATE(136)] = 1505,
+  [SMALL_STATE(137)] = 1518,
+  [SMALL_STATE(138)] = 1531,
+  [SMALL_STATE(139)] = 1544,
+  [SMALL_STATE(140)] = 1557,
+  [SMALL_STATE(141)] = 1568,
+  [SMALL_STATE(142)] = 1579,
+  [SMALL_STATE(143)] = 1590,
+  [SMALL_STATE(144)] = 1601,
+  [SMALL_STATE(145)] = 1614,
+  [SMALL_STATE(146)] = 1625,
+  [SMALL_STATE(147)] = 1636,
+  [SMALL_STATE(148)] = 1649,
+  [SMALL_STATE(149)] = 1662,
+  [SMALL_STATE(150)] = 1673,
+  [SMALL_STATE(151)] = 1686,
+  [SMALL_STATE(152)] = 1697,
+  [SMALL_STATE(153)] = 1708,
+  [SMALL_STATE(154)] = 1719,
+  [SMALL_STATE(155)] = 1730,
+  [SMALL_STATE(156)] = 1740,
+  [SMALL_STATE(157)] = 1748,
+  [SMALL_STATE(158)] = 1756,
+  [SMALL_STATE(159)] = 1766,
+  [SMALL_STATE(160)] = 1776,
+  [SMALL_STATE(161)] = 1786,
+  [SMALL_STATE(162)] = 1796,
+  [SMALL_STATE(163)] = 1806,
+  [SMALL_STATE(164)] = 1816,
+  [SMALL_STATE(165)] = 1826,
+  [SMALL_STATE(166)] = 1836,
+  [SMALL_STATE(167)] = 1846,
+  [SMALL_STATE(168)] = 1856,
+  [SMALL_STATE(169)] = 1866,
+  [SMALL_STATE(170)] = 1874,
+  [SMALL_STATE(171)] = 1884,
+  [SMALL_STATE(172)] = 1892,
+  [SMALL_STATE(173)] = 1900,
+  [SMALL_STATE(174)] = 1910,
+  [SMALL_STATE(175)] = 1918,
+  [SMALL_STATE(176)] = 1928,
+  [SMALL_STATE(177)] = 1938,
+  [SMALL_STATE(178)] = 1948,
+  [SMALL_STATE(179)] = 1958,
+  [SMALL_STATE(180)] = 1968,
+  [SMALL_STATE(181)] = 1978,
+  [SMALL_STATE(182)] = 1988,
+  [SMALL_STATE(183)] = 1998,
+  [SMALL_STATE(184)] = 2008,
+  [SMALL_STATE(185)] = 2018,
+  [SMALL_STATE(186)] = 2028,
+  [SMALL_STATE(187)] = 2036,
+  [SMALL_STATE(188)] = 2044,
+  [SMALL_STATE(189)] = 2054,
+  [SMALL_STATE(190)] = 2064,
+  [SMALL_STATE(191)] = 2071,
+  [SMALL_STATE(192)] = 2078,
+  [SMALL_STATE(193)] = 2085,
+  [SMALL_STATE(194)] = 2092,
+  [SMALL_STATE(195)] = 2099,
+  [SMALL_STATE(196)] = 2106,
+  [SMALL_STATE(197)] = 2113,
+  [SMALL_STATE(198)] = 2120,
+  [SMALL_STATE(199)] = 2127,
+  [SMALL_STATE(200)] = 2134,
+  [SMALL_STATE(201)] = 2141,
+  [SMALL_STATE(202)] = 2148,
+  [SMALL_STATE(203)] = 2155,
+  [SMALL_STATE(204)] = 2162,
+  [SMALL_STATE(205)] = 2169,
+  [SMALL_STATE(206)] = 2176,
+  [SMALL_STATE(207)] = 2183,
+  [SMALL_STATE(208)] = 2190,
+  [SMALL_STATE(209)] = 2197,
+  [SMALL_STATE(210)] = 2204,
+  [SMALL_STATE(211)] = 2211,
+  [SMALL_STATE(212)] = 2218,
+  [SMALL_STATE(213)] = 2225,
+  [SMALL_STATE(214)] = 2232,
+  [SMALL_STATE(215)] = 2239,
+  [SMALL_STATE(216)] = 2246,
+  [SMALL_STATE(217)] = 2253,
+  [SMALL_STATE(218)] = 2260,
+  [SMALL_STATE(219)] = 2267,
+  [SMALL_STATE(220)] = 2274,
+  [SMALL_STATE(221)] = 2281,
+  [SMALL_STATE(222)] = 2288,
+  [SMALL_STATE(223)] = 2295,
+  [SMALL_STATE(224)] = 2302,
+  [SMALL_STATE(225)] = 2309,
+  [SMALL_STATE(226)] = 2316,
+  [SMALL_STATE(227)] = 2323,
+  [SMALL_STATE(228)] = 2330,
+  [SMALL_STATE(229)] = 2337,
+  [SMALL_STATE(230)] = 2344,
+  [SMALL_STATE(231)] = 2351,
+  [SMALL_STATE(232)] = 2358,
+  [SMALL_STATE(233)] = 2365,
+  [SMALL_STATE(234)] = 2372,
+  [SMALL_STATE(235)] = 2379,
+  [SMALL_STATE(236)] = 2386,
+  [SMALL_STATE(237)] = 2393,
+  [SMALL_STATE(238)] = 2400,
+  [SMALL_STATE(239)] = 2407,
+  [SMALL_STATE(240)] = 2414,
+  [SMALL_STATE(241)] = 2421,
+  [SMALL_STATE(242)] = 2428,
+  [SMALL_STATE(243)] = 2435,
+  [SMALL_STATE(244)] = 2442,
+  [SMALL_STATE(245)] = 2449,
+  [SMALL_STATE(246)] = 2456,
+  [SMALL_STATE(247)] = 2463,
+  [SMALL_STATE(248)] = 2470,
+  [SMALL_STATE(249)] = 2477,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -5703,261 +6965,330 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(124),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
-  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(125),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
-  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(128),
-  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(164),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
-  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(131),
-  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(179),
-  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
-  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [57] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
-  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
-  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
-  [71] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
-  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [79] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
-  [83] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
-  [85] = {.entry = {.count = 1, .reusable = false}}, SHIFT(159),
-  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
-  [89] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(122),
-  [92] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(139),
-  [95] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(121),
-  [98] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(121),
-  [101] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(124),
-  [104] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(124),
-  [107] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(24),
-  [110] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(71),
-  [113] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(125),
-  [116] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(125),
-  [119] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(10),
-  [122] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(5),
-  [125] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(172),
-  [128] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(126),
-  [131] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(169),
-  [134] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(166),
-  [137] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(128),
-  [140] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(164),
-  [143] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(160),
-  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(159),
-  [149] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(131),
-  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
-  [154] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
-  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
-  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
-  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
-  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
-  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statement, 2),
-  [200] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statement, 2),
-  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [206] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
-  [208] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
-  [210] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [212] = {.entry = {.count = 1, .reusable = false}}, SHIFT(135),
-  [214] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
-  [220] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
-  [222] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 1),
-  [224] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [226] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
-  [228] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 4),
-  [230] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 3),
-  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6, .production_id = 3),
-  [234] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6),
-  [236] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 2),
-  [238] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 5, .production_id = 2),
-  [240] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 4),
-  [242] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
-  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [246] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
-  [248] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 3),
-  [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 3, .production_id = 1),
-  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commandLiteral, 3),
-  [262] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_regex, 3),
-  [264] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 3),
-  [266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
-  [268] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 2),
-  [270] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
-  [272] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bool, 1),
-  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
-  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
-  [280] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer, 1),
-  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [284] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [286] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char, 1),
-  [288] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
-  [290] = {.entry = {.count = 1, .reusable = false}}, SHIFT(102),
-  [292] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [294] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
-  [296] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(7),
-  [299] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
-  [301] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(15),
-  [304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [308] = {.entry = {.count = 1, .reusable = false}}, SHIFT(111),
-  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
-  [314] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
-  [316] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
-  [318] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
-  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
-  [322] = {.entry = {.count = 1, .reusable = false}}, SHIFT(117),
-  [324] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
-  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [328] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
-  [330] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
-  [332] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
-  [334] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
-  [336] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 4), SHIFT_REPEAT(16),
-  [339] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 4),
-  [341] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [343] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
-  [345] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
-  [347] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 4), SHIFT_REPEAT(63),
-  [350] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 4),
-  [352] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
-  [354] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
-  [356] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
-  [358] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
-  [360] = {.entry = {.count = 1, .reusable = false}}, SHIFT(89),
-  [362] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [364] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
-  [366] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [368] = {.entry = {.count = 1, .reusable = false}}, SHIFT(92),
-  [370] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [372] = {.entry = {.count = 1, .reusable = false}}, SHIFT(93),
-  [374] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [376] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [378] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [380] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [382] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
-  [384] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [386] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 2), SHIFT_REPEAT(102),
-  [389] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [391] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [393] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [395] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [397] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [399] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
-  [401] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
-  [403] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
-  [405] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
-  [407] = {.entry = {.count = 1, .reusable = false}}, SHIFT(108),
-  [409] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [411] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [413] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [415] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
-  [417] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 3),
-  [419] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commandLiteral, 3),
-  [421] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
-  [423] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [425] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [427] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 4),
-  [429] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer, 1),
-  [431] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_char, 1),
-  [433] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 1),
-  [435] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 4),
-  [437] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [439] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 1),
-  [441] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 5, .production_id = 2),
-  [443] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 2),
-  [445] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
-  [447] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 1),
-  [449] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6),
-  [451] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6, .production_id = 3),
-  [453] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 3),
-  [455] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 2),
-  [457] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 4, .production_id = 2),
-  [459] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [461] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 2),
-  [463] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
-  [465] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 2),
-  [467] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bool, 1),
-  [469] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 4, .production_id = 2),
-  [471] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
-  [473] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assignment, 3, .production_id = 1),
-  [475] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_regex, 3),
-  [477] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
-  [479] = {.entry = {.count = 1, .reusable = false}}, SHIFT(153),
-  [481] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [483] = {.entry = {.count = 1, .reusable = false}}, SHIFT(175),
-  [485] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 3),
-  [487] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 3),
-  [489] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [491] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 2),
-  [493] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [495] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [497] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [499] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [501] = {.entry = {.count = 1, .reusable = false}}, SHIFT(132),
-  [503] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [505] = {.entry = {.count = 1, .reusable = false}}, SHIFT(156),
-  [507] = {.entry = {.count = 1, .reusable = false}}, SHIFT(155),
-  [509] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 2),
-  [511] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
-  [513] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
-  [515] = {.entry = {.count = 1, .reusable = false}}, SHIFT(144),
-  [517] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [519] = {.entry = {.count = 1, .reusable = false}}, SHIFT(157),
-  [521] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [523] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [525] = {.entry = {.count = 1, .reusable = false}}, SHIFT(165),
-  [527] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [529] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [531] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [533] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [535] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [537] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
-  [539] = {.entry = {.count = 1, .reusable = false}}, SHIFT(168),
-  [541] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(160),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(162),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(165),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(236),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
+  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
+  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(229),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(225),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(208),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
+  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
+  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [57] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
+  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
+  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
+  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [71] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
+  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [79] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
+  [83] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
+  [85] = {.entry = {.count = 1, .reusable = false}}, SHIFT(169),
+  [87] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
+  [89] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
+  [93] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(173),
+  [96] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(155),
+  [99] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(160),
+  [102] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(160),
+  [105] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(162),
+  [108] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(162),
+  [111] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(35),
+  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(85),
+  [117] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(165),
+  [120] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(165),
+  [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(29),
+  [126] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(2),
+  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(236),
+  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(167),
+  [135] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(233),
+  [138] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(231),
+  [141] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(87),
+  [144] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(229),
+  [147] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(225),
+  [150] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(169),
+  [153] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(88),
+  [156] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
+  [160] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(230),
+  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
+  [176] = {.entry = {.count = 1, .reusable = false}}, SHIFT(201),
+  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
+  [180] = {.entry = {.count = 1, .reusable = false}}, SHIFT(200),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
+  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(199),
+  [188] = {.entry = {.count = 1, .reusable = false}}, SHIFT(199),
+  [190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
+  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
+  [198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
+  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
+  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [208] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [210] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
+  [212] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [214] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
+  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
+  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
+  [228] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [232] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [234] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
+  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [238] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
+  [240] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
+  [242] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [246] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statement, 2),
+  [248] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statement, 2),
+  [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [254] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
+  [258] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
+  [260] = {.entry = {.count = 1, .reusable = false}}, SHIFT(196),
+  [262] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
+  [264] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
+  [266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
+  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [270] = {.entry = {.count = 1, .reusable = false}}, SHIFT(178),
+  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [274] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
+  [276] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 1),
+  [278] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [280] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
+  [282] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 4),
+  [284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_index_expression, 4, .production_id = 2),
+  [286] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_index_expression, 4, .production_id = 2),
+  [288] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 3),
+  [290] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bool, 1),
+  [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [294] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
+  [296] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 5, .production_id = 3),
+  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 3),
+  [300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [302] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_char, 1),
+  [304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
+  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [314] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
+  [318] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6, .production_id = 4),
+  [320] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 4),
+  [322] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
+  [324] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
+  [326] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hash, 6),
+  [328] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 1),
+  [330] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 2),
+  [332] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [334] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
+  [336] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [338] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 3),
+  [340] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_regex, 3),
+  [342] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
+  [344] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [346] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_commandLiteral, 3),
+  [348] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 3, .production_id = 1),
+  [350] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer, 1),
+  [352] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 4),
+  [354] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [356] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
+  [358] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [360] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [362] = {.entry = {.count = 1, .reusable = false}}, SHIFT(92),
+  [364] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [366] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [368] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 1),
+  [370] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
+  [372] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 1),
+  [374] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(15),
+  [377] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
+  [379] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression, 1),
+  [381] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [383] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [385] = {.entry = {.count = 1, .reusable = false}}, SHIFT(131),
+  [387] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
+  [389] = {.entry = {.count = 1, .reusable = false}}, SHIFT(125),
+  [391] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
+  [393] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(17),
+  [396] = {.entry = {.count = 1, .reusable = false}}, SHIFT(154),
+  [398] = {.entry = {.count = 1, .reusable = false}}, SHIFT(94),
+  [400] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [402] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [404] = {.entry = {.count = 1, .reusable = false}}, SHIFT(153),
+  [406] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [408] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [410] = {.entry = {.count = 1, .reusable = false}}, SHIFT(152),
+  [412] = {.entry = {.count = 1, .reusable = false}}, SHIFT(98),
+  [414] = {.entry = {.count = 1, .reusable = false}}, SHIFT(151),
+  [416] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [418] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [420] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [422] = {.entry = {.count = 1, .reusable = false}}, SHIFT(149),
+  [424] = {.entry = {.count = 1, .reusable = false}}, SHIFT(102),
+  [426] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
+  [428] = {.entry = {.count = 1, .reusable = false}}, SHIFT(104),
+  [430] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [432] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 5), SHIFT_REPEAT(27),
+  [435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 2, .production_id = 5),
+  [437] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
+  [439] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
+  [441] = {.entry = {.count = 1, .reusable = false}}, SHIFT(108),
+  [443] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 5), SHIFT_REPEAT(76),
+  [446] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 2, .production_id = 5),
+  [448] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
+  [450] = {.entry = {.count = 1, .reusable = false}}, SHIFT(110),
+  [452] = {.entry = {.count = 1, .reusable = false}}, SHIFT(143),
+  [454] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [456] = {.entry = {.count = 1, .reusable = false}}, SHIFT(142),
+  [458] = {.entry = {.count = 1, .reusable = false}}, SHIFT(141),
+  [460] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
+  [462] = {.entry = {.count = 1, .reusable = false}}, SHIFT(140),
+  [464] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
+  [466] = {.entry = {.count = 1, .reusable = true}}, SHIFT(235),
+  [468] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
+  [470] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
+  [472] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [474] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
+  [478] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_symbol_repeat1, 2), SHIFT_REPEAT(125),
+  [481] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
+  [483] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
+  [485] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
+  [487] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
+  [489] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [491] = {.entry = {.count = 1, .reusable = false}}, SHIFT(127),
+  [493] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
+  [495] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [497] = {.entry = {.count = 1, .reusable = false}}, SHIFT(129),
+  [499] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [501] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [503] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [505] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [507] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [509] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [511] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [513] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2),
+  [515] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 3),
+  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3),
+  [519] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_symbol, 4),
+  [521] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [523] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [525] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 2),
+  [527] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
+  [529] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 2),
+  [531] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
+  [533] = {.entry = {.count = 1, .reusable = false}}, SHIFT(144),
+  [535] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [537] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
+  [539] = {.entry = {.count = 1, .reusable = false}}, SHIFT(139),
+  [541] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bool, 1),
+  [543] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constant, 2),
+  [545] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_local_variable, 2),
+  [547] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [549] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 3),
+  [551] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
+  [553] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [555] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer, 1),
+  [557] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_regex, 3),
+  [559] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [561] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_char, 1),
+  [563] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 1),
+  [565] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_commandLiteral, 3),
+  [567] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [569] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instance_variable, 3),
+  [571] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_variable, 3),
+  [573] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
+  [575] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [577] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assignment, 3, .production_id = 1),
+  [579] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [581] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [583] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [585] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [587] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_symbol, 2),
+  [589] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 4),
+  [591] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 4),
+  [593] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 5, .production_id = 3),
+  [595] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 5, .production_id = 3),
+  [597] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6),
+  [599] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_hash, 6, .production_id = 4),
+  [601] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_namedTupleLiteral_repeat1, 4, .production_id = 3),
+  [603] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_hash_repeat1, 4, .production_id = 3),
+  [605] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namedTupleLiteral, 6, .production_id = 4),
+  [607] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
+  [609] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [611] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [613] = {.entry = {.count = 1, .reusable = false}}, SHIFT(224),
+  [615] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [617] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [619] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
+  [621] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
+  [623] = {.entry = {.count = 1, .reusable = false}}, SHIFT(183),
+  [625] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
+  [627] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
+  [629] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [631] = {.entry = {.count = 1, .reusable = false}}, SHIFT(242),
+  [633] = {.entry = {.count = 1, .reusable = false}}, SHIFT(240),
+  [635] = {.entry = {.count = 1, .reusable = false}}, SHIFT(238),
+  [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
+  [639] = {.entry = {.count = 1, .reusable = true}}, SHIFT(222),
+  [641] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [643] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
+  [645] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
+  [647] = {.entry = {.count = 1, .reusable = false}}, SHIFT(206),
+  [649] = {.entry = {.count = 1, .reusable = false}}, SHIFT(205),
+  [651] = {.entry = {.count = 1, .reusable = false}}, SHIFT(219),
+  [653] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [655] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [657] = {.entry = {.count = 1, .reusable = false}}, SHIFT(204),
+  [659] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
+  [661] = {.entry = {.count = 1, .reusable = false}}, SHIFT(247),
+  [663] = {.entry = {.count = 1, .reusable = false}}, SHIFT(246),
+  [665] = {.entry = {.count = 1, .reusable = false}}, SHIFT(209),
+  [667] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [669] = {.entry = {.count = 1, .reusable = false}}, SHIFT(220),
+  [671] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [673] = {.entry = {.count = 1, .reusable = false}}, SHIFT(232),
+  [675] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [677] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
+  [679] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1,0 +1,20 @@
+==========
+assignment
+==========
+
+foo = 1
+@foo = "test"
+@@foo = [1, 2, 3]
+PI = 3.14
+foo = bar = 4
+
+---
+(program
+  (assignment lhs: (local_variable) rhs: (integer))
+  (assignment lhs: (instance_variable) rhs: (string))
+  (assignment lhs: (class_variable) rhs: (array (integer) (integer) (integer)))
+  (assignment lhs: (constant) rhs: (float))
+  (assignment lhs: (local_variable) rhs: (
+    assignment lhs: (local_variable) rhs: (integer))
+  )
+)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -14,7 +14,5 @@ foo = bar = 4
   (assignment lhs: (instance_variable) rhs: (string))
   (assignment lhs: (class_variable) rhs: (array (integer) (integer) (integer)))
   (assignment lhs: (constant) rhs: (float))
-  (assignment lhs: (local_variable) rhs: (
-    assignment lhs: (local_variable) rhs: (integer))
-  )
+  (assignment lhs: (local_variable) rhs: (assignment lhs: (local_variable) rhs: (integer)))
 )

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1,3 +1,20 @@
+====================
+index element access
+====================
+
+foo["one"]
+@foo[1]
+@@foo[:my_symbol]
+FOO[foo[1]] 
+
+---
+(program
+  (index_expression target: (local_variable) key: (string))
+  (index_expression target: (instance_variable) key: (integer))
+  (index_expression target: (class_variable) key: (symbol))
+  (index_expression target: (constant) key: (index_expression target: (local_variable) key: (integer)))
+)
+
 ==========
 assignment
 ==========
@@ -7,6 +24,7 @@ foo = 1
 @@foo = [1, 2, 3]
 PI = 3.14
 foo = bar = 4
+foo[:test] = "test"
 
 ---
 (program
@@ -15,4 +33,5 @@ foo = bar = 4
   (assignment lhs: (class_variable) rhs: (array (integer) (integer) (integer)))
   (assignment lhs: (constant) rhs: (float))
   (assignment lhs: (local_variable) rhs: (assignment lhs: (local_variable) rhs: (integer)))
+  (assignment lhs: (index_expression target: (local_variable) key: (symbol)) rhs: (string))
 )

--- a/test/corpus/extras.txt
+++ b/test/corpus/extras.txt
@@ -1,0 +1,16 @@
+=======
+comment
+=======
+
+# this is a comment
+"test" # this is another comment
+42 # a comment "with stuff in it"
+
+---
+
+(program
+ (comment)
+ (string) (comment)
+ (integer) (comment)
+)
+


### PR DESCRIPTION
Adds support for:  
- Comments
- Local variables
- Instance variables
- Class variables
- Constants
- Index access (like `foo[:bar]`)
- Assignments (including chained assignments like `foo = bar = 4`)